### PR TITLE
Adding Filing Generator Controller

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/FilingController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/FilingController.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.api.accounts.controller;
+
+import java.util.Arrays;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
+import uk.gov.companieshouse.api.accounts.model.filing.Filing;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@RestController
+public class FilingController {
+
+    private static final Logger LOGGER = LoggerFactory
+        .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
+
+    @GetMapping("/private/transactions/{transactionId}/company-accounts/{companyAccountId}/filings")
+    public ResponseEntity generateFiling() {
+
+        return new ResponseEntity<>(Arrays.asList(new Filing()), HttpStatus.OK);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/FilingControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/FilingControllerTest.java
@@ -20,8 +20,6 @@ import org.springframework.http.ResponseEntity;
 public class FilingControllerTest {
 
     private ResponseEntity response;
-
-
     private FilingController filingController = new FilingController();
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/FilingControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/FilingControllerTest.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.api.accounts.controller;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class FilingControllerTest {
+
+    private ResponseEntity response;
+
+
+    private FilingController filingController = new FilingController();
+
+    @Test
+    @DisplayName("Tests the filing controller successful response")
+    public void shouldGenerateFiling() {
+        response = filingController.generateFiling();
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/FilingControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/FilingControllerTest.java
@@ -3,29 +3,22 @@ package uk.gov.companieshouse.api.accounts.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-@ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class FilingControllerTest {
 
-    private ResponseEntity response;
     private FilingController filingController = new FilingController();
 
     @Test
     @DisplayName("Tests the filing controller successful response")
     public void shouldGenerateFiling() {
-        response = filingController.generateFiling();
+        ResponseEntity response = filingController.generateFiling();
         assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
     }
 }


### PR DESCRIPTION
Changes to implement the existing **Filing Generator** functionality from _abridged_ to _company-accounts.api_.  Changes: 
- Adding the Filing Generator Controller. Junit tests.

Resolves: SFA-559