### PR TITLE
Removes errors object passed to mapping function

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/ApprovalController.java
@@ -58,7 +58,7 @@ public class ApprovalController {
         if (bindingResult.hasErrors()) {
 
             Errors errors = errorMapper
-                .mapBindingResultErrorsToErrorModel(bindingResult, new Errors());
+                .mapBindingResultErrorsToErrorModel(bindingResult);
 
             if (errors.hasErrors()) {
                 LOGGER.error("Approval validation failure", logContext);


### PR DESCRIPTION
- Compilation is failing due to a method accepting wrong arguments
- Removes the errors object being passed to the mapping function