### PR TITLE
Removal of the type specification from two HashMaps

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/CompanyAccountInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/CompanyAccountInterceptor.java
@@ -56,7 +56,7 @@ public class CompanyAccountInterceptor extends HandlerInterceptorAdapter {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
             Object handler) {
 
-        final Map<String, Object> debugMap = new HashMap<String, Object>();
+        final Map<String, Object> debugMap = new HashMap<>();
         debugMap.put("request_method", request.getMethod());
 
         HttpSession session = request.getSession();

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptor.java
@@ -60,7 +60,7 @@ public class SmallFullInterceptor extends HandlerInterceptorAdapter {
             return true;
         }
 
-        final Map<String, Object> debugMap = new HashMap<String, Object>();
+        final Map<String, Object> debugMap = new HashMap<>();
         debugMap.put("request_method", request.getMethod());
 
         HttpSession session = request.getSession();


### PR DESCRIPTION
Minor change to remove two type specifications from HashMaps in the interceptors. Raised as an issue via static code analysis.