### PR TITLE
Added error handling for json parse exceptions

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/AccountsType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/AccountsType.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.api.accounts;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.api.accounts;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -57,16 +58,17 @@ public class CompanyAccountsApplication implements WebMvcConfigurer {
         SpringApplication.run(CompanyAccountsApplication.class, args);
     }
 
-    @Bean
-    @Primary
-    public ObjectMapper objectMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-        return objectMapper;
-    }
+//    @Bean
+//    @Primary
+//    public ObjectMapper objectMapper() {
+//        ObjectMapper objectMapper = new ObjectMapper();
+//        //objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+//        objectMapper.disable(MapperFeature.USE_STATIC_TYPING);
+//        objectMapper.registerModule(new JavaTimeModule());
+//        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+//
+//        return objectMapper;
+//    }
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.api.accounts;
 
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -58,17 +57,16 @@ public class CompanyAccountsApplication implements WebMvcConfigurer {
         SpringApplication.run(CompanyAccountsApplication.class, args);
     }
 
-//    @Bean
-//    @Primary
-//    public ObjectMapper objectMapper() {
-//        ObjectMapper objectMapper = new ObjectMapper();
-//        //objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-//        objectMapper.disable(MapperFeature.USE_STATIC_TYPING);
-//        objectMapper.registerModule(new JavaTimeModule());
-//        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-//
-//        return objectMapper;
-//    }
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        return objectMapper;
+    }
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandler.java
@@ -2,15 +2,12 @@ package uk.gov.companieshouse.api.accounts.exception.handler;
 
 import static uk.gov.companieshouse.api.accounts.CompanyAccountsApplication.APPLICATION_NAME_SPACE;
 
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import java.util.HashMap;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -18,6 +15,7 @@ import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.validation.ErrorMessageKeys;
 import uk.gov.companieshouse.api.accounts.validation.ErrorType;
+import uk.gov.companieshouse.api.accounts.validation.LocationType;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -38,38 +36,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return super.handleNoHandlerFoundException(ex, headers, status, request);
     }
 
-    @ExceptionHandler(value = {RuntimeException.class, Exception.class})
-    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
-    protected void handleException(Exception ex) {
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+        HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatus status,
+        WebRequest request) {
         logError(ex);
+        Errors errors = new Errors();
+        Error error = new Error(ErrorMessageKeys.INVALID_VALUE.getKey(), ex.getMessage(),
+            LocationType.JSON_BODY.getValue(), ErrorType.VALIDATION.getType());
+        errors.addError(error);
+        return new ResponseEntity<>(errors, headers, status);
     }
 
     private void logError(Exception ex) {
         HashMap<String, Object> message = new HashMap<>();
         message.put("message", ex.getMessage());
         message.put("error", ex.getClass());
-        STRUCTURED_LOGGER.error(ex, message);
+        STRUCTURED_LOGGER.error(ex.getMessage(), message);
     }
-
-    @Override
-    protected ResponseEntity<Object> handleHttpMessageNotReadable(
-        HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatus status,
-        WebRequest request) {
-
-        HashMap<String, Object> message = new HashMap<>();
-        message.put("message", ex.getMessage());
-        message.put("error", ex.getClass());
-        STRUCTURED_LOGGER.info(ex.getMessage(), message);
-
-        if (ex.getCause() instanceof InvalidFormatException) {
-            Errors errors = new Errors();
-            Error error = new Error(ErrorMessageKeys.INVALID_VALUE.getKey(), null,
-                null, ErrorType.VALIDATION.getType());
-            errors.addError(error);
-            return new ResponseEntity<>(errors, headers, status);
-        } else {
-            return this.handleExceptionInternal(ex, null, headers, status, request);
-        }
-    }
-
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandler.java
@@ -3,10 +3,8 @@ package uk.gov.companieshouse.api.accounts.exception.handler;
 import static uk.gov.companieshouse.api.accounts.CompanyAccountsApplication.APPLICATION_NAME_SPACE;
 
 import com.fasterxml.jackson.core.JsonLocation;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import java.util.HashMap;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -53,15 +51,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             InvalidFormatException ife = (InvalidFormatException) cause;
             message.append(":Can not deserialize value of ").append(ife.getValue())
                 .append(getLocationMessage(ife.getLocation()));
-        } else if (cause instanceof MismatchedInputException) {
-            MismatchedInputException mie = (MismatchedInputException) cause;
-            message.append(getLocationMessage(mie.getLocation()));
-        } else if (cause instanceof JsonMappingException) {
-            JsonMappingException jme = (JsonMappingException) cause;
-            message.append(getLocationMessage(jme.getLocation()));
-        } else if (cause instanceof JsonParseException) {
-            JsonParseException jpe = (JsonParseException) cause;
-            message.append(getLocationMessage(jpe.getLocation()));
+        } else if (cause instanceof JsonProcessingException) {
+          JsonProcessingException jpe = (JsonProcessingException) cause;
+          message.append(getLocationMessage(jpe.getLocation()));
         }
 
         Errors errors = new Errors();

--- a/src/main/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandler.java
@@ -58,7 +58,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         Errors errors = new Errors();
         Error error = new Error(ErrorMessageKeys.INVALID_VALUE.getKey(), message.toString(),
-            LocationType.JSON_BODY.getValue(), ErrorType.VALIDATION.getType());
+            LocationType.REQUEST_BODY.getValue(), ErrorType.VALIDATION.getType());
         errors.addError(error);
         return new ResponseEntity<>(errors, headers, status);
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandler.java
@@ -2,15 +2,24 @@ package uk.gov.companieshouse.api.accounts.exception.handler;
 
 import static uk.gov.companieshouse.api.accounts.CompanyAccountsApplication.APPLICATION_NAME_SPACE;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import java.util.HashMap;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import uk.gov.companieshouse.api.accounts.model.validation.Error;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.validation.ErrorMessageKeys;
