### PR TITLE
Feature/filing gen create filing model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<api-helper-java.version>1.0.0-rc1</api-helper-java.version>
 		<structured-logging.version>1.4.0-rc2</structured-logging.version>
 		<aws-java-sdk.version>1.11.52</aws-java-sdk.version>
-		<environment-reader-library.version>1.0.0-rc1</environment-reader-library.version>
+		<environment-reader-library.version>1043eed</environment-reader-library.version>
 		<company-accounts-library.version>5a6005b</company-accounts-library.version>
 		<jackson-datatype-jsr310.version>2.9.6</jackson-datatype-jsr310.version>
 		<httpclient.version>4.5.6</httpclient.version>

--- a/src/main/java/uk/gov/companieshouse/api/accounts/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/ApplicationConfiguration.java
@@ -5,6 +5,8 @@ import java.security.NoSuchAlgorithmException;
 import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
 
 /**
  * General application configuration .
@@ -15,5 +17,10 @@ public class ApplicationConfiguration {
     @Bean
     public MessageDigest getMessageDigest() throws NoSuchAlgorithmException {
         return MessageDigest.getInstance(MessageDigestAlgorithms.SHA_256);
+    }
+
+    @Bean
+    public EnvironmentReader environmentReader() {
+        return  new EnvironmentReaderImpl();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/FilingController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/FilingController.java
@@ -39,7 +39,7 @@ public class FilingController {
 
         if (transaction == null) {
             logRequestError(request, "no transaction in request session");
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
 
         CompanyAccountEntity companyAccountEntity =
@@ -47,7 +47,7 @@ public class FilingController {
 
         if (companyAccountEntity == null) {
             logRequestError(request,  "no company account in request session");
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
 
         Filing filing = filingService.generateAccountFiling(transaction, companyAccountEntity);
@@ -56,7 +56,7 @@ public class FilingController {
         }
 
         logRequestError(request,  "Failed to generate filing");
-        return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
     private void logRequestError(HttpServletRequest request, String errorMessage) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
@@ -112,8 +112,8 @@ public class FilingServiceImpl implements FilingService {
      */
     private boolean isValidIxbrl() {
         boolean isIxbrlValid = true;
-        if (environmentReader.getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR) == false) {
-            //TODO TNEP validation to be added when functionality is implemented . (STORY SFA-574)
+        if (!environmentReader.getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR)) {
+            //TODO Add TNEP validation to be added when functionality is implemented . (STORY SFA-574)
             //isIxbrlValid will be set to false if fails the tnep validation.
         }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
@@ -2,17 +2,23 @@ package uk.gov.companieshouse.api.accounts.service.impl;
 
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.accounts.AccountsType;
 import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
+import uk.gov.companieshouse.api.accounts.model.filing.Data;
 import uk.gov.companieshouse.api.accounts.model.filing.Filing;
+import uk.gov.companieshouse.api.accounts.model.filing.Link;
 import uk.gov.companieshouse.api.accounts.service.FilingService;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.utility.ixbrl.DocumentGeneratorCaller;
