### PR TITLE
Add beans to the application config for the autowired dependencies

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/ApplicationConfiguration.java
@@ -5,6 +5,10 @@ import java.security.NoSuchAlgorithmException;
 import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
 
 /**
  * General application configuration .
@@ -15,5 +19,15 @@ public class ApplicationConfiguration {
     @Bean
     public MessageDigest getMessageDigest() throws NoSuchAlgorithmException {
         return MessageDigest.getInstance(MessageDigestAlgorithms.SHA_256);
+    }
+    
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+    
+    @Bean
+    EnvironmentReader environmentReader() {
+        return new EnvironmentReaderImpl();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/ApplicationConfiguration.java
@@ -22,12 +22,12 @@ public class ApplicationConfiguration {
     }
     
     @Bean
-    public RestTemplate restTemplate() {
+    public RestTemplate getRestTemplate() {
         return new RestTemplate();
     }
     
     @Bean
-    EnvironmentReader environmentReader() {
+    public EnvironmentReader getEnvironmentReader() {
         return new EnvironmentReaderImpl();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImpl.java
@@ -1,28 +1,28 @@
 package uk.gov.companieshouse.api.accounts.service.impl;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.web.client.RestTemplate;
-import uk.gov.companieshouse.api.accounts.validation.Results;
-import uk.gov.companieshouse.api.accounts.service.TnepValidationService;
-import uk.gov.companieshouse.environment.EnvironmentReader;
-import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
+import static uk.gov.companieshouse.api.accounts.CompanyAccountsApplication.APPLICATION_NAME_SPACE;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static uk.gov.companieshouse.api.accounts.CompanyAccountsApplication.APPLICATION_NAME_SPACE;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
-@Component
+import uk.gov.companieshouse.api.accounts.service.TnepValidationService;
+import uk.gov.companieshouse.api.accounts.validation.Results;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Service
 public class TnepValidationServiceImpl implements TnepValidationService {
 
     private static final String IXBRL_VALIDATOR_URI = "IXBRL_VALIDATOR_URI";
@@ -182,13 +182,5 @@ public class TnepValidationServiceImpl implements TnepValidationService {
         public String getFilename() {
             return filename;
         }
-    }
-
-    public RestTemplate getRestTemplate() {
-        return restTemplate;
-    }
-
-    public void setRestTemplate(RestTemplate restTemplate) {
-        this.restTemplate = restTemplate;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/ApplicationConfigurationTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/ApplicationConfigurationTest.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.api.accounts;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestTemplate;
+
+import uk.gov.companieshouse.environment.EnvironmentReader;
+
+public class ApplicationConfigurationTest {
+
+	private ApplicationConfiguration applicationConfiguration;
+	
+	@BeforeEach
+	public void setUp() {
+		applicationConfiguration = new ApplicationConfiguration();
+	}
+	
+	@Test
+	@DisplayName("Get the bean for sending REST requests")
+	public void getBeanForRestRequests() {
+		RestTemplate bean = applicationConfiguration.getRestTemplate();
+		assertNotNull(bean);
+	}
+	
+	@Test
+	@DisplayName("Get the bean for reading environment variables")
+	public void getBeanForReadingEnvironmentVariables() {
+		EnvironmentReader bean = applicationConfiguration.getEnvironmentReader();
+		assertNotNull(bean);
+	}
+}


### PR DESCRIPTION
Autowired dependencies for the environment reader and the REST template need a bean defined in the application configuration.

Removes unused imports.