### PR TITLE
Removed spring-data-rest-webmvc from the pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-rest-webmvc</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>


### PR DESCRIPTION
Refactoring to remove the spring-data-rest-webmvc lib from the pom.xml it's not required. 