### PR TITLE
Changed PatchException to extend RuntimeException

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/transaction/PatchException.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transaction/PatchException.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.api.accounts.transaction;
 
-public class PatchException extends Exception {
+public class PatchException extends RuntimeException {
 
     public PatchException(String message) {
         super(message);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionManager.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionManager.java
@@ -6,5 +6,5 @@ public interface TransactionManager {
 
     ResponseEntity<Transaction> getTransaction(String id, String requestId);
 
-    void updateTransaction(String transactionId, String requestId, String link) throws PatchException ;
+    void updateTransaction(String transactionId, String requestId, String link);
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionManagerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transaction/TransactionManagerImpl.java
@@ -58,7 +58,7 @@ public class TransactionManagerImpl implements TransactionManager {
      * @param requestId - id of the request
      * @param link - link of the resource to add to the transaction resources
      */
-    public void updateTransaction(String transactionId, String requestId, String link) throws PatchException {
+    public void updateTransaction(String transactionId, String requestId, String link) {
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("resources", createResourceMap(link));
 


### PR DESCRIPTION
Changed this exception to a runtime exception this will allow the @Transactional spring annotation to work as expected should we need to implement it at a later date. This will also bring it inline with the other errors that can be thrown via the database driver libraries.