### PR TITLE
Ensure 'period' is included in json path for returned errors

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/ErrorMapper.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/ErrorMapper.java
@@ -30,7 +30,9 @@ public class ErrorMapper {
                 String field = fieldError.getField();
                 String errorMessage = fieldError.getDefaultMessage();
 
-                String location = (field.replaceAll("(.)([A-Z])", "$1_$2")).toLowerCase();
+                //Convert returned location to a json path
+                String period = fieldError.getObjectName() + ".";
+                String location = ((period + field).replaceAll("(.)([A-Z])", "$1_$2")).toLowerCase();
 
                 if ("VALUE_OUTSIDE_RANGE".equals(errorMessage)) {
 


### PR DESCRIPTION
Ensure the full json path (including period) is included in binding result error json path.

Get period from 'Field error object' and append to beginning of the field error locations
Format return location to json format.

SFA-327