### PR TITLE
CompanyAccount service refactor to return Rest object.

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.exception.PatchException;
-import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.service.CompanyAccountService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
@@ -49,19 +48,19 @@ public class CompanyAccountController {
 
     @PostMapping
     public ResponseEntity createCompanyAccount(@Valid @RequestBody CompanyAccount companyAccount,
-            HttpServletRequest request) {
+        HttpServletRequest request) {
 
         Transaction transaction = (Transaction) request
-                .getAttribute(AttributeName.TRANSACTION.getValue());
+            .getAttribute(AttributeName.TRANSACTION.getValue());
 
         String requestId = request.getHeader("X-Request-Id");
         ResponseEntity responseEntity;
         try {
             ResponseObject<CompanyAccount> responseObject = companyAccountService
-                    .create(companyAccount, transaction, requestId);
+                .create(companyAccount, transaction, requestId);
             responseEntity = apiResponseMapper
-                    .map(responseObject.getStatus(), responseObject.getData(),
-                            responseObject.getValidationErrorData());
+                .map(responseObject.getStatus(), responseObject.getData(),
+                    responseObject.getValidationErrorData());
         } catch (PatchException | DataException ex) {
             final Map<String, Object> debugMap = new HashMap<>();
             debugMap.put("transaction_id", transaction.getId());
@@ -76,17 +75,16 @@ public class CompanyAccountController {
     public ResponseEntity getCompanyAccount(HttpServletRequest request) {
         LogContext logContext = LogHelper.createNewLogContext(request);
 
-        CompanyAccountEntity companyAccountEntity = (CompanyAccountEntity) request
-                .getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
-        if (companyAccountEntity == null) {
+        CompanyAccount companyAccount = (CompanyAccount) request
+            .getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
+        if (companyAccount == null) {
 
             LOGGER.error("CompanyAccountController error: No company account in request",
-                    logContext);
+                logContext);
             return ResponseEntity.status(HttpServletResponse.SC_NOT_FOUND).body(null);
         }
 
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(companyAccountTransformer.transform(companyAccountEntity));
+        return ResponseEntity.status(HttpStatus.OK).body(companyAccount);
 
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/FilingController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/FilingController.java
@@ -12,8 +12,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
-import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.filing.Filing;
+import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.service.FilingService;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
@@ -42,20 +42,20 @@ public class FilingController {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
-        CompanyAccountEntity companyAccountEntity =
-            (CompanyAccountEntity) request.getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
+        CompanyAccount companyAccount =
+            (CompanyAccount) request.getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
 
-        if (companyAccountEntity == null) {
-            logRequestError(request,  "no company account in request session");
+        if (companyAccount == null) {
+            logRequestError(request, "no company account in request session");
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
-        Filing filing = filingService.generateAccountFiling(transaction, companyAccountEntity);
+        Filing filing = filingService.generateAccountFiling(transaction, companyAccount);
         if (filing != null) {
             return new ResponseEntity<>(Arrays.asList(filing), HttpStatus.OK);
         }
 
-        logRequestError(request,  "Failed to generate filing");
+        logRequestError(request, "Failed to generate filing");
         return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
@@ -14,9 +14,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.HandlerMapping;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
-import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.impl.SmallFullService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
@@ -28,7 +28,7 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 
 @RestController
 @RequestMapping(value = "/transactions/{transactionId}/company-accounts/{companyAccountId}/small-full",
-        produces = MediaType.APPLICATION_JSON_VALUE)
+    produces = MediaType.APPLICATION_JSON_VALUE)
 public class SmallFullController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
@@ -44,22 +44,21 @@ public class SmallFullController {
 
     @PostMapping
     public ResponseEntity create(@Valid @RequestBody SmallFull smallFull,
-            HttpServletRequest request) {
+        HttpServletRequest request) {
         Transaction transaction = (Transaction) request
-                .getAttribute(AttributeName.TRANSACTION.getValue());
-        CompanyAccountEntity companyAccountEntity = (CompanyAccountEntity) request
-                .getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
-
-        String companyAccountId = companyAccountEntity.getId();
+            .getAttribute(AttributeName.TRANSACTION.getValue());
+        Map<String, String> pathVariables = (Map) request
+            .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        String companyAccountId = pathVariables.get("companyAccountId");
         String requestId = request.getHeader("X-Request-Id");
 
         ResponseEntity responseEntity;
         try {
             ResponseObject<SmallFull> responseObject = smallFullService
-                    .create(smallFull, transaction, companyAccountId, requestId);
+                .create(smallFull, transaction, companyAccountId, requestId);
             responseEntity = apiResponseMapper
-                    .map(responseObject.getStatus(), responseObject.getData(),
-                            responseObject.getValidationErrorData());
+                .map(responseObject.getStatus(), responseObject.getData(),
+                    responseObject.getValidationErrorData());
         } catch (DataException ex) {
             final Map<String, Object> debugMap = new HashMap<>();
             debugMap.put("transaction_id", transaction.getId());
@@ -75,7 +74,7 @@ public class SmallFullController {
     public ResponseEntity get(HttpServletRequest request) {
 
         SmallFull smallFull = (SmallFull) request
-                .getAttribute(AttributeName.SMALLFULL.getValue());
+            .getAttribute(AttributeName.SMALLFULL.getValue());
 
         return apiResponseMapper.mapGetResponse(smallFull, request);
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/CompanyAccountService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/CompanyAccountService.java
@@ -15,10 +15,11 @@ import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 public interface CompanyAccountService {
 
     ResponseObject<CompanyAccount> create(CompanyAccount companyAccount,
-            Transaction transaction,
-            String requestId) throws PatchException, DataException;
+        Transaction transaction,
+        String requestId) throws PatchException, DataException;
 
-    CompanyAccountEntity findById(String id);
+    ResponseObject<CompanyAccount> findById(String id, String requestId)
+        throws DataException;
 
     void addLink(String id, LinkType linkType, String link);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/FilingService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/FilingService.java
@@ -1,18 +1,18 @@
 package uk.gov.companieshouse.api.accounts.service;
 
-import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.filing.Filing;
+import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 
 public interface FilingService {
 
     /**
      * Generate a filing with the ixbrl location that is generated for transaction and accounts id.
+     *
      * @param transaction - Transaction information
      * @param companyAccountEntity - Company Account information
-     *
      * @return {@link Filing}
      */
     Filing generateAccountFiling(Transaction transaction,
-        CompanyAccountEntity companyAccountEntity);
+        CompanyAccount companyAccount);
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
@@ -10,10 +10,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.accounts.AccountsType;
 import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
-import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.filing.Data;
 import uk.gov.companieshouse.api.accounts.model.filing.Filing;
 import uk.gov.companieshouse.api.accounts.model.filing.Link;
+import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.service.FilingService;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.utility.ixbrl.DocumentGeneratorCaller;
@@ -48,9 +48,9 @@ public class FilingServiceImpl implements FilingService {
      */
     @Override
     public Filing generateAccountFiling(Transaction transaction,
-        CompanyAccountEntity companyAccountEntity) {
+        CompanyAccount companyAccount) {
 
-        AccountsType accountType = getAccountType(companyAccountEntity);
+        AccountsType accountType = getAccountType(companyAccount);
         if (accountType != null) {
             return generateAccountFiling(transaction, accountType);
         }
@@ -60,12 +60,9 @@ public class FilingServiceImpl implements FilingService {
 
     /**
      * Get account type by checking the account type link within the account's data.
-     *
-     * @param accountEntity
-     * @return
      */
-    private AccountsType getAccountType(CompanyAccountEntity accountEntity) {
-        Map<String, String> links = accountEntity.getData().getLinks();
+    private AccountsType getAccountType(CompanyAccount companyAccount) {
+        Map<String, String> links = companyAccount.getLinks();
 
         if (links.containsKey(AccountsType.SMALL_FULL_ACCOUNTS.getResourceKey())) {
             return AccountsType.SMALL_FULL_ACCOUNTS;
@@ -73,7 +70,6 @@ public class FilingServiceImpl implements FilingService {
 
         Map<String, Object> logMap = new HashMap<>();
         logMap.put(LOG_MESSAGE_KEY, "Link for account type is missing from account data");
-        logMap.put(LOG_ACCOUNT_ID_KEY, accountEntity.getId());
         LOGGER.error("Account Type not found", logMap);
 
         return null;
@@ -114,7 +110,7 @@ public class FilingServiceImpl implements FilingService {
         if (!environmentReader.getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR)) {
             //TODO Add TNEP validation to be added when functionality is implemented . (STORY SFA-574)
             //isIxbrlValid will be set to false if fails the tnep validation.
-            isIxbrlValid =  true;
+            isIxbrlValid = true;
         }
 
         return isIxbrlValid;
@@ -126,7 +122,6 @@ public class FilingServiceImpl implements FilingService {
      * @param transaction - transaction information
      * @param accountsType - Account type information: account type, ixbrl's template name, account
      * @param ixbrlLocation - the location where the ixbrl is stored.
-     * @return
      */
     private Filing createAccountFiling(Transaction transaction, AccountsType accountsType,
         String ixbrlLocation) {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
@@ -47,7 +47,7 @@ public class CompanyAccountControllerTest {
     private CompanyAccountTransformer companyAccountTransformer;
 
     @Mock
-    private CompanyAccount companyAccountMock;
+    private CompanyAccount companyAccount;
 
     @Mock
     private CompanyAccountService companyAccountServiceMock;
@@ -72,9 +72,9 @@ public class CompanyAccountControllerTest {
         when(httpServletRequestMock.getAttribute("transaction")).thenReturn(transactionMock);
         when(httpServletRequestMock.getHeader("X-Request-Id")).thenReturn("test");
         ResponseObject responseObject = new ResponseObject<>(ResponseStatus.CREATED,
-                companyAccountMock);
+            companyAccount);
         when(companyAccountServiceMock
-                .create(companyAccountMock, transactionMock, "test"))
+                .create(companyAccount, transactionMock, "test"))
                 .thenReturn(responseObject);
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.CREATED)
                 .body(responseObject.getData());
@@ -84,12 +84,12 @@ public class CompanyAccountControllerTest {
                 .thenReturn(responseEntity);
 
         ResponseEntity response = companyAccountController
-                .createCompanyAccount(companyAccountMock, httpServletRequestMock);
+                .createCompanyAccount(companyAccount, httpServletRequestMock);
 
         assertNotNull(response);
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertEquals(companyAccountMock, response.getBody());
+        assertEquals(companyAccount, response.getBody());
     }
 
     @Test
@@ -98,9 +98,9 @@ public class CompanyAccountControllerTest {
         when(httpServletRequestMock.getAttribute("transaction")).thenReturn(transactionMock);
         when(httpServletRequestMock.getHeader("X-Request-Id")).thenReturn("test");
         ResponseObject responseObject = new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR,
-                companyAccountMock);
+            companyAccount);
         when(companyAccountServiceMock
-                .create(companyAccountMock, transactionMock, "test"))
+                .create(companyAccount, transactionMock, "test"))
                 .thenReturn(responseObject);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.CONFLICT).body(null);
@@ -109,7 +109,7 @@ public class CompanyAccountControllerTest {
                 .thenReturn(responseEntity);
 
         ResponseEntity response = companyAccountController
-                .createCompanyAccount(companyAccountMock, httpServletRequestMock);
+                .createCompanyAccount(companyAccount, httpServletRequestMock);
 
         assertNotNull(response);
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
@@ -121,14 +121,14 @@ public class CompanyAccountControllerTest {
         when(httpServletRequestMock.getAttribute("transaction")).thenReturn(transactionMock);
         when(httpServletRequestMock.getHeader("X-Request-Id")).thenReturn("test");
         doThrow(mock(DataException.class)).when(companyAccountServiceMock)
-                .create(companyAccountMock, transactionMock, "test");
+                .create(companyAccount, transactionMock, "test");
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(null);
         when(apiResponseMapper.map(any(DataException.class)))
                 .thenReturn(responseEntity);
 
         ResponseEntity response = companyAccountController
-                .createCompanyAccount(companyAccountMock, httpServletRequestMock);
+                .createCompanyAccount(companyAccount, httpServletRequestMock);
 
         assertNotNull(response);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
@@ -137,16 +137,14 @@ public class CompanyAccountControllerTest {
     @Test
     @DisplayName("Tests the successful get of a company account resource")
     public void canGetCompanyAccount() throws NoSuchAlgorithmException {
-        doReturn(companyAccountEntity).when(httpServletRequestMock)
+        doReturn(companyAccount).when(httpServletRequestMock)
                 .getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
-        doReturn(companyAccountMock).when(companyAccountTransformer)
-                .transform(companyAccountEntity);
         ResponseEntity response = companyAccountController
                 .getCompanyAccount(httpServletRequestMock);
 
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(companyAccountMock, response.getBody());
+        assertEquals(companyAccount, response.getBody());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +25,7 @@ import org.mockito.quality.Strictness;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.servlet.HandlerMapping;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
@@ -87,12 +89,13 @@ public class CurrentPeriodControllerTest {
         when(apiResponseMapper.map(responseObject.getStatus(),
                 responseObject.getData(), responseObject.getValidationErrorData()))
                 .thenReturn(responseEntity);
+        Map<String, String> pathVariables = new HashMap<>();
+        pathVariables.put("companyAccountId", "123456");
+        doReturn(pathVariables).when(request)
+            .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
         doReturn(transaction).when(request)
                 .getAttribute(AttributeName.TRANSACTION.getValue());
         doReturn(smallFull).when(request).getAttribute(AttributeName.SMALLFULL.getValue());
-        doReturn(companyAccountEntity).when(request)
-                .getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
-        doReturn("12345").when(companyAccountEntity).getId();
         doReturn(responseObject).when(currentPeriodService).findById("create", "test");
         doReturn(new ResponseObject(ResponseStatus.FOUND,
                 currentPeriod)).when(currentPeriodService).findById("find", "test");
@@ -113,7 +116,12 @@ public class CurrentPeriodControllerTest {
     @Test
     @DisplayName("Test the retreval of a current period resource")
     public void canRetrieveCurrentPeriod() throws NoSuchAlgorithmException {
-        doReturn("find").when(currentPeriodService).generateID(anyString());
+        Map<String, String> pathVariables = new HashMap<>();
+        pathVariables.put("companyAccountId", "123456");
+
+        doReturn(pathVariables).when(request)
+            .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        doReturn("find").when(currentPeriodService).generateID("123456");
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.OK).body(currentPeriod);
         when(apiResponseMapper.mapGetResponse(currentPeriod,
                 request)).thenReturn(responseEntity);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/FilingControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/FilingControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.filing.Filing;
+import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.service.FilingService;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 
@@ -35,7 +36,9 @@ class FilingControllerTest {
     @Mock
     private Transaction transactionMock;
     @Mock
-    private CompanyAccountEntity companyAccountEntityMock;
+    private CompanyAccountEntity companyAccountEntity;
+    @Mock
+    private CompanyAccount companyAccount;
 
     @InjectMocks
     private FilingController filingController;
@@ -45,7 +48,7 @@ class FilingControllerTest {
     void shouldGenerateFiling() {
         mockHttpServletRequestAllAttributesSet();
 
-        when(filingServiceMock.generateAccountFiling(transactionMock, companyAccountEntityMock))
+        when(filingServiceMock.generateAccountFiling(transactionMock, companyAccount))
             .thenReturn(new Filing());
 
         response =
@@ -59,7 +62,7 @@ class FilingControllerTest {
     void shouldNotGenerateFiling() {
 
         mockHttpServletRequestAllAttributesSet();
-        when(filingServiceMock.generateAccountFiling(transactionMock, companyAccountEntityMock))
+        when(filingServiceMock.generateAccountFiling(transactionMock, companyAccount))
             .thenReturn(null);
 
         response =
@@ -97,6 +100,6 @@ class FilingControllerTest {
     private void mockHttpServletRequestAllAttributesSet() {
         when(httpServletRequestMock.getAttribute(anyString()))
             .thenReturn(transactionMock)
-            .thenReturn(companyAccountEntityMock);
+            .thenReturn(companyAccount);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/SmallFullControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/SmallFullControllerTest.java
@@ -3,12 +3,16 @@ package uk.gov.companieshouse.api.accounts.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -19,9 +23,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.HandlerMapping;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.impl.SmallFullService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
@@ -43,6 +49,9 @@ public class SmallFullControllerTest {
     private CompanyAccountEntity companyAccountEntity;
 
     @Mock
+    private CompanyAccount companyAccount;
+
+    @Mock
     private SmallFull smallFull;
 
     @Mock
@@ -50,6 +59,9 @@ public class SmallFullControllerTest {
 
     @Mock
     private ApiResponseMapper apiResponseMapper;
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
 
     @InjectMocks
     private SmallFullController smallFullController;
@@ -60,14 +72,19 @@ public class SmallFullControllerTest {
         ResponseObject<SmallFull> responseObject = new ResponseObject(
                 ResponseStatus.CREATED,
                 smallFull);
+
+        Map<String, String> pathVariables = new HashMap<>();
+        pathVariables.put("companyAccountId", "123456");
+
+        doReturn(transaction).when(request)
+            .getAttribute(AttributeName.TRANSACTION.getValue());
+        doReturn(pathVariables).when(request)
+            .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.CREATED)
                 .body(responseObject.getData());
-        doReturn(transaction).when(request)
-                .getAttribute(AttributeName.TRANSACTION.getValue());
-        doReturn(companyAccountEntity).when(request)
-                .getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
 
-        doReturn(responseObject).when(smallFullService).create(smallFull, transaction, null,null);
+        doReturn(responseObject).when(smallFullService).create(smallFull, transaction, "123456",null);
         doReturn(responseEntity).when(apiResponseMapper).map(responseObject.getStatus(),
                 responseObject.getData(), responseObject.getValidationErrorData());
         ResponseEntity response = smallFullController.create(smallFull, request);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptorTest.java
@@ -29,6 +29,7 @@ import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountDataEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.impl.SmallFullService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
@@ -49,7 +50,7 @@ public class SmallFullInterceptorTest {
     private Transaction transaction;
 
     @Mock
-    private CompanyAccountEntity companyAccountEntity;
+    private CompanyAccount companyAccount;
 
     @Mock
     private CompanyAccountDataEntity companyAccountDataEntity;
@@ -77,13 +78,13 @@ public class SmallFullInterceptorTest {
 
         Map<String, String> pathVariables = new HashMap<>();
         pathVariables.put("transactionId", "5555");
+        pathVariables.put("companyAccountId", "test");
 
         when(httpServletRequest.getHeader("X-Request-Id")).thenReturn("test");
         doReturn(transaction).when(httpServletRequest).getAttribute(AttributeName.TRANSACTION.getValue());
-        doReturn(companyAccountEntity).when(httpServletRequest).getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
+        doReturn(companyAccount).when(httpServletRequest).getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
         doReturn(pathVariables).when(httpServletRequest).getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
 
-        when(companyAccountEntity.getId()).thenReturn("test");
         when(smallFullService.generateID(anyString())).thenReturn("test");
         when(httpServletRequest.getMethod()).thenReturn("GET");
     }
@@ -94,8 +95,7 @@ public class SmallFullInterceptorTest {
         when(smallFullService.findById(anyString(), anyString())).thenReturn(responseObject);
         when(responseObject.getStatus()).thenReturn(ResponseStatus.FOUND);
         when(responseObject.getData()).thenReturn(smallFull);
-        when(companyAccountEntity.getData()).thenReturn(companyAccountDataEntity);
-        when(companyAccountDataEntity.getLinks()).thenReturn(companyAccountLinks);
+        when(companyAccount.getLinks()).thenReturn(companyAccountLinks);
         when(smallFull.getLinks()).thenReturn(smallFullLinks);
         when(companyAccountLinks.get("small_full_accounts")).thenReturn("linkToSmallFull");
         when(smallFullLinks.get("self")).thenReturn("linkToSmallFull");

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImplTest.java
@@ -23,6 +23,7 @@ import uk.gov.companieshouse.api.accounts.LinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountDataEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.filing.Filing;
+import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.service.FilingService;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.utility.ixbrl.DocumentGeneratorCaller;
@@ -39,7 +40,7 @@ class FilingServiceImplTest {
     private static final String DISABLE_IXBRL_VALIDATION_ENV_VAR = "DISABLE_IXBRL_VALIDATION";
 
     private FilingService filingService;
-    private CompanyAccountEntity companyAccountEntity;
+    private CompanyAccount companyAccount;
     private Transaction transaction;
 
     @Mock
@@ -50,7 +51,7 @@ class FilingServiceImplTest {
     @BeforeEach
     void setUpBeforeEach() {
         transaction = new Transaction();
-        companyAccountEntity = createAccountEntity();
+        companyAccount = createAccount();
 
         filingService = new FilingServiceImpl(documentGeneratorCallerMock, environmentReaderMock);
     }
@@ -63,7 +64,7 @@ class FilingServiceImplTest {
             .getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR);
 
         Filing filing = filingService
-            .generateAccountFiling(transaction, companyAccountEntity);
+            .generateAccountFiling(transaction, companyAccount);
 
         verifyDocumentGeneratorCallerMock();
         verify(environmentReaderMock, times(1))
@@ -75,8 +76,8 @@ class FilingServiceImplTest {
     @Test
     @DisplayName("Tests the filing not generated when small full accounts link is not present")
     void shouldNotGenerateFilingAsSmallFullLinkNotPresentWithinAccountData() {
-        companyAccountEntity.getData().setLinks(new HashMap<>());
-        Filing filing = filingService.generateAccountFiling(transaction, companyAccountEntity);
+        companyAccount.setLinks(new HashMap<>());
+        Filing filing = filingService.generateAccountFiling(transaction, companyAccount);
 
         assertNull(filing);
     }
@@ -86,7 +87,7 @@ class FilingServiceImplTest {
     void shouldNotGenerateFilingAsIxbrlLocationNotSet() {
         doReturn(null).when(documentGeneratorCallerMock).generateIxbrl();
 
-        Filing filing = filingService.generateAccountFiling(transaction, companyAccountEntity);
+        Filing filing = filingService.generateAccountFiling(transaction, companyAccount);
 
         verifyDocumentGeneratorCallerMock();
         assertNull(filing);
@@ -102,19 +103,15 @@ class FilingServiceImplTest {
      * @return
      * @throws ParseException
      */
-    private CompanyAccountEntity createAccountEntity() {
-        CompanyAccountEntity account = new CompanyAccountEntity();
+    private CompanyAccount createAccount() {
+        CompanyAccount companyAccount = new CompanyAccount();
 
-        account.setId(ACCOUNTS_ID);
+        companyAccount.setEtag("etagForTesting");
+        companyAccount.setKind("accounts");
+        companyAccount.setLinks(createAccountEntityLinks());
+        companyAccount.setPeriodEndOn(LocalDate.of(2018, 1, 1));
 
-        CompanyAccountDataEntity accountData = new CompanyAccountDataEntity();
-        accountData.setEtag("etagForTesting");
-        accountData.setKind("accounts");
-        accountData.setLinks(createAccountEntityLinks());
-        accountData.setPeriodEndOn(LocalDate.of(2018, 1, 1));
-        account.setData(accountData);
-
-        return account;
+        return companyAccount;
     }
 
     /**


### PR DESCRIPTION
Refactored the Company account service implementation to return a `ResponseObject<CompanyAccount>` where applicable. 
Fixed the relevant calls to the Company account service.
Fixed the issues where we were using the ID from the `CompanyAccountEntity` model to use the CompanyID passed through in the URL.
Fixed the relevant Unit tests.