### PR TITLE
Adds basic validation and error mapping to PreviousPeriod controller

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodController.java
@@ -33,12 +33,14 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 public class PreviousPeriodController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
+    private static final String REQUEST_ID = "X-Request-Id";
 
     @Autowired
     private PreviousPeriodService previousPeriodService;
 
     @Autowired
     private ApiResponseMapper apiResponseMapper;
+
     @Autowired
     private ErrorMapper errorMapper;
 
@@ -60,8 +62,6 @@ public class PreviousPeriodController {
 
         Transaction transaction = getTransactionFromRequest(request);
         ResponseEntity responseEntity;
-
-        System.out.println("its here");
 
         try {
             ResponseObject<PreviousPeriod> responseObject = previousPeriodService.create(previousPeriod, transaction, companyAccountId, requestId);
@@ -90,6 +90,6 @@ public class PreviousPeriodController {
     }
 
     private String getRequestId(HttpServletRequest request) {
-        return request.getHeader("X-Request-Id");
+        return request.getHeader(REQUEST_ID);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/BalanceSheet.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/BalanceSheet.java
@@ -10,8 +10,8 @@ import javax.validation.Valid;
 @JsonInclude(Include.NON_NULL)
 public class BalanceSheet {
 
-    public static final int MAX_RANGE = 99999999;
-    public static final int MIN_RANGE = 0;
+    private static final int MAX_RANGE = 99999999;
+    private static final int MIN_RANGE = 0;
 
     @Range(min = MIN_RANGE, max = MAX_RANGE, message = "VALUE_OUTSIDE_RANGE")
     @JsonProperty("called_up_share_capital_not_paid")

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/PreviousPeriod.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/PreviousPeriod.java
@@ -3,11 +3,15 @@ package uk.gov.companieshouse.api.accounts.model.rest;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 @JsonInclude(Include.NON_NULL)
 public class PreviousPeriod extends RestObject {
 
+    @NotNull(message="MANDATORY_ELEMENT_MISSING")
     @JsonProperty("balance_sheet")
+    @Valid
     private BalanceSheet balanceSheet;
 
     public BalanceSheet getBalanceSheet() {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodControllerTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
@@ -48,6 +49,9 @@ public class PreviousPeriodControllerTest {
 
     @Mock
     private CompanyAccountEntity companyAccountEntity;
+
+    @Mock
+    private BindingResult bindingResult;
 
     @Mock
     private PreviousPeriodService previousPeriodService;
@@ -82,7 +86,7 @@ public class PreviousPeriodControllerTest {
             responseObject.getData(), responseObject.getValidationErrorData()))
             .thenReturn(responseEntity);
 
-        ResponseEntity response = previousPeriodController.create(previousPeriod, "", request);
+        ResponseEntity response = previousPeriodController.create(previousPeriod, "", request, bindingResult);
 
         verify(apiResponseMapper, times(1)).map(any(), any(), any());
 
@@ -101,7 +105,7 @@ public class PreviousPeriodControllerTest {
 
         when(apiResponseMapper.map(exception))
             .thenReturn(new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR));
-        ResponseEntity response = previousPeriodController.create(previousPeriod, "", request);
+        ResponseEntity response = previousPeriodController.create(previousPeriod, "", request, bindingResult);
 
         verify(previousPeriodService, times(1)).create(any(), any(), any(), any());
         verify(apiResponseMapper, times(1)).map(exception);


### PR DESCRIPTION
- adds basic validation and error mapping to the previous period controller
- adds validation to the `PreviousPeriod` rest object so that it validates the `balanceSheet` member
- adds unit tests for validation
Resolves: SFA-749