### PR TITLE
proposed fix for zero code test coverage problem on sonar qube

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,9 @@
         <!-- JUnit testing -->
         <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
+        
+        <!-- Jacoco -->
+        <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
 
         <!-- Sonar -->
         <sonar-maven-plugin.version>3.4.0.905</sonar-maven-plugin.version>
@@ -215,6 +218,26 @@
                                 <version>${junit-platform-surefire-provider.version}</version>
                             </dependency>
                         </dependencies>
+                    </plugin>
+                    <plugin>
+                      <groupId>org.jacoco</groupId>
+                      <artifactId>jacoco-maven-plugin</artifactId>
+                      <version>${jacoco-maven-plugin.version}</version>
+                      <executions>
+                        <execution>
+                          <id>default-prepare-agent</id>
+                          <goals>
+                            <goal>prepare-agent</goal>
+                          </goals>
+                        </execution>
+                        <execution>
+                          <id>default-report</id>
+                          <phase>prepare-package</phase>
+                          <goals>
+                            <goal>report</goal>
+                          </goals>
+                        </execution>
+                      </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Fixed code test coverage problem by adding the Jacoco plugin to the pom, results are on 
http://code-analysis.aws.chdev.org:9000/projects?sort=analysis_date

showing 48.7% coverage for this project.