### PR TITLE
Adds application .jar file to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .settings
 /bin/
 
+company-accounts.api.ch.gov.uk.jar
 target/
 pom.xml.tag
 pom.xml.releaseBackup


### PR DESCRIPTION
As we don't want the application `.jar` file to appear in the changes log, we add the `company-accounts.api.ch.gov.uk.jar` to the .`.gitignore` file