### PR TITLE
Added the base for the Smallfull entity

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.api.accounts.controller;
+
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
+import uk.gov.companieshouse.api.accounts.service.SmallFullService;
+
+@RestController
+public class SmallFullController {
+
+    @Autowired
+    private SmallFullService smallFullService;
+
+    @PostMapping(value = "/transactions/{transactionId}/company-accounts/{companyAccountId}/small-full",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity create(@Valid @RequestBody SmallFull smallFull) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(smallFullService.save(smallFull));
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/BaseDataEntity.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/BaseDataEntity.java
@@ -9,6 +9,8 @@ public class BaseDataEntity {
 
     private String etag;
 
+    private String kind;
+
     public String getEtag() {
         return etag;
     }
@@ -23,6 +25,14 @@ public class BaseDataEntity {
 
     public void setLinks(Map<String, String> links) {
         this.links = links;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/CompanyAccountDataEntity.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/CompanyAccountDataEntity.java
@@ -10,22 +10,12 @@ public class CompanyAccountDataEntity extends BaseDataEntity {
     @Field("period_end_on")
     private LocalDate periodEndOn;
 
-    private String kind;
-
     public LocalDate getPeriodEndOn() {
         return periodEndOn;
     }
 
     public void setPeriodEndOn(LocalDate periodEndOn) {
         this.periodEndOn = periodEndOn;
-    }
-
-    public String getKind() {
-        return kind;
-    }
-
-    public void setKind(String kind) {
-        this.kind = kind;
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/SmallFullDataEntity.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/SmallFullDataEntity.java
@@ -1,0 +1,5 @@
+package uk.gov.companieshouse.api.accounts.model.entity;
+
+public class SmallFullDataEntity extends BaseDataEntity {
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/SmallFullEntity.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/SmallFullEntity.java
@@ -1,0 +1,19 @@
+package uk.gov.companieshouse.api.accounts.model.entity;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "accounts")
+public class SmallFullEntity extends BaseEntity{
+
+    @Field("data")
+    private SmallFullDataEntity data;
+
+    public SmallFullDataEntity getData() {
+        return data;
+    }
+
+    public void setData(SmallFullDataEntity data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/SmallFull.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/SmallFull.java
@@ -1,0 +1,5 @@
+package uk.gov.companieshouse.api.accounts.model.rest;
+
+public class SmallFull extends RestObject {
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/repository/SmallFullRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/repository/SmallFullRepository.java
@@ -1,0 +1,10 @@
+package uk.gov.companieshouse.api.accounts.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.companieshouse.api.accounts.model.entity.SmallFullEntity;
+
+@Repository
+public interface SmallFullRepository extends MongoRepository<SmallFullEntity, String> {
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/SmallFullService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/SmallFullService.java
@@ -1,0 +1,10 @@
+package uk.gov.companieshouse.api.accounts.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.accounts.model.entity.SmallFullEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
+
+@Service
+public interface SmallFullService extends AbstractService<SmallFull, SmallFullEntity> {
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/AbstractServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/AbstractServiceImpl.java
@@ -40,6 +40,6 @@ public abstract class AbstractServiceImpl<C extends RestObject, E extends BaseEn
 
     @Override
     public void addID(BaseEntity entity) {
-        entity.setId("generated id");
+
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
@@ -17,8 +17,8 @@ public class CompanyAccountServiceImpl extends
     @Autowired
     public CompanyAccountServiceImpl(
             @Qualifier("companyAccountRepository") MongoRepository<CompanyAccountEntity, String> mongoRepository,
-            @Qualifier("companyAccountTransformer") GenericTransformer<CompanyAccount, CompanyAccountEntity> companyAccountTransformer) {
-        super(mongoRepository, companyAccountTransformer);
+            @Qualifier("companyAccountTransformer") GenericTransformer<CompanyAccount, CompanyAccountEntity> transformer) {
+        super(mongoRepository, transformer);
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullServiceImpl.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.api.accounts.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.accounts.model.entity.SmallFullEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
+import uk.gov.companieshouse.api.accounts.service.SmallFullService;
+import uk.gov.companieshouse.api.accounts.transformer.GenericTransformer;
+
+@Service
+public class SmallFullServiceImpl extends
+        AbstractServiceImpl<SmallFull, SmallFullEntity> implements SmallFullService {
+
+    @Autowired
+    public SmallFullServiceImpl(
+            @Qualifier("smallFullRepository") MongoRepository<SmallFullEntity, String> mongoRepository,
+            @Qualifier("smallFullTransformer") GenericTransformer<SmallFull, SmallFullEntity> transformer) {
+        super(mongoRepository, transformer);
+    }
+
+    @Override
+    public void addLinks(SmallFull rest) {
+
+    }
+
+    @Override
+    public void addKind(SmallFull rest) {
+
+    }
+
+}
+

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transformer/SmallFullTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transformer/SmallFullTransformer.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.api.accounts.transformer;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.accounts.model.entity.SmallFullDataEntity;
+import uk.gov.companieshouse.api.accounts.model.entity.SmallFullEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
+
+@Component
+public class SmallFullTransformer implements
+        GenericTransformer<SmallFull, SmallFullEntity> {
+
+
+    @Override
+    public SmallFullEntity transform(SmallFull entity) {
+        SmallFullDataEntity smallFullDataEntity = new SmallFullDataEntity();
+        SmallFullEntity smallFullEntity = new SmallFullEntity();
+        BeanUtils.copyProperties(entity, smallFullDataEntity);
+        smallFullEntity.setData(smallFullDataEntity);
+        return smallFullEntity;
+    }
+
+    @Override
+    public SmallFull transform(SmallFullEntity entity) {
+        return null;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/SmallFullControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/SmallFullControllerTest.java
@@ -1,0 +1,54 @@
+package uk.gov.companieshouse.api.accounts.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.internal.matchers.Equals;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
+import uk.gov.companieshouse.api.accounts.service.SmallFullService;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class SmallFullControllerTest {
+
+
+        @Mock
+        private SmallFull smallFull;
+
+        @Mock
+        private SmallFull createdSmallFull;
+
+        @Mock
+        private SmallFullService smallFullService;
+
+        @InjectMocks
+        private SmallFullController smallFullController;
+
+        @BeforeEach
+        public void setUp(){
+            when(smallFullService.save(smallFull)).thenReturn(createdSmallFull);
+        }
+
+        @Test
+        @DisplayName("Tests the successful creation of a smallFull resource")
+        public void canCreateSmallFull() {
+            ResponseEntity response = smallFullController.create(smallFull);
+
+            assertNotNull(response);
+            assertEquals(HttpStatus.CREATED, response.getStatusCode());
+            assertTrue(new Equals(createdSmallFull).matches(response.getBody()));
+        }
+    }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullServiceImplTest.java
@@ -1,0 +1,53 @@
+package uk.gov.companieshouse.api.accounts.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.accounts.model.entity.SmallFullEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
+import uk.gov.companieshouse.api.accounts.repository.SmallFullRepository;
+import uk.gov.companieshouse.api.accounts.transformer.SmallFullTransformer;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class SmallFullServiceImplTest {
+
+        @Mock
+        private SmallFull smallFull;
+
+        @Mock
+        private SmallFullEntity createdSmallFullEntity;
+
+        @Mock
+        private SmallFullRepository smallFullRepository;
+
+        @Mock
+        private SmallFullTransformer smallFullTransformer;
+
+        @InjectMocks
+        private SmallFullServiceImpl smallFullService;
+
+        @BeforeEach
+        public void setUp() {
+            when(smallFullTransformer.transform(smallFull)).thenReturn(createdSmallFullEntity);
+        }
+
+        @Test
+        @DisplayName("Tests the successful creation of a smallFull resource")
+        public void canCreateAccount() {
+            SmallFull result = smallFullService.save(smallFull);
+            assertNotNull(result);
+            assertEquals(smallFull, result);
+
+        }
+    }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/SmallFullTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/SmallFullTransformerTest.java
@@ -1,0 +1,48 @@
+package uk.gov.companieshouse.api.accounts.transformer;
+
+import java.util.HashMap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.accounts.model.entity.SmallFullEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class SmallFullTransformerTest {
+
+
+    private SmallFullTransformer smallFullTransformer = new SmallFullTransformer();
+
+    @Test
+    @DisplayName("Tests smallfull transformer with empty object which should result in null values")
+    public void testTransformerWithEmptyObject() {
+        SmallFullEntity smallFullEntity = smallFullTransformer.transform(new SmallFull());
+
+        Assertions.assertNotNull(smallFullEntity);
+        Assertions.assertNull(smallFullEntity.getData().getEtag());
+        Assertions.assertNull(smallFullEntity.getData().getKind());
+        Assertions.assertEquals(new HashMap<>(), smallFullEntity.getData().getLinks());
+    }
+
+    @Test
+    @DisplayName("Tests smallfull transformer with populated object and validates values returned")
+    public void testTransformerWithPopulatedObject() {
+        SmallFull smallFull = new SmallFull();
+        smallFull.setEtag("etag");
+        smallFull.setKind("kind");
+        smallFull.setLinks(new HashMap<>());
+
+        SmallFullEntity smallFullEntity = smallFullTransformer.transform(smallFull);
+
+        Assertions.assertNotNull(smallFullEntity);
+        Assertions.assertEquals("etag", smallFullEntity.getData().getEtag());
+        Assertions.assertEquals("kind", smallFullEntity.getData().getKind());
+        Assertions.assertEquals(new HashMap<>(), smallFullEntity.getData().getLinks());
+    }
+}
+


### PR DESCRIPTION
Adds the classes to get the initial smallEntity saved to the database.
Added the relevant test classes.
Moved the kind field to the BaseDataEntity as it is needed by all future entities.
Removed the place holder from the addID field as it was preventing data saving correctly.

Helps resolve: SFA-337