### PR TITLE
Altered the LinkType enums to prevent misplaced links

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
@@ -68,7 +68,7 @@ public class CurrentPeriodController {
         if (errors.hasErrors()) {
 
             LOGGER.error(
-                "Current period uk.gov.companieshouse.api.accounts.uk.gov.companieshouse.api.accounts.validation failure");
+                "Current period validation failure");
             logValidationFailureError(getRequestId(request), errors);
 
             return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.HandlerMapping;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
@@ -68,7 +67,8 @@ public class CurrentPeriodController {
         currentPeriodValidator.validateCurrentPeriod(currentPeriod, errors);
         if (errors.hasErrors()) {
 
-            LOGGER.error("Current period validation failure");
+            LOGGER.error(
+                "Current period uk.gov.companieshouse.api.accounts.uk.gov.companieshouse.api.accounts.validation failure");
             logValidationFailureError(getRequestId(request), errors);
 
             return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/CompanyAccountInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/CompanyAccountInterceptor.java
@@ -44,7 +44,7 @@ public class CompanyAccountInterceptor extends HandlerInterceptorAdapter {
      * This method extracts the 'company_account' parameter passed via the URI then validates it.
      * Validation is carried out via a database lookup for a CompanyAccountEntity Object then
      * matching the retrieved Entities 'self' link to the session stored Transactions
-     * 'company_account' link. Providing this uk.gov.companieshouse.api.accounts.uk.gov.companieshouse.api.accounts.validation
+     * 'company_account' link. Providing this validation
      * passes it assigns the CompanyAccountEntity to the session.
      *
      * @param request - current HTTP request

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/CompanyAccountInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/CompanyAccountInterceptor.java
@@ -44,8 +44,8 @@ public class CompanyAccountInterceptor extends HandlerInterceptorAdapter {
      * This method extracts the 'company_account' parameter passed via the URI then validates it.
      * Validation is carried out via a database lookup for a CompanyAccountEntity Object then
      * matching the retrieved Entities 'self' link to the session stored Transactions
-     * 'company_account' link. Providing this validation
-     * passes it assigns the CompanyAccountEntity to the session.
+     * 'company_account' link. Providing this validation passes it assigns the CompanyAccountEntity
+     * to the session.
      *
      * @param request - current HTTP request
      * @param response - current HTTP response

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/CompanyAccountInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/CompanyAccountInterceptor.java
@@ -12,8 +12,9 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.Kind;
-import uk.gov.companieshouse.api.accounts.LinkType;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
+import uk.gov.companieshouse.api.accounts.links.TransactionLinkType;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.service.CompanyAccountService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
@@ -43,8 +44,8 @@ public class CompanyAccountInterceptor extends HandlerInterceptorAdapter {
      * This method extracts the 'company_account' parameter passed via the URI then validates it.
      * Validation is carried out via a database lookup for a CompanyAccountEntity Object then
      * matching the retrieved Entities 'self' link to the session stored Transactions
-     * 'company_account' link. Providing this validation passes it assigns the CompanyAccountEntity
-     * to the session.
+     * 'company_account' link. Providing this uk.gov.companieshouse.api.accounts.uk.gov.companieshouse.api.accounts.validation
+     * passes it assigns the CompanyAccountEntity to the session.
      *
      * @param request - current HTTP request
      * @param response - current HTTP response
@@ -107,7 +108,7 @@ public class CompanyAccountInterceptor extends HandlerInterceptorAdapter {
 
         CompanyAccount companyAccount = responseObject.getData();
 
-        String accountsSelf = companyAccount.getLinks().get(LinkType.SELF.getLink());
+        String accountsSelf = companyAccount.getLinks().get(BasicLinkType.SELF.getLink());
         Map<String, Resources> resourcesList = transaction.getResources();
         if (!isLinkInResourceMap(resourcesList, accountsSelf)) {
             LOGGER.debugRequest(request,
@@ -125,7 +126,7 @@ public class CompanyAccountInterceptor extends HandlerInterceptorAdapter {
         for (Entry<String, Resources> entry : resourcesList.entrySet()) {
             Resources resources = entry.getValue();
             if (resources.getKind().equals(Kind.COMPANY_ACCOUNTS.getValue()) && resources.getLinks()
-                .get(LinkType.RESOURCE.getLink()).equals(accountsSelf)) {
+                .get(TransactionLinkType.RESOURCE.getLink()).equals(accountsSelf)) {
                 return true;
             }
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptor.java
@@ -42,8 +42,7 @@ public class SmallFullInterceptor extends HandlerInterceptorAdapter {
      * This class validates a Small-full account exists for the given CompanyAccount. Validation is
      * carried out via a database lookup for the SmallFullEntity Object then matching the retrieved
      * Entities 'self' link to the session stored CompanyAccountEntities 'small_full_accounts' link.
-     * Providing this uk.gov.companieshouse.api.accounts.uk.gov.companieshouse.api.accounts.validation
-     * passes it assigns the SmallFullEntity to the session.
+     * Providing this validation passes it assigns the SmallFullEntity to the session.
      *
      * @param request - current HTTP request
      * @param response - current HTTP response

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptor.java
@@ -11,8 +11,9 @@ import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
-import uk.gov.companieshouse.api.accounts.LinkType;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.links.CompanyAccountLinkType;
+import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.impl.SmallFullService;
@@ -41,7 +42,8 @@ public class SmallFullInterceptor extends HandlerInterceptorAdapter {
      * This class validates a Small-full account exists for the given CompanyAccount. Validation is
      * carried out via a database lookup for the SmallFullEntity Object then matching the retrieved
      * Entities 'self' link to the session stored CompanyAccountEntities 'small_full_accounts' link.
-     * Providing this validation passes it assigns the SmallFullEntity to the session.
+     * Providing this uk.gov.companieshouse.api.accounts.uk.gov.companieshouse.api.accounts.validation
+     * passes it assigns the SmallFullEntity to the session.
      *
      * @param request - current HTTP request
      * @param response - current HTTP response
@@ -117,8 +119,8 @@ public class SmallFullInterceptor extends HandlerInterceptorAdapter {
         SmallFull smallFull = responseObject.getData();
 
         String companyAccountLink = companyAccount.getLinks()
-            .get(LinkType.SMALL_FULL.getLink());
-        String smallFullSelf = smallFull.getLinks().get(LinkType.SELF.getLink());
+            .get(CompanyAccountLinkType.SMALL_FULL.getLink());
+        String smallFullSelf = smallFull.getLinks().get(SmallFullLinkType.SELF.getLink());
         if (!companyAccountLink.equals(smallFullSelf)) {
             LOGGER.debugRequest(request,
                 "SmallFullInterceptor error: The SmallFull self link does not exist in the CompanyAccounts links",

--- a/src/main/java/uk/gov/companieshouse/api/accounts/links/BasicLinkType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/links/BasicLinkType.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.api.accounts.links;
+
+public enum BasicLinkType implements LinkType {
+
+    SELF("self");
+
+    private String link;
+
+    BasicLinkType(String link) {
+        this.link = link;
+    }
+
+    public String getLink() {
+        return link;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/links/CompanyAccountLinkType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/links/CompanyAccountLinkType.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.api.accounts.links;
+
+public enum CompanyAccountLinkType implements LinkType {
+
+    SELF("self"),
+    SMALL_FULL("small_full_accounts");
+
+    private String link;
+
+    CompanyAccountLinkType(String link) {
+        this.link = link;
+    }
+
+    public String getLink() {
+        return link;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/links/LinkType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/links/LinkType.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.api.accounts.links;
+
+public interface LinkType {
+
+    String getLink();
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/links/SmallFullLinkType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/links/SmallFullLinkType.java
@@ -1,10 +1,8 @@
-package uk.gov.companieshouse.api.accounts;
+package uk.gov.companieshouse.api.accounts.links;
 
-public enum LinkType {
+public enum SmallFullLinkType implements LinkType {
+
     SELF("self"),
-    RESOURCE("resource"),
-    COMPANY_ACCOUNT("company_account"),
-    SMALL_FULL("small_full_accounts"),
     ACCOUNTING_POLICY_NOTE("accounting_policy_note"),
     APPROVAL("approval"),
     CREDITORS_AFTER_MORE_THAN_ONE_YEAR_NOTE("creditors_after_more_than_one_year_note"),
@@ -19,12 +17,11 @@ public enum LinkType {
 
     private String link;
 
-    LinkType(String link) {
+    SmallFullLinkType(String link) {
         this.link = link;
     }
 
     public String getLink() {
         return link;
     }
-
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/links/TransactionLinkType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/links/TransactionLinkType.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.api.accounts.links;
+
+public enum TransactionLinkType implements LinkType {
+
+    SELF("self"),
+    PAYMENTS("payments"),
+    RESOURCE("resource");
+
+    private String link;
+
+    TransactionLinkType(String link) {
+        this.link = link;
+    }
+
+    public String getLink() {
+        return link;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Error.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Error.java
@@ -3,14 +3,14 @@ package uk.gov.companieshouse.api.accounts.model.validation;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.springframework.data.mongodb.core.mapping.Field;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 /**
- * Represents a validation error
+ * Represents a uk.gov.companieshouse.api.accounts.validation error
  */
 @JsonInclude(Include.NON_NULL)
 public class Error {
@@ -38,10 +38,6 @@ public class Error {
     /**
      * Constructor
      *
-     * @param error
-     * @param location
-     * @param locationType
-     * @param type
      * @throws IllegalArgumentException on null or empty arguments
      */
     public Error(String error, String location, String locationType, String type) {
@@ -58,11 +54,31 @@ public class Error {
         this.type = type;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Error error1 = (Error) o;
+        return Objects.equals(getError(), error1.getError()) &&
+            Objects.equals(getErrorValues(), error1.getErrorValues()) &&
+            Objects.equals(getLocation(), error1.getLocation()) &&
+            Objects.equals(getLocationType(), error1.getLocationType()) &&
+            Objects.equals(getType(), error1.getType());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects
+            .hash(getError(), getErrorValues(), getLocation(), getLocationType(), getType());
+    }
+
     /**
      * Add an error value
      *
-     * @param argument
-     * @param value
      * @throws IllegalArgumentException on null or empty arguments
      */
     public void addErrorValue(String argument, String value) {
@@ -83,7 +99,7 @@ public class Error {
     }
 
     public Map<String, String> getErrorValues() {
-        if(errorValues != null) {
+        if (errorValues != null) {
             return Collections.unmodifiableMap(errorValues);
         }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Error.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Error.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 /**
- * Represents a uk.gov.companieshouse.api.accounts.validation error
+ * Represents a validation error
  */
 @JsonInclude(Include.NON_NULL)
 public class Error {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Errors.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Errors.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 /**
- * Used to encapsulate uk.gov.companieshouse.api.accounts.validation errors
+ * Used to encapsulate validation errors
  */
 public class Errors {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Errors.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Errors.java
@@ -1,14 +1,13 @@
 package uk.gov.companieshouse.api.accounts.model.validation;
 
-    import com.fasterxml.jackson.annotation.JsonIgnore;
-    import com.fasterxml.jackson.annotation.JsonProperty;
-    import org.springframework.data.mongodb.core.mapping.Field;
-
-    import java.util.HashSet;
-    import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashSet;
+import java.util.Set;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 /**
- * Used to encapsulate validation errors
+ * Used to encapsulate uk.gov.companieshouse.api.accounts.validation errors
  */
 public class Errors {
 
@@ -19,7 +18,6 @@ public class Errors {
     /**
      * Add the given {@link Error}
      *
-     * @param error
      * @return True if added, false otherwise
      * @throws IllegalArgumentException on null errors
      */
@@ -43,9 +41,7 @@ public class Errors {
     /**
      * Determine whether the given {@link Error} is contained
      *
-     * @param error
      * @return True or false
-     * @throws IllegalArgumentException
      */
     public boolean containsError(Error error) {
         if (error == null) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/CompanyAccountService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/CompanyAccountService.java
@@ -1,8 +1,8 @@
 package uk.gov.companieshouse.api.accounts.service;
 
-import uk.gov.companieshouse.api.accounts.LinkType;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.exception.PatchException;
+import uk.gov.companieshouse.api.accounts.links.CompanyAccountLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountDataEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
@@ -21,6 +21,6 @@ public interface CompanyAccountService {
     ResponseObject<CompanyAccount> findById(String id, String requestId)
         throws DataException;
 
-    void addLink(String id, LinkType linkType, String link);
+    void addLink(String id, CompanyAccountLinkType linkType, String link);
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/ParentService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/ParentService.java
@@ -1,12 +1,13 @@
 package uk.gov.companieshouse.api.accounts.service;
 
-import uk.gov.companieshouse.api.accounts.LinkType;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.links.LinkType;
 import uk.gov.companieshouse.api.accounts.model.rest.RestObject;
 
-public interface ParentService<T extends RestObject> extends ResourceService<T> {
+public interface ParentService<T extends RestObject, U extends LinkType> extends
+    ResourceService<T> {
 
-    void addLink(String id, LinkType linkType, String link, String requestId)
+    void addLink(String id, U linkType, String link, String requestId)
         throws DataException;
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
@@ -15,6 +15,7 @@ import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.exception.PatchException;
 import uk.gov.companieshouse.api.accounts.links.CompanyAccountLinkType;
+import uk.gov.companieshouse.api.accounts.links.TransactionLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountDataEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
@@ -112,7 +113,7 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
     }
 
     private String getTransactionSelfLink(Transaction transaction) {
-        return transaction.getLinks().get(CompanyAccountLinkType.SELF.getLink());
+        return transaction.getLinks().get(TransactionLinkType.SELF.getLink());
     }
 
     private void addEtag(CompanyAccount rest) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
 import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.Kind;
-import uk.gov.companieshouse.api.accounts.LinkType;
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.exception.PatchException;
+import uk.gov.companieshouse.api.accounts.links.CompanyAccountLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountDataEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
@@ -89,7 +89,7 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
     }
 
     @Override
-    public void addLink(String id, LinkType linkType, String link) {
+    public void addLink(String id, CompanyAccountLinkType linkType, String link) {
         CompanyAccountEntity companyAccountEntity = companyAccountRepository.findById(id)
             .orElseThrow(() -> new MongoException(
                 "Failed to add link to Company account entity"));
@@ -102,7 +102,7 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
 
     private void addLinks(CompanyAccount companyAccount, String companyAccountLink) {
         Map<String, String> map = new HashMap<>();
-        map.put(LinkType.SELF.getLink(), companyAccountLink);
+        map.put(CompanyAccountLinkType.SELF.getLink(), companyAccountLink);
         companyAccount.setLinks(map);
     }
 
@@ -112,7 +112,7 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
     }
 
     private String getTransactionSelfLink(Transaction transaction) {
-        return transaction.getLinks().get(LinkType.SELF.getLink());
+        return transaction.getLinks().get(CompanyAccountLinkType.SELF.getLink());
     }
 
     private void addEtag(CompanyAccount rest) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodService.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
 import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
+import uk.gov.companieshouse.api.accounts.links.TransactionLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.CurrentPeriodEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.repository.CurrentPeriodRepository;
@@ -117,7 +118,7 @@ public class CurrentPeriodService implements
     }
 
     public String createSelfLink(Transaction transaction, String companyAccountId) {
-        return transaction.getLinks().get(BasicLinkType.SELF.getLink()) + "/"
+        return transaction.getLinks().get(TransactionLinkType.SELF.getLink()) + "/"
             + ResourceName.COMPANY_ACCOUNT.getName() + "/"
             + companyAccountId + "/" + ResourceName.SMALL_FULL.getName() + "/"
             + ResourceName.CURRENT_PERIOD.getName();

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
@@ -101,8 +101,8 @@ public class FilingServiceImpl implements FilingService {
     }
 
     /**
-     * Validates the ixbrl against TNEP. This validation
-     * is driven by the environment and it can be disable.
+     * Validates the ixbrl against TNEP. This validation is driven by the environment and it can be
+     * disable.
      */
     private boolean isValidIxbrl() {
         //TODO: this will be set to true when TNEP Validation plugged in.(STORY SFA-574)

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
@@ -101,15 +101,15 @@ public class FilingServiceImpl implements FilingService {
     }
 
     /**
-     * Validates the ixbrl against TNEP. This validation is driven by the environment and it can be
-     * disable.
+     * Validates the ixbrl against TNEP. This uk.gov.companieshouse.api.accounts.uk.gov.companieshouse.api.accounts.validation
+     * is driven by the environment and it can be disable.
      */
     private boolean isValidIxbrl() {
         //TODO: this will be set to true when TNEP Validation plugged in.(STORY SFA-574)
         boolean isIxbrlValid = false;
         if (!environmentReader.getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR)) {
-            //TODO Add TNEP validation to be added when functionality is implemented . (STORY SFA-574)
-            //isIxbrlValid will be set to false if fails the tnep validation.
+            //TODO Add TNEP uk.gov.companieshouse.api.accounts.uk.gov.companieshouse.api.accounts.validation to be added when functionality is implemented . (STORY SFA-574)
+            //isIxbrlValid will be set to false if fails the tnep uk.gov.companieshouse.api.accounts.uk.gov.companieshouse.api.accounts.validation.
             isIxbrlValid = true;
         }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
@@ -101,15 +101,15 @@ public class FilingServiceImpl implements FilingService {
     }
 
     /**
-     * Validates the ixbrl against TNEP. This uk.gov.companieshouse.api.accounts.uk.gov.companieshouse.api.accounts.validation
+     * Validates the ixbrl against TNEP. This validation
      * is driven by the environment and it can be disable.
      */
     private boolean isValidIxbrl() {
         //TODO: this will be set to true when TNEP Validation plugged in.(STORY SFA-574)
         boolean isIxbrlValid = false;
         if (!environmentReader.getMandatoryBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR)) {
-            //TODO Add TNEP uk.gov.companieshouse.api.accounts.uk.gov.companieshouse.api.accounts.validation to be added when functionality is implemented . (STORY SFA-574)
-            //isIxbrlValid will be set to false if fails the tnep uk.gov.companieshouse.api.accounts.uk.gov.companieshouse.api.accounts.validation.
+            //TODO Add TNEP validation to be added when functionality is implemented . (STORY SFA-574)
+            //isIxbrlValid will be set to false if fails the tnep validation.
             isIxbrlValid = true;
         }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodService.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
 import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
+import uk.gov.companieshouse.api.accounts.links.TransactionLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.PreviousPeriodEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod;
 import uk.gov.companieshouse.api.accounts.repository.PreviousPeriodRespository;
@@ -108,7 +109,7 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
     private String buildSelfLink(Transaction transaction, String companyAccountId) {
 
         StringBuilder builder = new StringBuilder();
-        builder.append(transaction.getLinks().get(BasicLinkType.SELF.getLink())).append("/")
+        builder.append(transaction.getLinks().get(TransactionLinkType.SELF.getLink())).append("/")
             .append(ResourceName.COMPANY_ACCOUNT.getName()).append("/")
             .append(companyAccountId).append("/")
             .append(ResourceName.SMALL_FULL.getName()).append("/")

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodService.java
@@ -2,14 +2,17 @@ package uk.gov.companieshouse.api.accounts.service.impl;
 
 import com.mongodb.DuplicateKeyException;
 import com.mongodb.MongoException;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
 import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.Kind;
-import uk.gov.companieshouse.api.accounts.LinkType;
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
+import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.PreviousPeriodEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod;
 import uk.gov.companieshouse.api.accounts.repository.PreviousPeriodRespository;
@@ -21,9 +24,6 @@ import uk.gov.companieshouse.api.accounts.transformer.PreviousPeriodTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Service
 public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
@@ -82,7 +82,8 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
             throw dataException;
         }
 
-        smallFullService.addLink(companyAccountId, LinkType.SMALL_FULL, selfLink, requestId);
+        smallFullService
+            .addLink(companyAccountId, SmallFullLinkType.PREVIOUS_PERIOD, selfLink, requestId);
 
         return new ResponseObject<>(ResponseStatus.CREATED, previousPeriod);
     }
@@ -105,9 +106,9 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
     }
 
     private String buildSelfLink(Transaction transaction, String companyAccountId) {
-        
+
         StringBuilder builder = new StringBuilder();
-        builder.append(transaction.getLinks().get(LinkType.SELF.getLink())).append("/")
+        builder.append(transaction.getLinks().get(BasicLinkType.SELF.getLink())).append("/")
             .append(ResourceName.COMPANY_ACCOUNT.getName()).append("/")
             .append(companyAccountId).append("/")
             .append(ResourceName.SMALL_FULL.getName()).append("/")
@@ -118,7 +119,7 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
 
     private void initLinks(PreviousPeriod previousPeriod, String link) {
         Map<String, String> map = new HashMap<>();
-        map.put(LinkType.SELF.getLink(), link);
+        map.put(BasicLinkType.SELF.getLink(), link);
         previousPeriod.setLinks(map);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullService.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.links.CompanyAccountLinkType;
 import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
+import uk.gov.companieshouse.api.accounts.links.TransactionLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.SmallFullEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.repository.SmallFullRepository;
@@ -139,7 +140,7 @@ public class SmallFullService implements
     }
 
     public String createSelfLink(Transaction transaction, String companyAccountId) {
-        return transaction.getLinks().get(SmallFullLinkType.SELF.getLink()) + "/"
+        return transaction.getLinks().get(TransactionLinkType.SELF.getLink()) + "/"
             + ResourceName.COMPANY_ACCOUNT.getName() + "/"
             + companyAccountId + "/" + ResourceName.SMALL_FULL.getName();
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullService.java
@@ -9,14 +9,15 @@ import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
 import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.Kind;
-import uk.gov.companieshouse.api.accounts.LinkType;
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.links.CompanyAccountLinkType;
+import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.SmallFullEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.repository.SmallFullRepository;
-import uk.gov.companieshouse.api.accounts.service.ParentService;
 import uk.gov.companieshouse.api.accounts.service.CompanyAccountService;
+import uk.gov.companieshouse.api.accounts.service.ParentService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
@@ -27,10 +28,10 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Service
 public class SmallFullService implements
-    ParentService<SmallFull> {
+    ParentService<SmallFull, SmallFullLinkType> {
 
     private static final Logger LOGGER = LoggerFactory
-            .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
+        .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
 
     private SmallFullRepository smallFullRepository;
 
@@ -42,9 +43,9 @@ public class SmallFullService implements
 
     @Autowired
     public SmallFullService(SmallFullRepository smallFullRepository,
-            SmallFullTransformer smallFullTransformer,
-            CompanyAccountService companyAccountService,
-            KeyIdGenerator keyIdGenerator) {
+        SmallFullTransformer smallFullTransformer,
+        CompanyAccountService companyAccountService,
+        KeyIdGenerator keyIdGenerator) {
         this.smallFullRepository = smallFullRepository;
         this.smallFullTransformer = smallFullTransformer;
         this.companyAccountService = companyAccountService;
@@ -53,8 +54,8 @@ public class SmallFullService implements
 
     @Override
     public ResponseObject<SmallFull> create(SmallFull smallFull, Transaction transaction,
-            String companyAccountId, String requestId)
-            throws DataException {
+        String companyAccountId, String requestId)
+        throws DataException {
         String selfLink = createSelfLink(transaction, companyAccountId);
         initLinks(smallFull, selfLink);
         smallFull.setEtag(GenerateEtagUtil.generateEtag());
@@ -76,12 +77,13 @@ public class SmallFullService implements
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR, null);
         } catch (MongoException me) {
             DataException dataException = new DataException(
-                    "Failed to insert " + ResourceName.SMALL_FULL.getName(), me);
+                "Failed to insert " + ResourceName.SMALL_FULL.getName(), me);
             LOGGER.errorContext(requestId, dataException, debugMap);
             throw dataException;
         }
 
-        companyAccountService.addLink(companyAccountId, LinkType.SMALL_FULL, selfLink);
+        companyAccountService
+            .addLink(companyAccountId, CompanyAccountLinkType.SMALL_FULL, selfLink);
 
         return new ResponseObject<>(ResponseStatus.CREATED, smallFull);
     }
@@ -108,12 +110,12 @@ public class SmallFullService implements
     }
 
     @Override
-    public void addLink(String id, LinkType linkType, String link, String requestId)
-            throws DataException {
+    public void addLink(String id, SmallFullLinkType linkType, String link, String requestId)
+        throws DataException {
         String smallFullId = generateID(id);
         SmallFullEntity smallFullEntity = smallFullRepository.findById(smallFullId)
-                .orElseThrow(() -> new DataException(
-                        "Failed to add get Small full entity to add link"));
+            .orElseThrow(() -> new DataException(
+                "Failed to add get Small full entity to add link"));
         smallFullEntity.getData().getLinks().put(linkType.getLink(), link);
 
         try {
@@ -137,14 +139,14 @@ public class SmallFullService implements
     }
 
     public String createSelfLink(Transaction transaction, String companyAccountId) {
-        return transaction.getLinks().get(LinkType.SELF.getLink()) + "/"
-                + ResourceName.COMPANY_ACCOUNT.getName() + "/"
-                + companyAccountId + "/" + ResourceName.SMALL_FULL.getName();
+        return transaction.getLinks().get(SmallFullLinkType.SELF.getLink()) + "/"
+            + ResourceName.COMPANY_ACCOUNT.getName() + "/"
+            + companyAccountId + "/" + ResourceName.SMALL_FULL.getName();
     }
 
     private void initLinks(SmallFull smallFull, String link) {
         Map<String, String> map = new HashMap<>();
-        map.put(LinkType.SELF.getLink(), link);
+        map.put(SmallFullLinkType.SELF.getLink(), link);
         smallFull.setLinks(map);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/ErrorType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/ErrorType.java
@@ -6,7 +6,7 @@ package uk.gov.companieshouse.api.accounts.validation;
 public enum ErrorType {
 
     SERVICE("ch:service"),
-    VALIDATION("ch:validation");
+    VALIDATION("ch:uk.gov.companieshouse.api.accounts.validation");
 
     private String type;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/ErrorType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/ErrorType.java
@@ -6,7 +6,7 @@ package uk.gov.companieshouse.api.accounts.validation;
 public enum ErrorType {
 
     SERVICE("ch:service"),
-    VALIDATION("ch:uk.gov.companieshouse.api.accounts.validation");
+    VALIDATION("ch:validation");
 
     private String type;
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
@@ -25,7 +25,8 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.api.accounts.LinkType;
+import uk.gov.companieshouse.api.accounts.links.CompanyAccountLinkType;
+import uk.gov.companieshouse.api.accounts.links.LinkType;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.exception.PatchException;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
@@ -142,7 +143,7 @@ public class CompanyAccountServiceImplTest {
      */
     private Map<String, String> createLinksMap() {
         Map<String, String> links = new HashMap<>();
-        links.put(LinkType.SELF.getLink(), "selfLinkTest");
+        links.put(CompanyAccountLinkType.SELF.getLink(), "selfLinkTest");
         return links;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImplTest.java
@@ -11,6 +11,7 @@ import java.text.ParseException;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
+import javax.persistence.Basic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,9 +20,10 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.api.accounts.LinkType;
-import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountDataEntity;
-import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
+import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
+import uk.gov.companieshouse.api.accounts.links.CompanyAccountLinkType;
+import uk.gov.companieshouse.api.accounts.links.LinkType;
+import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
 import uk.gov.companieshouse.api.accounts.model.filing.Filing;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.service.FilingService;
@@ -122,10 +124,10 @@ class FilingServiceImplTest {
     private Map<String, String> createAccountEntityLinks() {
         Map<String, String> dataLinks = new HashMap<>();
 
-        dataLinks.put(LinkType.SELF.getLink(),
+        dataLinks.put(BasicLinkType.SELF.getLink(),
             String.format("/transactions/%s/company-accounts/%s", TRANSACTION_ID, ACCOUNTS_ID));
 
-        dataLinks.put(LinkType.SMALL_FULL.getLink(),
+        dataLinks.put(CompanyAccountLinkType.SMALL_FULL.getLink(),
             String.format("/transactions/%s/company-accounts/%s/small-full/%s",
                 TRANSACTION_ID,
                 ACCOUNTS_ID,

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
@@ -1,6 +1,5 @@
-package validation;
+package uk.gov.companieshouse.api.accounts.validation;
 
-import org.junit.Before;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.api.accounts.model.rest.BalanceSheet;
@@ -8,10 +7,6 @@ import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
 import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
-import uk.gov.companieshouse.api.accounts.validation.CurrentPeriodValidator;
-import uk.gov.companieshouse.api.accounts.validation.ErrorMessageKeys;
-import uk.gov.companieshouse.api.accounts.validation.ErrorType;
-import uk.gov.companieshouse.api.accounts.validation.LocationType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,7 +24,7 @@ public class CurrentPeriodValidatorTest {
     Errors errors = new Errors();
 
     @Test
-    @DisplayName("Test total fixed assets validation")
+    @DisplayName("Test total fixed assets uk.gov.companieshouse.api.accounts.validation")
     public void validateTotalFixedAssets() {
 
         FixedAssets fixedAssets = new FixedAssets();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
@@ -24,7 +24,7 @@ public class CurrentPeriodValidatorTest {
     Errors errors = new Errors();
 
     @Test
-    @DisplayName("Test total fixed assets uk.gov.companieshouse.api.accounts.validation")
+    @DisplayName("Test total fixed assets validation")
     public void validateTotalFixedAssets() {
 
         FixedAssets fixedAssets = new FixedAssets();


### PR DESCRIPTION
_This change should prevent links of the wrong link type being placed in the wrong resource._

Amended the `LinkType` enum to be an interface then added the following classes:
- `BasicLinkType`
- `CompanyAccountLinkType`
- `SmallFullLinkType`
- `TransactionLinkType`

Fixed the relevant unit tests.

Refactored the test `validation` package to bring it into the main body of the test packages to mirror the placement of the `validation` package in the main body of the application.

