### PR TITLE
Added id generation for the database

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/AttributeName.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/AttributeName.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.api.accounts;
+
+public enum AttributeName {
+
+    TRANSACTION("transaction"),
+    COMPANY_ACCOUNT("accounts"),
+    SMALLFULL("small-full");
+
+    private String value;
+
+    AttributeName(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
@@ -51,6 +51,6 @@ public class CompanyAccountsApplication implements WebMvcConfigurer {
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(transactionInterceptor)
-                .addPathPatterns("/transactions/{transactionId}/company-accounts");
+                .addPathPatterns("/transactions/{transactionId}/**");
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/Kind.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/Kind.java
@@ -3,7 +3,8 @@ package uk.gov.companieshouse.api.accounts;
 public enum Kind {
 
     ACCOUNT("accounts"),
-    SMALL_FULL_ACCOUNT("accounts#smallfull");
+    SMALL_FULL_ACCOUNT("small-full-accounts#small-full-accounts"),
+    CURRENT_PERIOD("small-full-accounts#current-period");
 
     private String value;
 
@@ -14,6 +15,5 @@ public enum Kind {
     public String getValue() {
         return value;
     }
-
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.api.accounts.controller;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -19,7 +21,15 @@ public class CompanyAccountController {
 
     @PostMapping(value = "/transactions/{transactionId}/company-accounts",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity createCompanyAccount(@Valid @RequestBody CompanyAccount companyAccount) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(companyAccountService.save(companyAccount));
+    public ResponseEntity createCompanyAccount(@Valid @RequestBody CompanyAccount companyAccount)
+            throws NoSuchAlgorithmException {
+        //TODO accountNumber should be retrieved from the Transaction after it becomes available via the interceptor
+        SecureRandom random = new SecureRandom();
+        byte[] bytes = new byte[6];
+        random.nextBytes(bytes);
+        String accountNumber = new String(bytes);
+
+        CompanyAccount result = companyAccountService.save(companyAccount, accountNumber);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
@@ -26,7 +26,7 @@ public class CompanyAccountController {
     public ResponseEntity createCompanyAccount(@Valid @RequestBody CompanyAccount companyAccount,
             HttpServletRequest request)
             throws NoSuchAlgorithmException {
-        Transaction transaction = (Transaction) request.getAttribute(AttributeName.TRANSACTION.getValue());
+        Transaction transaction = (Transaction) request.getSession().getAttribute(AttributeName.TRANSACTION.getValue());
         CompanyAccount result = companyAccountService
                 .save(companyAccount, transaction.getCompanyNumber());
         return ResponseEntity.status(HttpStatus.CREATED).body(result);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.service.CompanyAccountService;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
@@ -25,7 +26,7 @@ public class CompanyAccountController {
     public ResponseEntity createCompanyAccount(@Valid @RequestBody CompanyAccount companyAccount,
             HttpServletRequest request)
             throws NoSuchAlgorithmException {
-        Transaction transaction = (Transaction) request.getAttribute("transaction");
+        Transaction transaction = (Transaction) request.getAttribute(AttributeName.TRANSACTION.getValue());
         CompanyAccount result = companyAccountService
                 .save(companyAccount, transaction.getCompanyNumber());
         return ResponseEntity.status(HttpStatus.CREATED).body(result);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.api.accounts.controller;
 
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.service.CompanyAccountService;
+import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 
 @RestController
 public class CompanyAccountController {
@@ -21,15 +22,12 @@ public class CompanyAccountController {
 
     @PostMapping(value = "/transactions/{transactionId}/company-accounts",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity createCompanyAccount(@Valid @RequestBody CompanyAccount companyAccount)
+    public ResponseEntity createCompanyAccount(@Valid @RequestBody CompanyAccount companyAccount,
+            HttpServletRequest request)
             throws NoSuchAlgorithmException {
-        //TODO accountNumber should be retrieved from the Transaction after it becomes available via the interceptor
-        SecureRandom random = new SecureRandom();
-        byte[] bytes = new byte[6];
-        random.nextBytes(bytes);
-        String accountNumber = new String(bytes);
-
-        CompanyAccount result = companyAccountService.save(companyAccount, accountNumber);
+        Transaction transaction = (Transaction) request.getAttribute("transaction");
+        CompanyAccount result = companyAccountService
+                .save(companyAccount, transaction.getCompanyNumber());
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.service.CurrentPeriodService;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
@@ -25,7 +26,7 @@ public class CurrentPeriodController {
     public ResponseEntity create(@Valid @RequestBody CurrentPeriod currentPeriod,
             HttpServletRequest request)
             throws NoSuchAlgorithmException {
-        Transaction transaction = (Transaction) request.getAttribute("transaction");
+        Transaction transaction = (Transaction) request.getAttribute(AttributeName.TRANSACTION.getValue());
         CurrentPeriod result = currentPeriodService
                 .save(currentPeriod, transaction.getCompanyNumber());
         return ResponseEntity.status(HttpStatus.CREATED).body(result);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.api.accounts.controller;
 
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.service.CurrentPeriodService;
+import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 
 @RestController
 public class CurrentPeriodController {
@@ -21,15 +22,12 @@ public class CurrentPeriodController {
 
     @PostMapping(value = "/transactions/{transactionId}/company-accounts/{companyAccountsId}/small-full/current-period",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity create(@Valid @RequestBody CurrentPeriod currentPeriod)
+    public ResponseEntity create(@Valid @RequestBody CurrentPeriod currentPeriod,
+            HttpServletRequest request)
             throws NoSuchAlgorithmException {
-        //TODO accountNumber should be retrieved from the Transaction after it becomes available via the interceptor
-        SecureRandom random = new SecureRandom();
-        byte[] bytes = new byte[6];
-        random.nextBytes(bytes);
-        String accountNumber = new String(bytes);
-
-        CurrentPeriod result = currentPeriodService.save(currentPeriod, accountNumber);
+        Transaction transaction = (Transaction) request.getAttribute("transaction");
+        CurrentPeriod result = currentPeriodService
+                .save(currentPeriod, transaction.getCompanyNumber());
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
 
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.api.accounts.controller;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -19,8 +21,16 @@ public class CurrentPeriodController {
 
     @PostMapping(value = "/transactions/{transactionId}/company-accounts/{companyAccountsId}/small-full/current-period",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity create(@Valid @RequestBody CurrentPeriod currentPeriod) {
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(currentPeriodService.save(currentPeriod));
+    public ResponseEntity create(@Valid @RequestBody CurrentPeriod currentPeriod)
+            throws NoSuchAlgorithmException {
+        //TODO accountNumber should be retrieved from the Transaction after it becomes available via the interceptor
+        SecureRandom random = new SecureRandom();
+        byte[] bytes = new byte[6];
+        random.nextBytes(bytes);
+        String accountNumber = new String(bytes);
+
+        CurrentPeriod result = currentPeriodService.save(currentPeriod, accountNumber);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
@@ -26,7 +26,7 @@ public class CurrentPeriodController {
     public ResponseEntity create(@Valid @RequestBody CurrentPeriod currentPeriod,
             HttpServletRequest request)
             throws NoSuchAlgorithmException {
-        Transaction transaction = (Transaction) request.getAttribute(AttributeName.TRANSACTION.getValue());
+        Transaction transaction = (Transaction) request.getSession().getAttribute(AttributeName.TRANSACTION.getValue());
         CurrentPeriod result = currentPeriodService
                 .save(currentPeriod, transaction.getCompanyNumber());
         return ResponseEntity.status(HttpStatus.CREATED).body(result);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.api.accounts.controller;
 
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.SmallFullService;
+import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 
 @RestController
 public class SmallFullController {
@@ -21,15 +22,12 @@ public class SmallFullController {
 
     @PostMapping(value = "/transactions/{transactionId}/company-accounts/{companyAccountId}/small-full",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity create(@Valid @RequestBody SmallFull smallFull)
+    public ResponseEntity create(@Valid @RequestBody SmallFull smallFull,
+            HttpServletRequest request)
             throws NoSuchAlgorithmException {
-        //TODO accountNumber should be retrieved from the Transaction after it becomes available via the interceptor
-        SecureRandom random = new SecureRandom();
-        byte[] bytes = new byte[6];
-        random.nextBytes(bytes);
-        String accountNumber = new String(bytes);
+        Transaction transaction = (Transaction) request.getAttribute("transaction");
 
-        SmallFull result = smallFullService.save(smallFull, accountNumber);
+        SmallFull result = smallFullService.save(smallFull, transaction.getCompanyNumber());
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.api.accounts.controller;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -19,8 +21,15 @@ public class SmallFullController {
 
     @PostMapping(value = "/transactions/{transactionId}/company-accounts/{companyAccountId}/small-full",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity create(@Valid @RequestBody SmallFull smallFull) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(smallFullService.save(smallFull));
-    }
+    public ResponseEntity create(@Valid @RequestBody SmallFull smallFull)
+            throws NoSuchAlgorithmException {
+        //TODO accountNumber should be retrieved from the Transaction after it becomes available via the interceptor
+        SecureRandom random = new SecureRandom();
+        byte[] bytes = new byte[6];
+        random.nextBytes(bytes);
+        String accountNumber = new String(bytes);
 
+        SmallFull result = smallFullService.save(smallFull, accountNumber);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.SmallFullService;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
@@ -25,7 +26,7 @@ public class SmallFullController {
     public ResponseEntity create(@Valid @RequestBody SmallFull smallFull,
             HttpServletRequest request)
             throws NoSuchAlgorithmException {
-        Transaction transaction = (Transaction) request.getAttribute("transaction");
+        Transaction transaction = (Transaction) request.getAttribute(AttributeName.TRANSACTION.getValue());
 
         SmallFull result = smallFullService.save(smallFull, transaction.getCompanyNumber());
         return ResponseEntity.status(HttpStatus.CREATED).body(result);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
@@ -26,7 +26,8 @@ public class SmallFullController {
     public ResponseEntity create(@Valid @RequestBody SmallFull smallFull,
             HttpServletRequest request)
             throws NoSuchAlgorithmException {
-        Transaction transaction = (Transaction) request.getAttribute(AttributeName.TRANSACTION.getValue());
+        Transaction transaction = (Transaction) request.getSession()
+                .getAttribute(AttributeName.TRANSACTION.getValue());
 
         SmallFull result = smallFullService.save(smallFull, transaction.getCompanyNumber());
         return ResponseEntity.status(HttpStatus.CREATED).body(result);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/exceptionhandler/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/exceptionhandler/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.api.accounts.exceptionhandler;
+
+import java.security.NoSuchAlgorithmException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(value = NoSuchAlgorithmException.class)
+    protected ResponseEntity<Object> handleConflict(NoSuchAlgorithmException ex, WebRequest
+            request) {
+        String bodyOfResponse = "An internal exception has occurred";
+        return handleExceptionInternal(ex, bodyOfResponse, new HttpHeaders(),
+                HttpStatus.INTERNAL_SERVER_ERROR, request);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
@@ -34,6 +34,7 @@ public class TransactionInterceptor extends HandlerInterceptorAdapter {
             String transactionId = pathVariables.get("transactionId");
             ResponseEntity<Transaction> transaction = transactionManager
                     .getTransaction(transactionId, request.getHeader("X-Request-Id"));
+            request.setAttribute("transaction", transaction);
             return isTransactionIsOpen(transaction);
         } catch (HttpClientErrorException httpClientErrorException) {
             response.setStatus(httpClientErrorException.getStatusCode().value());

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transaction.TransactionManager;
 import uk.gov.companieshouse.api.accounts.transaction.TransactionStatus;
@@ -36,7 +37,7 @@ public class TransactionInterceptor extends HandlerInterceptorAdapter {
             ResponseEntity<Transaction> transaction = transactionManager
                     .getTransaction(transactionId, request.getHeader("X-Request-Id"));
             HttpSession session = request.getSession();
-            session.setAttribute("transaction", transaction);
+            session.setAttribute(AttributeName.TRANSACTION.getValue(), transaction);
             return isTransactionIsOpen(transaction);
         } catch (HttpClientErrorException httpClientErrorException) {
             response.setStatus(httpClientErrorException.getStatusCode().value());

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.api.accounts.interceptor;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -34,7 +35,8 @@ public class TransactionInterceptor extends HandlerInterceptorAdapter {
             String transactionId = pathVariables.get("transactionId");
             ResponseEntity<Transaction> transaction = transactionManager
                     .getTransaction(transactionId, request.getHeader("X-Request-Id"));
-            request.setAttribute("transaction", transaction);
+            HttpSession session = request.getSession();
+            session.setAttribute("transaction", transaction);
             return isTransactionIsOpen(transaction);
         } catch (HttpClientErrorException httpClientErrorException) {
             response.setStatus(httpClientErrorException.getStatusCode().value());

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/AbstractService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/AbstractService.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.api.accounts.service;
 
+import java.security.NoSuchAlgorithmException;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.accounts.model.entity.BaseEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.RestObject;
@@ -7,7 +8,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.RestObject;
 @Service
 public interface AbstractService<C extends RestObject, E extends BaseEntity> {
 
-    public C save(C rest);
+    public C save(C rest, String companyAccountId) throws NoSuchAlgorithmException;
 
     public void addEtag(C rest);
 
@@ -15,6 +16,7 @@ public interface AbstractService<C extends RestObject, E extends BaseEntity> {
 
     public void addKind(C rest);
 
-    public void addID(E entity);
+    public String getResourceName();
 
+    public String generateID(String value) throws NoSuchAlgorithmException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/AbstractServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/AbstractServiceImpl.java
@@ -1,5 +1,9 @@
 package uk.gov.companieshouse.api.accounts.service.impl;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
@@ -12,9 +16,9 @@ import uk.gov.companieshouse.api.accounts.transformer.GenericTransformer;
 public abstract class AbstractServiceImpl<C extends RestObject, E extends BaseEntity> implements
         AbstractService<C, E> {
 
-    private MongoRepository mongoRepository;
+    public MongoRepository mongoRepository;
 
-    private GenericTransformer<C, E> genericTransformer;
+    public GenericTransformer<C, E> genericTransformer;
 
     public AbstractServiceImpl(MongoRepository mongoRepository,
             GenericTransformer<C, E> genericTransformer) {
@@ -23,12 +27,12 @@ public abstract class AbstractServiceImpl<C extends RestObject, E extends BaseEn
     }
 
     @Override
-    public C save(C rest) {
+    public C save(C rest, String companyAccountId) throws NoSuchAlgorithmException {
         addEtag(rest);
         addKind(rest);
         addLinks(rest);
         E baseEntity = genericTransformer.transform(rest);
-        addID(baseEntity);
+        baseEntity.setId(generateID(companyAccountId));
         mongoRepository.save(baseEntity);
         return rest;
     }
@@ -39,7 +43,11 @@ public abstract class AbstractServiceImpl<C extends RestObject, E extends BaseEn
     }
 
     @Override
-    public void addID(BaseEntity entity) {
-
+    public String generateID(String value) throws NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        String unencryptedId = value + getResourceName();
+        byte[] id = digest.digest(
+                unencryptedId.getBytes(StandardCharsets.UTF_8));
+        return Base64.getUrlEncoder().encodeToString(id);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
@@ -1,5 +1,8 @@
 package uk.gov.companieshouse.api.accounts.service.impl;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -27,7 +30,20 @@ public class CompanyAccountServiceImpl extends
     }
 
     @Override
+    public String getResourceName() {
+        return "company-account";
+    }
+
+    @Override
     public void addKind(CompanyAccount rest) {
         rest.setKind(Kind.ACCOUNT.getValue());
+    }
+
+    @Override
+    public String generateID(String value) throws NoSuchAlgorithmException {
+        SecureRandom random = new SecureRandom();
+        byte[] bytes = new byte[20];
+        random.nextBytes(bytes);
+        return Base64.getUrlEncoder().encodeToString(bytes);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceImpl.java
@@ -4,8 +4,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.accounts.Kind;
 import uk.gov.companieshouse.api.accounts.model.entity.CurrentPeriodEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
+import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.CurrentPeriodService;
 import uk.gov.companieshouse.api.accounts.transformer.GenericTransformer;
 
@@ -27,6 +29,11 @@ public class CurrentPeriodServiceImpl extends
 
     @Override
     public void addKind(CurrentPeriod rest) {
-        rest.setKind("small-full-accounts#current-period");
+        rest.setKind(Kind.CURRENT_PERIOD.getValue());
+    }
+
+    @Override
+    public String getResourceName() {
+        return "current-period";
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullServiceImpl.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.accounts.Kind;
 import uk.gov.companieshouse.api.accounts.model.entity.SmallFullEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.SmallFullService;
@@ -27,8 +28,14 @@ public class SmallFullServiceImpl extends
 
     @Override
     public void addKind(SmallFull rest) {
-
+        rest.setKind(Kind.SMALL_FULL_ACCOUNT.getValue());
     }
+
+    @Override
+    public String getResourceName() {
+        return "small-full";
+    }
+
 
 }
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.security.NoSuchAlgorithmException;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.service.CompanyAccountService;
+import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -30,35 +31,31 @@ import uk.gov.companieshouse.api.accounts.service.CompanyAccountService;
 public class CompanyAccountControllerTest {
 
     @Mock
+    private HttpServletRequest request;
+    @Mock
+    private Transaction transaction;
+    @Mock
     private CompanyAccount companyAccount;
-
     @Mock
     private CompanyAccount createdCompanyAccount;
-
     @Mock
     private CompanyAccountService companyAccountService;
-
     @InjectMocks
     private CompanyAccountController companyAccountController;
 
     @BeforeEach
-    public void setUp(){
-        try {
-            when(companyAccountService.save(any(CompanyAccount.class), anyString())).thenReturn(createdCompanyAccount);
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        }
+    public void setUp() throws NoSuchAlgorithmException {
+        when(companyAccountService.save(any(CompanyAccount.class), anyString()))
+                .thenReturn(createdCompanyAccount);
+        when(request.getAttribute(anyString())).thenReturn(transaction);
+        when(transaction.getCompanyNumber()).thenReturn("123456");
     }
 
     @Test
     @DisplayName("Tests the successful creation of an companyAccount resource")
-    public void canCreateAccount() {
-        ResponseEntity response = null;
-        try {
-            response = companyAccountController.createCompanyAccount(companyAccount);
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        }
+    public void canCreateAccount() throws NoSuchAlgorithmException {
+        ResponseEntity response = companyAccountController
+                .createCompanyAccount(companyAccount, request);
 
         assertNotNull(response);
         assertEquals(HttpStatus.CREATED, response.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.security.NoSuchAlgorithmException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,13 +40,22 @@ public class CompanyAccountControllerTest {
 
     @BeforeEach
     public void setUp(){
-        when(companyAccountService.save(companyAccount)).thenReturn(createdCompanyAccount);
+        try {
+            when(companyAccountService.save(companyAccount, "")).thenReturn(createdCompanyAccount);
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
     }
 
     @Test
     @DisplayName("Tests the successful creation of an companyAccount resource")
     public void canCreateAccount() {
-        ResponseEntity response = companyAccountController.createCompanyAccount(companyAccount);
+        ResponseEntity response = null;
+        try {
+            response = companyAccountController.createCompanyAccount(companyAccount);
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
 
         assertNotNull(response);
         assertEquals(HttpStatus.CREATED, response.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
@@ -3,6 +3,9 @@ package uk.gov.companieshouse.api.accounts.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.security.NoSuchAlgorithmException;
@@ -41,7 +44,7 @@ public class CompanyAccountControllerTest {
     @BeforeEach
     public void setUp(){
         try {
-            when(companyAccountService.save(companyAccount, "")).thenReturn(createdCompanyAccount);
+            when(companyAccountService.save(any(CompanyAccount.class), anyString())).thenReturn(createdCompanyAccount);
         } catch (NoSuchAlgorithmException e) {
             e.printStackTrace();
         }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
@@ -3,8 +3,12 @@ package uk.gov.companieshouse.api.accounts.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.security.NoSuchAlgorithmException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,13 +42,22 @@ public class CurrentPeriodControllerTest {
 
     @BeforeEach
     public void setUp() {
-        when(currentPeriodService.save(currentPeriod)).thenReturn(createdCurrentPeriod);
+        try {
+            when(currentPeriodService.save(any(CurrentPeriod.class), anyString())).thenReturn(createdCurrentPeriod);
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
     }
 
     @Test
     @DisplayName("Tests the successful creation of a currentPeriod resource")
     public void canCreateAccount() {
-        ResponseEntity response = currentPeriodController.create(currentPeriod);
+        ResponseEntity response = null;
+        try {
+            response = currentPeriodController.create(currentPeriod);
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
 
         assertNotNull(response);
         assertEquals(HttpStatus.CREATED, response.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.security.NoSuchAlgorithmException;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,41 +23,37 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.service.CurrentPeriodService;
+import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class CurrentPeriodControllerTest {
 
     @Mock
+    private HttpServletRequest request;
+    @Mock
+    private Transaction transaction;
+    @Mock
     private CurrentPeriod currentPeriod;
-
     @Mock
     private CurrentPeriod createdCurrentPeriod;
-
     @Mock
     private CurrentPeriodService currentPeriodService;
-
     @InjectMocks
     private CurrentPeriodController currentPeriodController;
 
     @BeforeEach
-    public void setUp() {
-        try {
-            when(currentPeriodService.save(any(CurrentPeriod.class), anyString())).thenReturn(createdCurrentPeriod);
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        }
+    public void setUp() throws NoSuchAlgorithmException {
+        when(currentPeriodService.save(any(CurrentPeriod.class), anyString()))
+                .thenReturn(createdCurrentPeriod);
+        when(request.getAttribute(anyString())).thenReturn(transaction);
+        when(transaction.getCompanyNumber()).thenReturn("123456");
     }
 
     @Test
     @DisplayName("Tests the successful creation of a currentPeriod resource")
-    public void canCreateAccount() {
-        ResponseEntity response = null;
-        try {
-            response = currentPeriodController.create(currentPeriod);
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        }
+    public void canCreateAccount() throws NoSuchAlgorithmException {
+        ResponseEntity response = currentPeriodController.create(currentPeriod, request);
 
         assertNotNull(response);
         assertEquals(HttpStatus.CREATED, response.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/SmallFullControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/SmallFullControllerTest.java
@@ -3,6 +3,9 @@ package uk.gov.companieshouse.api.accounts.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.security.NoSuchAlgorithmException;
@@ -18,6 +21,7 @@ import org.mockito.internal.matchers.Equals;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.RestObject;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.SmallFullService;
 
@@ -41,7 +45,7 @@ public class SmallFullControllerTest {
         @BeforeEach
         public void setUp(){
             try {
-                when(smallFullService.save(smallFull, "")).thenReturn(createdSmallFull);
+                when(smallFullService.save(any(SmallFull.class), anyString())).thenReturn(createdSmallFull);
             } catch (NoSuchAlgorithmException e) {
                 e.printStackTrace();
             }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/SmallFullControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/SmallFullControllerTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.security.NoSuchAlgorithmException;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,48 +21,42 @@ import org.mockito.internal.matchers.Equals;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import uk.gov.companieshouse.api.accounts.model.rest.RestObject;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.SmallFullService;
+import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class SmallFullControllerTest {
 
 
-        @Mock
-        private SmallFull smallFull;
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private Transaction transaction;
+    @Mock
+    private SmallFull smallFull;
+    @Mock
+    private SmallFull createdSmallFull;
+    @Mock
+    private SmallFullService smallFullService;
+    @InjectMocks
+    private SmallFullController smallFullController;
 
-        @Mock
-        private SmallFull createdSmallFull;
-
-        @Mock
-        private SmallFullService smallFullService;
-
-        @InjectMocks
-        private SmallFullController smallFullController;
-
-        @BeforeEach
-        public void setUp(){
-            try {
-                when(smallFullService.save(any(SmallFull.class), anyString())).thenReturn(createdSmallFull);
-            } catch (NoSuchAlgorithmException e) {
-                e.printStackTrace();
-            }
-        }
-
-        @Test
-        @DisplayName("Tests the successful creation of a smallFull resource")
-        public void canCreateSmallFull() {
-            ResponseEntity response = null;
-            try {
-                response = smallFullController.create(smallFull);
-            } catch (NoSuchAlgorithmException e) {
-                e.printStackTrace();
-            }
-
-            assertNotNull(response);
-            assertEquals(HttpStatus.CREATED, response.getStatusCode());
-            assertTrue(new Equals(createdSmallFull).matches(response.getBody()));
-        }
+    @BeforeEach
+    public void setUp() throws NoSuchAlgorithmException {
+        when(smallFullService.save(any(SmallFull.class), anyString())).thenReturn(createdSmallFull);
+        when(request.getAttribute(anyString())).thenReturn(transaction);
+        when(transaction.getCompanyNumber()).thenReturn("123456");
     }
+
+    @Test
+    @DisplayName("Tests the successful creation of a smallFull resource")
+    public void canCreateSmallFull() throws NoSuchAlgorithmException {
+        ResponseEntity response = smallFullController.create(smallFull, request);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertTrue(new Equals(createdSmallFull).matches(response.getBody()));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/SmallFullControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/SmallFullControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.security.NoSuchAlgorithmException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,13 +40,22 @@ public class SmallFullControllerTest {
 
         @BeforeEach
         public void setUp(){
-            when(smallFullService.save(smallFull)).thenReturn(createdSmallFull);
+            try {
+                when(smallFullService.save(smallFull, "")).thenReturn(createdSmallFull);
+            } catch (NoSuchAlgorithmException e) {
+                e.printStackTrace();
+            }
         }
 
         @Test
         @DisplayName("Tests the successful creation of a smallFull resource")
         public void canCreateSmallFull() {
-            ResponseEntity response = smallFullController.create(smallFull);
+            ResponseEntity response = null;
+            try {
+                response = smallFullController.create(smallFull);
+            } catch (NoSuchAlgorithmException e) {
+                e.printStackTrace();
+            }
 
             assertNotNull(response);
             assertEquals(HttpStatus.CREATED, response.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.security.NoSuchAlgorithmException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,12 @@ public class CompanyAccountServiceImplTest {
     @Test
     @DisplayName("Tests the successful creation of an companyAccount resource")
     public void canCreateAccount() {
-        CompanyAccount result = companyAccountService.save(companyAccount);
+        CompanyAccount result = null;
+        try {
+            result = companyAccountService.save(companyAccount, "");
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
         assertNotNull(result);
         assertEquals(companyAccount, result);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
@@ -46,13 +46,8 @@ public class CompanyAccountServiceImplTest {
 
     @Test
     @DisplayName("Tests the successful creation of an companyAccount resource")
-    public void canCreateAccount() {
-        CompanyAccount result = null;
-        try {
-            result = companyAccountService.save(companyAccount, "");
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        }
+    public void canCreateAccount() throws NoSuchAlgorithmException {
+        CompanyAccount result = companyAccountService.save(companyAccount, "");
         assertNotNull(result);
         assertEquals(companyAccount, result);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceImplTest.java
@@ -46,7 +46,7 @@ public class CurrentPeriodServiceImplTest {
 
     @Test
     @DisplayName("Tests the successful creation of a currentPeriod resource")
-    public void canCresteCurrentPeriod() {
+    public void canCreateCurrentPeriod() {
         CurrentPeriod result = null;
         try {
             result = currentPeriodService.save(currentPeriod, "");

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
+import java.security.NoSuchAlgorithmException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,12 @@ public class CurrentPeriodServiceImplTest {
     @Test
     @DisplayName("Tests the successful creation of a currentPeriod resource")
     public void canCresteCurrentPeriod() {
-        CurrentPeriod result = currentPeriodService.save(currentPeriod);
+        CurrentPeriod result = null;
+        try {
+            result = currentPeriodService.save(currentPeriod, "");
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
         assertNotNull(result);
         assertEquals(currentPeriod, result);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceImplTest.java
@@ -46,13 +46,8 @@ public class CurrentPeriodServiceImplTest {
 
     @Test
     @DisplayName("Tests the successful creation of a currentPeriod resource")
-    public void canCreateCurrentPeriod() {
-        CurrentPeriod result = null;
-        try {
-            result = currentPeriodService.save(currentPeriod, "");
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        }
+    public void canCreateCurrentPeriod() throws NoSuchAlgorithmException {
+        CurrentPeriod result = currentPeriodService.save(currentPeriod, "");
         assertNotNull(result);
         assertEquals(currentPeriod, result);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullServiceImplTest.java
@@ -45,13 +45,8 @@ public class SmallFullServiceImplTest {
 
         @Test
         @DisplayName("Tests the successful creation of a smallFull resource")
-        public void canCreateAccount() {
-            SmallFull result = null;
-            try {
-                result = smallFullService.save(smallFull, "");
-            } catch (NoSuchAlgorithmException e) {
-                e.printStackTrace();
-            }
+        public void canCreateAccount() throws NoSuchAlgorithmException {
+            SmallFull result = smallFullService.save(smallFull, "");
             assertNotNull(result);
             assertEquals(smallFull, result);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
+import java.security.NoSuchAlgorithmException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,12 @@ public class SmallFullServiceImplTest {
         @Test
         @DisplayName("Tests the successful creation of a smallFull resource")
         public void canCreateAccount() {
-            SmallFull result = smallFullService.save(smallFull);
+            SmallFull result = null;
+            try {
+                result = smallFullService.save(smallFull, "");
+            } catch (NoSuchAlgorithmException e) {
+                e.printStackTrace();
+            }
             assertNotNull(result);
             assertEquals(smallFull, result);
 


### PR DESCRIPTION
Added the ID generation for existing entities.
Added a global error handling class as a result due to a NoSuchAlgorithmException needing to be captured.

The account number which should be read from the Transaction is currently unavailable so a TODO is added in both existing Controller classes.

Helps resolve: SFA-337