+import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -25,13 +31,18 @@ public class FilingServiceImpl implements FilingService {
     private static final String LOG_ACCOUNT_ID_KEY = "account-id";
     private static final String LOG_ERROR_KEY = "error";
     private static final String LOG_MESSAGE_KEY = "message";
+    private static final String DISABLE_IXBRL_VALIDATION_ENV_VAR = "DISABLE_IXBRL_VALIDATION";
+    private static final String LINK_RELATIONSHIP = "accounts";
+    private static final String PERIOD_END_ON = "period_end_on";
 
     private final DocumentGeneratorCaller documentGeneratorCaller;
+    private final EnvironmentReader environmentReader;
 
     @Autowired
-    public FilingServiceImpl(
-        DocumentGeneratorCaller documentGeneratorCaller) {
+    public FilingServiceImpl(DocumentGeneratorCaller documentGeneratorCaller,
+        EnvironmentReader environmentReader) {
         this.documentGeneratorCaller = documentGeneratorCaller;
+        this.environmentReader = environmentReader;
     }
 
     /**
@@ -43,7 +54,7 @@ public class FilingServiceImpl implements FilingService {
 
         AccountsType accountType = getAccountType(companyAccountEntity);
         if (accountType != null) {
-            return generateAccountFiling();
+            return generateAccountFiling(transaction, accountType);
         }
 
         return null;
@@ -78,9 +89,10 @@ public class FilingServiceImpl implements FilingService {
      * accounts name, etc)
      * @throws IOException -
      */
-    private Filing generateAccountFiling() {
-        if (generateIxbrl() != null) {
-            return new Filing();
+    private Filing generateAccountFiling(Transaction transaction, AccountsType accountsType) {
+        String ixbrlLocation = generateIxbrl();
+        if (ixbrlLocation != null && isValidIxbrl()) {
+            return createAccountFiling(transaction, accountsType, ixbrlLocation);
         }
 
         return null;
@@ -92,8 +104,90 @@ public class FilingServiceImpl implements FilingService {
      * @return The location where the service has stored the generated ixbrl.
      */
     private String generateIxbrl() {
-        //TODO: call the document generator's new end point to get generate ixbrl. Implementation does NOT exist yet. (STORY SFA-574)
+        //TODO: call the document generator's new end point to get generate ixbrl. Implementation does NOT exist yet. (STORY SFA-595)
         return documentGeneratorCaller.generateIxbrl();
     }
 
+    /**
+     * Validates the ixbrl against TNEP. This validation is driven by the env. variable and it can
+     * be disable.
+     */
+    private boolean isValidIxbrl() {
+        boolean isIxbrlValid = true;
+        if (environmentReader.getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR) == false) {
+            //TODO TNEP validation to be added when functionality is implemented . (STORY SFA-574)
+            isIxbrlValid = false;
+        }
+
+        return isIxbrlValid;
+    }
+
+    /**
+     * Generates the filing based on the Filing model.
+     *
+     * @param transaction - transaction information
+     * @param accountsType - Account type information: account type, ixbrl's template name, account
+     * @param ixbrlLocation - the location where the ixbrl is stored.
+     * @return
+     * @throws IOException
+     */
+    private Filing createAccountFiling(Transaction transaction, AccountsType accountsType,
+        String ixbrlLocation) {
+        Filing filing = new Filing();
+
+        //TODO Set correct periodEndOn (it is the Current Period's end date" in mongodb). Waiting for Doc.Gen changes. (STORY SFA-595)
+        LocalDate periodEndDate = LocalDate.now();
+
+        filing.setCompanyNumber(transaction.getCompanyNumber());
+        filing.setDescriptionIdentifier(accountsType.getAccountType());
+        filing.setKind(accountsType.getKind());
+        filing.setDescriptionValues(getDescriptionValues(periodEndDate));
+        filing.setData(getFilingData(periodEndDate, ixbrlLocation));
+
+        return filing;
+    }
+
+    /**
+     * Get the description values, which currently contains the period end date. This data is
+     * required for the filing description.
+     *
+     * @param periodEndDate - account's period end date
+     * @return {@link Map<String,String>} containing period end date, to match filing model
+     */
+    private Map<String, String> getDescriptionValues(LocalDate periodEndDate) {
+        Map<String, String> descriptionValues = new HashMap<>();
+        descriptionValues.put(PERIOD_END_ON, periodEndDate.toString());
+
+        return descriptionValues;
+    }
+
+    /**
+     * Get the filing data, it contains period end date and the links (ixbrl location and
+     * relationship link).
+     *
+     * @param periodEndDate - accounts end date
+     * @param ixbrlLocation - the location where ixbrl is stored
+     * @return {@link Data}
+     */
+    private Data getFilingData(LocalDate periodEndDate, String ixbrlLocation) {
+        Data data = new Data();
+        data.setPeriodEndOn(periodEndDate);
+        data.setLinks(getFilingLinks(ixbrlLocation));
+
+        return data;
+    }
+
+    /**
+     * Get the Link containing the ixbrl location and the relationship link e.g. accounts.
+     *
+     * @param ixbrlLocation - the location where ixbrl is stored
+     * @return {@link List < Link >}
+     */
+    private List<Link> getFilingLinks(String ixbrlLocation) {
+        Link link = new Link();
+        link.setRelationship(LINK_RELATIONSHIP);
+        link.setHref(ixbrlLocation);
+
+        return Arrays.asList(link);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
@@ -114,7 +114,7 @@ public class FilingServiceImpl implements FilingService {
         boolean isIxbrlValid = true;
         if (environmentReader.getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR) == false) {
             //TODO TNEP validation to be added when functionality is implemented . (STORY SFA-574)
-            isIxbrlValid = false;
+            //isIxbrlValid will be set to false if fails the tnep validation.
         }
 
         return isIxbrlValid;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/ixbrl/DocumentGeneratorCaller.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/ixbrl/DocumentGeneratorCaller.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * Class to call the document generator to obtain the ixbrl location.
- * Since the functionality has not been implemented yet, (STORY SFA-574), it returns an empty string.
+ * Since the functionality has not been implemented yet, (STORY SFA-595), it returns an empty string.
  *
  * This class will change to call the new end point and it will return the s3 ixbrl location.
  */

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/FilingControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/FilingControllerTest.java
@@ -65,7 +65,7 @@ class FilingControllerTest {
         response =
             filingController.generateFiling(TRANSACTION_ID, ACCOUNTS_ID, httpServletRequestMock);
 
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getStatusCode().value());
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCode().value());
     }
 
     @Test
@@ -77,7 +77,7 @@ class FilingControllerTest {
         response =
             filingController.generateFiling(TRANSACTION_ID, ACCOUNTS_ID, httpServletRequestMock);
 
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getStatusCode().value());
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCode().value());
     }
 
     @Test
@@ -91,7 +91,7 @@ class FilingControllerTest {
         response =
             filingController.generateFiling(TRANSACTION_ID, ACCOUNTS_ID, httpServletRequestMock);
 
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getStatusCode().value());
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCode().value());
     }
 
     private void mockHttpServletRequestAllAttributesSet() {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImplTest.java
@@ -26,6 +26,7 @@ import uk.gov.companieshouse.api.accounts.model.filing.Filing;
 import uk.gov.companieshouse.api.accounts.service.FilingService;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.utility.ixbrl.DocumentGeneratorCaller;
+import uk.gov.companieshouse.environment.EnvironmentReader;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
@@ -35,6 +36,7 @@ class FilingServiceImplTest {
     private static final String ACCOUNTS_ID = "1234561";
     private static final String SMALL_FULL_ID = "smallFullId";
     private static final String IXBRL_LOCATION = "http://test/ixbrl_bucket_location";
+    private static final String DISABLE_IXBRL_VALIDATION_ENV_VAR = "DISABLE_IXBRL_VALIDATION";
 
     private FilingService filingService;
     private CompanyAccountEntity companyAccountEntity;
@@ -42,13 +44,15 @@ class FilingServiceImplTest {
 
     @Mock
     private DocumentGeneratorCaller documentGeneratorCallerMock;
+    @Mock
+    private EnvironmentReader environmentReaderMock;
 
     @BeforeEach
     void setUpBeforeEach() {
         transaction = new Transaction();
         companyAccountEntity = createAccountEntity();
 
-        filingService = new FilingServiceImpl(documentGeneratorCallerMock);
+        filingService = new FilingServiceImpl(documentGeneratorCallerMock, environmentReaderMock);
     }
 
     @Test
@@ -56,16 +60,21 @@ class FilingServiceImplTest {
     void shouldGenerateFiling() {
 
         doReturn(IXBRL_LOCATION).when(documentGeneratorCallerMock).generateIxbrl();
+        doReturn(true).when(environmentReaderMock)
+            .getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR);
 
         Filing filing = filingService
             .generateAccountFiling(transaction, companyAccountEntity);
 
         verifyDocumentGeneratorCallerMock();
+        verify(environmentReaderMock, times(1))
+            .getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR);
+
         assertNotNull(filing);
     }
 
-    @DisplayName("Tests the filing not generated when small full accounts link is not present")
     @Test
+    @DisplayName("Tests the filing not generated when small full accounts link is not present")
     void shouldNotGenerateFilingAsSmallFullLinkNotPresentWithinAccountData() {
 
         companyAccountEntity.getData().setLinks(new HashMap<>());
@@ -74,9 +83,8 @@ class FilingServiceImplTest {
         assertNull(filing);
     }
 
-
-    @DisplayName("Tests the filing not generated when ixbrl has not been generated, ixbrl location not set")
     @Test
+    @DisplayName("Tests the filing not generated when ixbrl has not been generated, ixbrl location not set")
     void shouldNotGenerateFilingAsIxbrlLocationNotSet() {
         doReturn(null).when(documentGeneratorCallerMock).generateIxbrl();
 
@@ -86,11 +94,27 @@ class FilingServiceImplTest {
         assertNull(filing);
     }
 
-    private void verifyDocumentGeneratorCallerMock() {
-        verify(documentGeneratorCallerMock, times(1))
-            .generateIxbrl();
+    @Test
+    @DisplayName("Tests the filing not generated when fails tnep validation")
+    void shouldNotGenerateFilingAsFailTnepValidation() {
+
+        doReturn(IXBRL_LOCATION).when(documentGeneratorCallerMock).generateIxbrl();
+        doReturn(false).when(environmentReaderMock)
+            .getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR);
+
+        Filing filing = filingService
+            .generateAccountFiling(transaction, companyAccountEntity);
+
+        verifyDocumentGeneratorCallerMock();
+        verify(environmentReaderMock, times(1))
+            .getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR);
+
+        assertNull(filing);
     }
 
+    private void verifyDocumentGeneratorCallerMock() {
+        verify(documentGeneratorCallerMock, times(1)).generateIxbrl();
+    }
 
     /**
      * Builds Account Entity object.

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImplTest.java
@@ -92,24 +92,6 @@ class FilingServiceImplTest {
         assertNull(filing);
     }
 
-    @Test
-    @DisplayName("Tests the filing not generated when fails tnep validation")
-    void shouldNotGenerateFilingAsFailTnepValidation() {
-
-        doReturn(IXBRL_LOCATION).when(documentGeneratorCallerMock).generateIxbrl();
-        doReturn(false).when(environmentReaderMock)
-            .getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR);
-
-        Filing filing = filingService
-            .generateAccountFiling(transaction, companyAccountEntity);
-
-        verifyDocumentGeneratorCallerMock();
-        verify(environmentReaderMock, times(1))
-            .getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR);
-
-        assertNull(filing);
-    }
-
     private void verifyDocumentGeneratorCallerMock() {
         verify(documentGeneratorCallerMock, times(1)).generateIxbrl();
     }


### PR DESCRIPTION
Code changes to create the returned filing model. 

The TNEP validation method has also been added so that functionality can be plugged-in when it is completed. This validation always occur as long as it has not been disable by using a environment variable.

The controllor returned error has changed from internal error to bad request as per model. 

Resolves: SFA-559