### PR TITLE
Gets account id from request param rather than request attribute

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodController.java
@@ -3,13 +3,13 @@ package uk.gov.companieshouse.api.accounts.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
-import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod;
 import uk.gov.companieshouse.api.accounts.service.impl.PreviousPeriodService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
@@ -38,23 +38,18 @@ public class PreviousPeriodController {
     private ApiResponseMapper apiResponseMapper;
 
     @PostMapping
-    public ResponseEntity create(@Valid @RequestBody PreviousPeriod previousPeriod,
-        HttpServletRequest request) {
+    public ResponseEntity create(@RequestBody @Valid PreviousPeriod previousPeriod,
+            @PathVariable("companyAccountId") String companyAccountId, HttpServletRequest request) {
 
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        CompanyAccountEntity companyAccountEntity = (CompanyAccountEntity) request
-            .getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
-
-        String companyAccountId = companyAccountEntity.getId();
         String requestId = request.getHeader("X-Request-Id");
 
         ResponseEntity responseEntity;
         try {
             ResponseObject<PreviousPeriod> responseObject = previousPeriodService.create(previousPeriod, transaction, companyAccountId, requestId);
-            responseEntity = apiResponseMapper.map(responseObject.getStatus(), responseObject.getData(),
-                    responseObject.getValidationErrorData());
+            responseEntity = apiResponseMapper.map(responseObject.getStatus(), responseObject.getData(), responseObject.getValidationErrorData());
         } catch (DataException ex) {
             final Map<String, Object> debugMap = new HashMap<>();
             debugMap.put("transaction_id", transaction.getId());

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodControllerTest.java
@@ -73,8 +73,7 @@ public class PreviousPeriodControllerTest {
     @DisplayName("Tests the successful creation of a previous period resource")
     void canCreatePreviousPeriod() throws DataException {
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED,
-            previousPeriod);
+        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED, previousPeriod);
         doReturn(responseObject).when(previousPeriodService)
             .create(any(PreviousPeriod.class), any(Transaction.class), anyString(), anyString());
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.CREATED)
@@ -83,8 +82,7 @@ public class PreviousPeriodControllerTest {
             responseObject.getData(), responseObject.getValidationErrorData()))
             .thenReturn(responseEntity);
 
-        ResponseEntity response = previousPeriodController
-            .create(previousPeriod, request);
+        ResponseEntity response = previousPeriodController.create(previousPeriod, "", request);
 
         verify(apiResponseMapper, times(1)).map(any(), any(), any());
 
@@ -103,8 +101,7 @@ public class PreviousPeriodControllerTest {
 
         when(apiResponseMapper.map(exception))
             .thenReturn(new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR));
-        ResponseEntity response = previousPeriodController
-            .create(previousPeriod, request);
+        ResponseEntity response = previousPeriodController.create(previousPeriod, "", request);
 
         verify(previousPeriodService, times(1)).create(any(), any(), any(), any());
         verify(apiResponseMapper, times(1)).map(exception);


### PR DESCRIPTION
- there was a problem before with the casting of the id from the request, we do not need to do this as the company account id is being passed as a request param so we can just get it from there instead