### PR TITLE
Updating Filing model. Updating jsonproperty name to match others

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/filing/Filing.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/filing/Filing.java
@@ -20,9 +20,6 @@ public class Filing {
     @JsonProperty("description_values")
     private Map<String, String> descriptionValues;
 
-    @JsonProperty("links")
-    private List<Links> links;
-
     @JsonProperty("kind")
     private String kind;
 
@@ -59,14 +56,6 @@ public class Filing {
 
     public void setDescriptionValues(Map<String, String> descriptionValues) {
         this.descriptionValues = descriptionValues;
-    }
-
-    public List<Links> getLinks() {
-        return links;
-    }
-
-    public void setLinks(List<Links> links) {
-        this.links = links;
     }
 
     public String getKind() {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/period/Period.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/period/Period.java
@@ -6,11 +6,11 @@ public class Period {
 
     @JsonProperty("current_period_start_on")
     private String currentPeriodStartOn;
-    @JsonProperty("current_period_ends_on")
+    @JsonProperty("current_period_end_on")
     private String currentPeriodEndsOn;
     @JsonProperty("previous_period_start_on")
     private String previousPeriodStartOn;
-    @JsonProperty("previous_period_ends_on")
+    @JsonProperty("previous_period_end_on")
     private String previousPeriodEndsOn;
 
     public String getCurrentPeriodStartOn() {


### PR DESCRIPTION
Updating Filing model, `links` variable was added by mistake. 
Renaming JsonProperties to match other similar fields so that it passes validation in the `document render service`.

Resolves: SFA-122