+import uk.gov.companieshouse.api.accounts.validation.ErrorType;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
-
 
 /**
  * GlobalExceptionHandler defines handlers for generic exceptions.
@@ -18,26 +27,49 @@ import uk.gov.companieshouse.logging.LoggerFactory;
  * Api Specific Errors are handled in the Controller.
  */
 @ControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
+    private static final Logger STRUCTURED_LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
 
-  @ExceptionHandler(value = {NoHandlerFoundException.class})
-  @ResponseStatus(value = HttpStatus.NOT_FOUND)
-  protected void handleNoHandlerFoundException(Exception ex) {
-    logError(ex);
-  }
+    @Override
+    protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex,
+        HttpHeaders headers, HttpStatus status, WebRequest request) {
+        logError(ex);
+        return super.handleNoHandlerFoundException(ex, headers, status, request);
+    }
 
-  @ExceptionHandler(value = {RuntimeException.class, Exception.class})
-  @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
-  protected void handleException(Exception ex) {
-    logError(ex);
-  }
+    @ExceptionHandler(value = {RuntimeException.class, Exception.class})
+    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+    protected void handleException(Exception ex) {
+        logError(ex);
+    }
 
-  private void logError(Exception ex) {
-    HashMap<String, Object> message = new HashMap<>();
-    message.put("message", ex.getMessage());
-    message.put("error", ex.getClass());
-    LOGGER.error(ex, message);
-  }
+    private void logError(Exception ex) {
+        HashMap<String, Object> message = new HashMap<>();
+        message.put("message", ex.getMessage());
+        message.put("error", ex.getClass());
+        STRUCTURED_LOGGER.error(ex, message);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+        HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatus status,
+        WebRequest request) {
+
+        HashMap<String, Object> message = new HashMap<>();
+        message.put("message", ex.getMessage());
+        message.put("error", ex.getClass());
+        STRUCTURED_LOGGER.info(ex.getMessage(), message);
+
+        if (ex.getCause() instanceof InvalidFormatException) {
+            Errors errors = new Errors();
+            Error error = new Error(ErrorMessageKeys.INVALID_VALUE.getKey(), null,
+                null, ErrorType.VALIDATION.getType());
+            errors.addError(error);
+            return new ResponseEntity<>(errors, headers, status);
+        } else {
+            return this.handleExceptionInternal(ex, null, headers, status, request);
+        }
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Error.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Error.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.api.accounts.model.validation;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -10,6 +12,7 @@ import java.util.Map;
 /**
  * Represents a validation error
  */
+@JsonInclude(Include.NON_NULL)
 public class Error {
 
     @JsonProperty("error")
@@ -45,12 +48,6 @@ public class Error {
         if (error == null || error.isEmpty()) {
             throw new IllegalArgumentException("Error cannot be null or empty");
         }
-        if (location == null || location.isEmpty()) {
-            throw new IllegalArgumentException("Location cannot be null or empty");
-        }
-        if (locationType == null || locationType.isEmpty()) {
-            throw new IllegalArgumentException("Location type cannot be null or empty");
-        }
         if (type == null || type.isEmpty()) {
             throw new IllegalArgumentException("Type cannot be null or empty");
         }
@@ -59,30 +56,6 @@ public class Error {
         this.location = location;
         this.locationType = locationType;
         this.type = type;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Error other = (Error) o;
-
-        if (!error.equals(other.error)) return false;
-        if (errorValues != null ? !errorValues.equals(other.errorValues) : other.errorValues != null) return false;
-        if (!location.equals(other.location)) return false;
-        if (!locationType.equals(other.locationType)) return false;
-        return type.equals(other.type);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = error.hashCode();
-        result = 31 * result + (errorValues != null ? errorValues.hashCode() : 0);
-        result = 31 * result + location.hashCode();
-        result = 31 * result + locationType.hashCode();
-        result = 31 * result + type.hashCode();
-        return result;
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/LocationType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/LocationType.java
@@ -5,6 +5,7 @@ package uk.gov.companieshouse.api.accounts.validation;
  */
 public enum LocationType {
 
+    JSON_BODY("json-body"),
     JSON_PATH("json-path");
 
     private String value;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/LocationType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/LocationType.java
@@ -5,7 +5,7 @@ package uk.gov.companieshouse.api.accounts.validation;
  */
 public enum LocationType {
 
-    JSON_BODY("json-body"),
+    REQUEST_BODY("request-body"),
     JSON_PATH("json-path");
 
     private String value;

--- a/src/test/java/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/validation/CurrentPeriodValidatorTest.java
@@ -16,7 +16,7 @@ import uk.gov.companieshouse.api.accounts.validation.LocationType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class currentPeriodValidatorTest {
+public class CurrentPeriodValidatorTest {
 
     String CURRENT_PERIOD_PATH = "$.current_period";
     String BALANCE_SHEET_PATH = CURRENT_PERIOD_PATH + ".balance_sheet";


### PR DESCRIPTION
- Changed the `GlobalExceptionHandler` to extend `ResponseEntityExceptionHandler` so that we can return a `ResponseEntity` in every use case.
- Added language agnostic error messages for parse exceptions.
- Correct a Class name to use match Java format.
- Removed an unused import.
- Changed the error logging for `NoHandlerFoundException` and `MessageNotReadableException` from `ERROR` to `INFO` as this is user error.
- Added `json-body` as a location type.

Helps resolve: SFA-705