### PR TITLE
Added change to prevent null values in the rest model

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/BalanceSheet.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/BalanceSheet.java
@@ -1,8 +1,11 @@
 package uk.gov.companieshouse.api.accounts.model.rest;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.validation.constraints.NotNull;
 
+@JsonInclude(Include.NON_NULL)
 public class BalanceSheet {
 
     @NotNull

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/CompanyAccount.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/CompanyAccount.java
@@ -1,9 +1,12 @@
 package uk.gov.companieshouse.api.accounts.model.rest;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import javax.validation.constraints.NotNull;
 
+@JsonInclude(Include.NON_NULL)
 public class CompanyAccount extends RestObject {
 
     @NotNull

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/CurrentPeriod.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/CurrentPeriod.java
@@ -1,8 +1,11 @@
 package uk.gov.companieshouse.api.accounts.model.rest;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.validation.constraints.NotNull;
 
+@JsonInclude(Include.NON_NULL)
 public class CurrentPeriod extends RestObject {
 
     @NotNull

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/RestObject.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/RestObject.java
@@ -1,9 +1,12 @@
 package uk.gov.companieshouse.api.accounts.model.rest;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashMap;
 import java.util.Map;
 
+@JsonInclude(Include.NON_NULL)
 public class RestObject {
 
     @JsonProperty("links")


### PR DESCRIPTION
Bug fix added the @JsonInclude(Include.NON_NULL) to the rest models to prevent missing values being populated as `null`