### PR TITLE
Change small-full reference to correct previous period

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodService.java
@@ -82,7 +82,7 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
             throw dataException;
         }
 
-        smallFullService.addLink(companyAccountId, LinkType.SMALL_FULL, selfLink, requestId);
+        smallFullService.addLink(companyAccountId, LinkType.PREVIOUS_PERIOD, selfLink, requestId);
 
         return new ResponseObject<>(ResponseStatus.CREATED, previousPeriod);
     }


### PR DESCRIPTION
The previous-period link was being saved under `small_full_accounts` in the links resource in the small full accounts data set. This corrects it to be `previous_period`