### PR TITLE
Adds transaction interceptor

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
@@ -4,15 +4,22 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import uk.gov.companieshouse.api.accounts.interceptor.TransactionInterceptor;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
 @SpringBootApplication
-public class CompanyAccountsApplication {
+public class CompanyAccountsApplication implements WebMvcConfigurer {
+
+    @Autowired
+    private TransactionInterceptor transactionInterceptor;
 
     private static final Logger LOGGER = LoggerFactory.getLogger("company-accounts.api.ch.gov.uk");
 
@@ -39,5 +46,11 @@ public class CompanyAccountsApplication {
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         return objectMapper;
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(transactionInterceptor)
+                .addPathPatterns("/transactions/{transactionId}/company-accounts");
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
@@ -36,7 +36,7 @@ public class TransactionInterceptor extends HandlerInterceptorAdapter {
                     .getTransaction(transactionId, request.getHeader("X-Request-Id"));
             return isTransactionIsOpen(transaction);
         } catch (HttpClientErrorException httpClientErrorException) {
-            response.setStatus(httpClientErrorException.getStatusCode().value()));
+            response.setStatus(httpClientErrorException.getStatusCode().value());
             return false;
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
@@ -1,0 +1,50 @@
+package uk.gov.companieshouse.api.accounts.interceptor;
+
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import uk.gov.companieshouse.api.accounts.transaction.Transaction;
+import uk.gov.companieshouse.api.accounts.transaction.TransactionManager;
+import uk.gov.companieshouse.api.accounts.transaction.TransactionStatus;
+
+@Component
+public class TransactionInterceptor extends HandlerInterceptorAdapter {
+
+    @Autowired
+    private TransactionManager transactionManager;
+
+    /**
+     * Pre handle method to validate the request before it reaches the controller. Check if the url
+     * has an existing transaction and to further check if transaction is open. If transaction is
+     * not found then return 404
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+            Object handler) {
+        try {
+            Map<String, String> pathVariables = (Map) request
+                    .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+            String transactionId = pathVariables.get("transactionId");
+            ResponseEntity<Transaction> transaction = transactionManager
+                    .getTransaction(transactionId, request.getHeader("X-Request-Id"));
+            return isTransactionIsOpen(transaction);
+        } catch (HttpClientErrorException httpClientErrorException) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return false;
+        }
+    }
+
+    /**
+     * Returns whether transaction is open or not.
+     */
+    private boolean isTransactionIsOpen(ResponseEntity<Transaction> transaction) {
+        return (transaction.getBody().getStatus().equals(TransactionStatus.OPEN.getStatus()));
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
@@ -36,7 +36,7 @@ public class TransactionInterceptor extends HandlerInterceptorAdapter {
                     .getTransaction(transactionId, request.getHeader("X-Request-Id"));
             return isTransactionIsOpen(transaction);
         } catch (HttpClientErrorException httpClientErrorException) {
-            response.setStatus(Integer.parseInt(httpClientErrorException.getStatusCode().toString()));
+            response.setStatus(httpClientErrorException.getStatusCode().value()));
             return false;
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
@@ -36,7 +36,7 @@ public class TransactionInterceptor extends HandlerInterceptorAdapter {
                     .getTransaction(transactionId, request.getHeader("X-Request-Id"));
             return isTransactionIsOpen(transaction);
         } catch (HttpClientErrorException httpClientErrorException) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            response.setStatus(Integer.parseInt(httpClientErrorException.getStatusCode().toString()));
             return false;
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transaction/Filings.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transaction/Filings.java
@@ -1,0 +1,76 @@
+package uk.gov.companieshouse.api.accounts.transaction;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Filings {
+    private String id;
+    @Field("processed_at")
+    @JsonProperty("processed_at")
+    private Date processedAt;
+
+    private String status;
+
+    private String type;
+
+    @Field("reject_reasons")
+    @JsonProperty("reject_reasons")
+    private Set<RejectReasons> rejectReasons;
+
+    private Map<String,String> links;
+
+    public Map<String, String> getLinks() {
+        return links;
+    }
+
+    public void setLinks(Map<String, String> links) {
+        this.links = links;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Date getProcessedAt() {
+        return processedAt;
+    }
+
+    public void setProcessedAt(Date processedAt) {
+        this.processedAt = processedAt;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Set<RejectReasons> getRejectReasons() {
+        return rejectReasons;
+    }
+
+    public void setRejectReasons(Set<RejectReasons> rejectReasons) {
+        this.rejectReasons = rejectReasons;
+    }
+
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transaction/RejectReasons.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transaction/RejectReasons.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.api.accounts.transaction;
+
+public class RejectReasons {
+    private String english;
+    private String welsh;
+
+    public String getEnglish() {
+        return english;
+    }
+
+    public void setEnglish(String english) {
+        this.english = english;
+    }
+
+    public String getWelsh() {
+        return welsh;
+    }
+
+    public void setWelsh(String welsh) {
+        this.welsh = welsh;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transaction/Resources.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transaction/Resources.java
@@ -1,0 +1,64 @@
+package uk.gov.companieshouse.api.accounts.transaction;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.util.Date;
+import java.util.Map;
+
+public class Resources {
+
+    @Field("updated_by")
+    @JsonProperty("updated_by")
+    private Map<String, String> updatedBy;
+
+    private String kind;
+
+    @Field("updated_at")
+    @JsonProperty("updated_at")
+    private Date updatedAt;
+
+    private Map<String,String> links;
+
+    public Map<String, String> getLinks() {
+        return links;
+    }
+
+    public void setLinks(Map<String, String> links) {
+        this.links = links;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+
+    public Map<String, String> getUpdatedBy() {
+        return updatedBy;
+    }
+
+    public void setUpdatedBy(Map<String, String> updatedBy) {
+        this.updatedBy = updatedBy;
+    }
+
+    @Override
+    public String toString() {
+        return "Resources [updatedBy=" + updatedBy + ", kind="
+                + kind + ", updatedAt=" + updatedAt + ", links=" + links
+                + "]";
+    }
+
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transaction/Transaction.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transaction/Transaction.java
@@ -1,0 +1,152 @@
+package uk.gov.companieshouse.api.accounts.transaction;
+
+import java.util.Date;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Transaction {
+
+    private String id;
+
+    @JsonProperty("closed_at")
+    private Date closedAt;
+
+    @JsonProperty("company_number")
+    private String companyNumber;
+
+    @JsonProperty("created_at")
+    private Date createdAt;
+
+    private String kind;
+
+    private String reference;
+
+    private String status;
+
+    @JsonProperty("updated_at")
+    private Date updatedAt;
+
+    @JsonProperty("created_by")
+    private Map<String,String> createdBy;
+
+    private Map<String,String> links;
+
+    private Map<String, Filings> filings;
+
+    public Map<String, Filings> getFilings() {
+        return filings;
+    }
+
+    public void setFilings(Map<String, Filings> filings) {
+        this.filings = filings;
+    }
+
+    private String etag;
+
+    private Map<String,Resources> resources;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Date getClosedAt() {
+        return closedAt;
+    }
+
+    public void setClosedAt(Date closedAt) {
+        this.closedAt = closedAt;
+    }
+
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+
+    public void setCompanyNumber(String companyNumber) {
+        this.companyNumber = companyNumber;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Map<String, String> getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(Map<String, String> createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Map<String, String> getLinks() {
+        return links;
+    }
+
+    public void setLinks(Map<String, String> links) {
+        this.links = links;
+    }
+
+    public String getEtag() {
+        return etag;
+    }
+
+    public void setEtag(String etag) {
+        this.etag = etag;
+    }
+
+    public Map<String, Resources> getResources() {
+        return resources;
+    }
+
+    public void setResources(Map<String, Resources> resources) {
+        this.resources = resources;
+    }
+
+    @Override
+    public String toString() {
+        return "Transaction [id=" + id + ", closedAt=" + closedAt + ", companyNumber=" + companyNumber + ", createdAt="
+                + createdAt + ", kind=" + kind + ", reference=" + reference + ", status=" + status + ", updatedAt="
+                + updatedAt + ", createdBy=" + createdBy + ", links=" + links + ", filings=" + filings + ", etag="
+                + etag + ", resources=" + resources + "]";
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionManager.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionManager.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.api.accounts.transaction;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Interface to the Transaction API .
+ *
+ * @author dparameswaran
+ *
+ */
+public interface TransactionManager {
+
+    ResponseEntity<Transaction> getTransaction(String id, String requestId);
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionManager.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionManager.java
@@ -1,14 +1,7 @@
 package uk.gov.companieshouse.api.accounts.transaction;
 
-import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 
-/**
- * Interface to the Transaction API .
- *
- * @author dparameswaran
- *
- */
 public interface TransactionManager {
 
     ResponseEntity<Transaction> getTransaction(String id, String requestId);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionManagerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionManagerImpl.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.api.accounts.transaction;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class TransactionManagerImpl implements TransactionManager {
+
+    private RestTemplate transactionRestTemplate;
+
+    @Autowired
+    private TransactionServiceProperties configuration;
+
+    private static final String ID_PARAMETER = "{id}";
+
+    public TransactionManagerImpl(RestTemplateBuilder builder, TransactionServiceProperties configuration) {
+        this.configuration = configuration;
+        this.transactionRestTemplate = builder.rootUri(configuration.getRootUri())
+                .basicAuthorization(configuration.getApiKey(), "").build();
+    }
+
+    /**
+     * Try get transaction if exists
+     *
+     * @param id
+     * @param requestId
+     * @return transaction object along with the status or a Not Found status.
+     */
+    public ResponseEntity<Transaction> getTransaction(String id, String requestId) {
+        HttpHeaders requestHeaders = new HttpHeaders();
+        requestHeaders.set("x-request-id", requestId);
+        HttpEntity requestEntity = new HttpEntity(requestHeaders);
+        String url = (configuration.getBaseUrl()).replace(ID_PARAMETER, id);
+        return transactionRestTemplate.exchange(url, HttpMethod.GET, requestEntity, Transaction.class);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionServiceProperties.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionServiceProperties.java
@@ -1,0 +1,54 @@
+package uk.gov.companieshouse.api.accounts.transaction;
+
+import org.hibernate.validator.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix="transactions")
+public class TransactionServiceProperties {
+    @NotBlank
+    private String rootUri;
+
+    @NotBlank
+    private String baseUrl;
+
+    @NotBlank
+    private String patchUrl;
+
+    @NotBlank
+    private String apiKey;
+
+    public String getRootUri() {
+        return rootUri;
+    }
+
+    public void setRootUri(String rootUri) {
+        this.rootUri = rootUri;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getPatchUrl() {
+        return patchUrl;
+    }
+
+    public void setPatchUrl(String patchUrl) {
+        this.patchUrl = patchUrl;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionStatus.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionStatus.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.api.accounts.transaction;
+
+public enum TransactionStatus {
+    OPEN("open"), DELETED("deleted"), CLOSED("closed");
+
+    private String status;
+
+    private TransactionStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,7 @@
 spring.data.mongodb.uri=${ACCOUNTS_DB_URL}
 spring.jackson.date-format=yyyy-MM-dd'T'HH:mm:ss'Z'
+
+# transaction-api properties
+transactions.root-uri=${TRANSACTIONS_API_URL}
+transactions.baseUrl=/transactions/{id}
+transactions.api-key=${CHS_API_KEY}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -44,7 +44,8 @@ public class TransactionInterceptorTest {
 
     @BeforeEach
     public void setUp() {
-        Map<String, String> pathVariables = ImmutableMap.of("transactionId", "5555");
+        Map<String, String> pathVariables = new HashMap<>();
+        pathVariables.put("transactionId", "5555");
 
         when(httpServletRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
                 .thenReturn(pathVariables);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
@@ -58,7 +58,7 @@ public class TransactionInterceptorTest {
     @DisplayName("Tests the interceptor with an existing transaction that is open")
     public void testPreHandleWithOpenTransaction() {
         when(transactionManagerMock.getTransaction(anyString(), anyString()))
-                .thenReturn(createOpenDummyTransaction(true));
+                .thenReturn(createDummyTransaction(true));
 
         assertTrue(transactionInterceptor.preHandle(httpServletRequest, httpServletResponse, new Object()));
     }
@@ -67,7 +67,7 @@ public class TransactionInterceptorTest {
     @DisplayName("Tests the interceptor with an existing transaction that is closed")
     public void testPreHandleWithClosedTransaction() {
         when(transactionManagerMock.getTransaction(anyString(), anyString()))
-                .thenReturn(createOpenDummyTransaction(false));
+                .thenReturn(createDummyTransaction(false));
 
         assertFalse(transactionInterceptor.preHandle(httpServletRequest, httpServletResponse, new Object()));
     }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
@@ -96,14 +96,10 @@ public class TransactionInterceptorTest {
      * @return ResponseEntity<> with the desired transaction
      */
     private ResponseEntity<Transaction> createOpenDummyTransaction(boolean isOpen) {
-        Transaction openTransaction = new Transaction();
+        Transaction transaction = new Transaction();
 
-        if (isOpen) {
-            openTransaction.setStatus(TransactionStatus.OPEN.getStatus());
-        } else {
-            openTransaction.setStatus(TransactionStatus.CLOSED.getStatus());
-        }
+        transaction.setStatus(isOpen ? TransactionStatus.OPEN.getStatus() : TransactionStatus.CLOSED.getStatus());
 
-        return new ResponseEntity<>(openTransaction, HttpStatus.OK);
+        return new ResponseEntity<>(transaction, HttpStatus.OK);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
@@ -1,0 +1,115 @@
+package uk.gov.companieshouse.api.accounts.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.internal.matchers.Equals;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.servlet.HandlerMapping;
+import uk.gov.companieshouse.api.accounts.transaction.Transaction;
+import uk.gov.companieshouse.api.accounts.transaction.TransactionManager;
+import uk.gov.companieshouse.api.accounts.transaction.TransactionStatus;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class TransactionInterceptorTest {
+
+    @InjectMocks
+    private TransactionInterceptor transactionInterceptor;
+
+    @Mock
+    private TransactionManager transactionManagerMock;
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    @Mock
+    private HttpServletResponse httpServletResponse;
+
+    @BeforeEach
+    public void setUp() {
+        Map<String, String> pathVariables = ImmutableMap.of("transactionId", "5555");
+
+        when(httpServletRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
+                .thenReturn(pathVariables);
+        when(httpServletRequest.getHeader("X-Request-Id")).thenReturn("1111");
+
+        httpServletResponse.setContentType("text/html");
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with an existing transaction that is open")
+    public void testPreHandleWithOpenTransaction() {
+        when(transactionManagerMock.getTransaction(anyString(), anyString()))
+                .thenReturn(createOpenDummyTransaction(true));
+
+        boolean result = transactionInterceptor
+                .preHandle(httpServletRequest, httpServletResponse, new Object());
+
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with an existing transaction that is closed")
+    public void testPreHandleWithClosedTransaction() {
+        when(transactionManagerMock.getTransaction(anyString(), anyString()))
+                .thenReturn(createOpenDummyTransaction(false));
+
+        boolean result = transactionInterceptor
+                .preHandle(httpServletRequest, httpServletResponse, new Object());
+
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with a non-existing transaction")
+    public void testPreHandleWithNonExistingTransaction() {
+        when(transactionManagerMock.getTransaction(anyString(), anyString()))
+                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+
+        boolean result = transactionInterceptor
+                .preHandle(httpServletRequest, httpServletResponse, new Object());
+
+        assertFalse(result);
+    }
+
+    /**
+     * creates an open or closed dummy transaction depending on the boolean passed into method
+     *
+     * @param isOpen - true = open, false - closed
+     * @return ResponseEntity<> with the desired transaction
+     */
+    private ResponseEntity<Transaction> createOpenDummyTransaction(boolean isOpen) {
+        Transaction openTransaction = new Transaction();
+
+        if (isOpen) {
+            openTransaction.setStatus(TransactionStatus.OPEN.getStatus());
+        } else {
+            openTransaction.setStatus(TransactionStatus.CLOSED.getStatus());
+        }
+
+        return new ResponseEntity<>(openTransaction, HttpStatus.OK);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.api.accounts.interceptor;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
@@ -79,6 +80,7 @@ public class TransactionInterceptorTest {
                 .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
 
         assertFalse(transactionInterceptor.preHandle(httpServletRequest, httpServletResponse, new Object()));
+        verify(httpServletResponse).setStatus(HttpStatus.NOT_FOUND.value());
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
@@ -1,16 +1,11 @@
 package uk.gov.companieshouse.api.accounts.interceptor;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -22,7 +17,6 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.internal.matchers.Equals;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
@@ -59,10 +59,7 @@ public class TransactionInterceptorTest {
         when(transactionManagerMock.getTransaction(anyString(), anyString()))
                 .thenReturn(createOpenDummyTransaction(true));
 
-        boolean result = transactionInterceptor
-                .preHandle(httpServletRequest, httpServletResponse, new Object());
-
-        assertTrue(result);
+        assertTrue(transactionInterceptor.preHandle(httpServletRequest, httpServletResponse, new Object()));
     }
 
     @Test
@@ -71,10 +68,7 @@ public class TransactionInterceptorTest {
         when(transactionManagerMock.getTransaction(anyString(), anyString()))
                 .thenReturn(createOpenDummyTransaction(false));
 
-        boolean result = transactionInterceptor
-                .preHandle(httpServletRequest, httpServletResponse, new Object());
-
-        assertFalse(result);
+        assertFalse(transactionInterceptor.preHandle(httpServletRequest, httpServletResponse, new Object()));
     }
 
     @Test
@@ -83,10 +77,7 @@ public class TransactionInterceptorTest {
         when(transactionManagerMock.getTransaction(anyString(), anyString()))
                 .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
 
-        boolean result = transactionInterceptor
-                .preHandle(httpServletRequest, httpServletResponse, new Object());
-
-        assertFalse(result);
+        assertFalse(transactionInterceptor.preHandle(httpServletRequest, httpServletResponse, new Object()));
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
@@ -87,7 +87,7 @@ public class TransactionInterceptorTest {
      * @param isOpen - true = open, false - closed
      * @return ResponseEntity<> with the desired transaction
      */
-    private ResponseEntity<Transaction> createOpenDummyTransaction(boolean isOpen) {
+    private ResponseEntity<Transaction> createDummyTransaction(boolean isOpen) {
         Transaction transaction = new Transaction();
 
         transaction.setStatus(isOpen ? TransactionStatus.OPEN.getStatus() : TransactionStatus.CLOSED.getStatus());


### PR DESCRIPTION
Adds transaction interceptor that deals with the validating of the transaction and its details. This PR includes:
- transaction interceptor and the paths it intercepts
- adds the transactions-api interfacing code that communicates with the transactions-api regarding retrieving transactions. It is important to note that this will be removed and replaced by the private java sdk once it has been done. To replace the transaction interfacing code, simply replace the `getTransaction` line in the transaction interceptor with the sdk code and subsequently delete the `transaction` package. We have done it this way because we still want to develop the API without being blocked by another piece of work - which when done, will slot right in.
- adds transaction interceptor junit tests

Resolves:
[SFA-465]