### PR TITLE
Removed strictness annotation from JUnit tests

### DIFF
--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
@@ -7,9 +7,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
-import java.security.NoSuchAlgorithmException;
-import java.util.HashMap;
-import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,17 +17,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.servlet.HandlerMapping;
-import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
-import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
-import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.impl.CurrentPeriodService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
@@ -39,7 +30,6 @@ import uk.gov.companieshouse.api.accounts.utility.ApiResponseMapper;
 import uk.gov.companieshouse.api.accounts.validation.CurrentPeriodValidator;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 @TestInstance(Lifecycle.PER_CLASS)
 public class CurrentPeriodControllerTest {
 
@@ -50,14 +40,8 @@ public class CurrentPeriodControllerTest {
     private Transaction transaction;
 
     @Mock
-    private SmallFull smallFull;
-
-    @Mock
-    private CompanyAccountEntity companyAccountEntity;
-
-    @Mock
     private CurrentPeriod currentPeriod;
-    
+
     @Mock
     private CurrentPeriodValidator currentPeriodValidator;
 
@@ -68,46 +52,33 @@ public class CurrentPeriodControllerTest {
     private CurrentPeriodService currentPeriodService;
 
     @Mock
-    private Map<String, String> links;
-
-    @Mock
     private ApiResponseMapper apiResponseMapper;
 
     @InjectMocks
     private CurrentPeriodController currentPeriodController;
 
     @BeforeEach
-    public void setUp() throws NoSuchAlgorithmException, DataException {
+    public void setUp() throws DataException {
         when(request.getAttribute("transaction")).thenReturn(transaction);
         when(request.getHeader("X-Request-Id")).thenReturn("test");
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED,
-                currentPeriod);
-        doReturn(responseObject).when(currentPeriodService)
-                .create(any(CurrentPeriod.class), any(Transaction.class), anyString(), anyString());
-        ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.CREATED)
-                .body(responseObject.getData());
-        when(apiResponseMapper.map(responseObject.getStatus(),
-                responseObject.getData(), responseObject.getValidationErrorData()))
-                .thenReturn(responseEntity);
-        Map<String, String> pathVariables = new HashMap<>();
-        pathVariables.put("companyAccountId", "123456");
-        doReturn(pathVariables).when(request)
-            .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
-        doReturn(transaction).when(request)
-                .getAttribute(AttributeName.TRANSACTION.getValue());
-        doReturn(smallFull).when(request).getAttribute(AttributeName.SMALLFULL.getValue());
-        doReturn(responseObject).when(currentPeriodService).findById("create", "test");
-        doReturn(new ResponseObject(ResponseStatus.FOUND,
-                currentPeriod)).when(currentPeriodService).findById("find", "test");
-        doReturn("123456").when(transaction).getCompanyNumber();
-        doReturn(links).when(smallFull).getLinks();
-        doReturn("7890").when(links).get("self");
     }
 
     @Test
     @DisplayName("Tests the successful creation of a currentPeriod resource")
-    public void canCreateCurrentPeriod() throws NoSuchAlgorithmException {
-        ResponseEntity response = currentPeriodController.create(currentPeriod, bindingResult, "123456", request);
+    public void canCreateCurrentPeriod() throws DataException {
+        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED,
+            currentPeriod);
+        ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.CREATED)
+            .body(responseObject.getData());
+        when(apiResponseMapper.map(responseObject.getStatus(),
+            responseObject.getData(), responseObject.getValidationErrorData()))
+            .thenReturn(responseEntity);
+        doReturn(responseObject).when(currentPeriodService)
+            .create(any(CurrentPeriod.class), any(Transaction.class), anyString(), anyString());
+
+        ResponseEntity response = currentPeriodController
+            .create(currentPeriod, bindingResult, "123456", request);
+
         assertNotNull(response);
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
         assertEquals(currentPeriod, response.getBody());
@@ -115,12 +86,14 @@ public class CurrentPeriodControllerTest {
 
     @Test
     @DisplayName("Test the retreval of a current period resource")
-    public void canRetrieveCurrentPeriod() throws NoSuchAlgorithmException {
-
+    public void canRetrieveCurrentPeriod() throws DataException {
         doReturn("find").when(currentPeriodService).generateID("123456");
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.OK).body(currentPeriod);
+        doReturn(new ResponseObject(ResponseStatus.FOUND,
+            currentPeriod)).when(currentPeriodService).findById("find", "test");
         when(apiResponseMapper.mapGetResponse(currentPeriod,
-                request)).thenReturn(responseEntity);
+            request)).thenReturn(responseEntity);
+
         ResponseEntity response = currentPeriodController.get("123456", request);
 
         assertNotNull(response);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodControllerTest.java
@@ -1,5 +1,15 @@
 package uk.gov.companieshouse.api.accounts.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -8,41 +18,24 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod;
-import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.impl.PreviousPeriodService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.utility.ApiResponseMapper;
 
-import javax.servlet.http.HttpServletRequest;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PreviousPeriodControllerTest {
 
     public static final String X_REQUEST_ID = "X-Request-Id";
-    public static final String TRANSACTION_STRING = "transaction";
     public static final String TEST = "test";
-    public static final String CREATE = "create";
-    public static final String FIND = "find";
-    public static final String SELF = "self";
 
     @Mock
     private HttpServletRequest request;
@@ -62,22 +55,14 @@ public class PreviousPeriodControllerTest {
     @Mock
     private ApiResponseMapper apiResponseMapper;
 
-    @Mock
-    private SmallFull smallFull;
-
-    @Mock
-    private Map<String, String> links;
-
     @InjectMocks
     private PreviousPeriodController previousPeriodController;
 
     @BeforeEach
     public void setUp() {
-        when(request.getAttribute(TRANSACTION_STRING)).thenReturn(transaction);
         when(request.getHeader(X_REQUEST_ID)).thenReturn(TEST);
         doReturn(transaction).when(request)
             .getAttribute(AttributeName.TRANSACTION.getValue());
-        doReturn(smallFull).when(request).getAttribute(AttributeName.SMALLFULL.getValue());
         doReturn(companyAccountEntity).when(request)
             .getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
         doReturn("12345").when(companyAccountEntity).getId();
@@ -97,12 +82,7 @@ public class PreviousPeriodControllerTest {
         when(apiResponseMapper.map(responseObject.getStatus(),
             responseObject.getData(), responseObject.getValidationErrorData()))
             .thenReturn(responseEntity);
-        doReturn(responseObject).when(previousPeriodService).findById(CREATE, TEST);
-        doReturn(new ResponseObject(ResponseStatus.FOUND,
-            previousPeriod)).when(previousPeriodService).findById(FIND, TEST);
-        doReturn("123456").when(transaction).getCompanyNumber();
-        doReturn(links).when(smallFull).getLinks();
-        doReturn("7890").when(links).get(SELF);
+
         ResponseEntity response = previousPeriodController
             .create(previousPeriod, request);
 


### PR DESCRIPTION
The `@MockitoSettings(strictness = Strictness.LENIENT)` annotation was allowing us to have mocks in our unit tests which were not used I have removed the annotation and then amended the tests to comply with standards.