### PR TITLE
Validation for OtherLiabilitiesOrAssets for both Current and Previous periods

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
@@ -118,10 +118,9 @@ public class CurrentPeriodController {
 
         Errors errors = currentPeriodValidator.validateCurrentPeriod(currentPeriod);
         if (errors.hasErrors()) {
-            LOGGER.error("Current period validation failure");
+            LOGGER.info("Current period validation failure");
             logValidationFailureError(getRequestId(request), errors);
             return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
-
         }
 
         Transaction transaction = (Transaction) request.getAttribute(AttributeName.TRANSACTION.getValue());

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
@@ -111,23 +111,20 @@ public class CurrentPeriodController {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
 
-        Errors errors = new Errors();
-
         if (bindingResult.hasErrors()) {
-            errors = errorMapper.mapBindingResultErrorsToErrorModel(bindingResult);
+            Errors errors = errorMapper.mapBindingResultErrorsToErrorModel(bindingResult);
+            return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
         }
 
-        currentPeriodValidator.validateCurrentPeriod(currentPeriod);
+        Errors errors = currentPeriodValidator.validateCurrentPeriod(currentPeriod);
         if (errors.hasErrors()) {
-            LOGGER.error(
-                "Current period validation failure");
+            LOGGER.error("Current period validation failure");
             logValidationFailureError(getRequestId(request), errors);
             return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
 
         }
 
-        Transaction transaction = (Transaction) request
-            .getAttribute(AttributeName.TRANSACTION.getValue());
+        Transaction transaction = (Transaction) request.getAttribute(AttributeName.TRANSACTION.getValue());
 
         String requestId = request.getHeader(REQUEST_ID);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodController.java
@@ -131,7 +131,7 @@ public class PreviousPeriodController {
 
         Errors errors = previousPeriodValidator.validatePreviousPeriod(previousPeriod);
         if (errors.hasErrors()) {
-            LOGGER.error( "Previous period validation failure");
+            LOGGER.info( "Previous period validation failure");
             logValidationFailureError(getRequestId(request), errors);
             return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/OtherLiabilitiesOrAssetsEntity.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/OtherLiabilitiesOrAssetsEntity.java
@@ -16,8 +16,8 @@ public class OtherLiabilitiesOrAssetsEntity {
     @Field("total_assets_less_current_liabilities")
     private Long totalAssetsLessCurrentLiabilities;
 
-    @Field("creditors_due_after_one_year")
-    private Long creditorsDueAfterOneYear;
+    @Field("creditors_after_one_year")
+    private Long creditorsAfterOneYear;
 
     @Field("provision_for_liabilities")
     private Long provisionForLiabilities;
@@ -60,12 +60,12 @@ public class OtherLiabilitiesOrAssetsEntity {
         this.totalAssetsLessCurrentLiabilities = totalAssetsLessCurrentLiabilities;
     }
 
-    public Long getCreditorsDueAfterOneYear() {
-        return creditorsDueAfterOneYear;
+    public Long getCreditorsAfterOneYear() {
+        return creditorsAfterOneYear;
     }
 
-    public void setCreditorsDueAfterOneYear(Long creditorsDueAfterOneYear) {
-        this.creditorsDueAfterOneYear = creditorsDueAfterOneYear;
+    public void setCreditorsAfterOneYear(Long creditorsAfterOneYear) {
+        this.creditorsAfterOneYear = creditorsAfterOneYear;
     }
 
     public Long getProvisionForLiabilities() {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/OtherLiabilitiesOrAssets.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/OtherLiabilitiesOrAssets.java
@@ -26,8 +26,8 @@ public class OtherLiabilitiesOrAssets {
     private Long totalAssetsLessCurrentLiabilities;
 
     @Range(min = MIN_RANGE, max = MAX_RANGE, message = "value.outside.range")
-    @JsonProperty("creditors_due_after_one_year")
-    private Long creditorsDueAfterOneYear;
+    @JsonProperty("creditors_after_one_year")
+    private Long creditorsAfterOneYear;
 
     @Range(min = MIN_RANGE, max = MAX_RANGE, message = "value.outside.range")
     @JsonProperty("provision_for_liabilities")
@@ -73,12 +73,12 @@ public class OtherLiabilitiesOrAssets {
         this.totalAssetsLessCurrentLiabilities = totalAssetsLessCurrentLiabilities;
     }
 
-    public Long getCreditorsDueAfterOneYear() {
-        return creditorsDueAfterOneYear;
+    public Long getCreditorsAfterOneYear() {
+        return creditorsAfterOneYear;
     }
 
-    public void setCreditorsDueAfterOneYear(Long creditorsDueAfterOneYear) {
-        this.creditorsDueAfterOneYear = creditorsDueAfterOneYear;
+    public void setCreditorsAfterOneYear(Long creditorsAfterOneYear) {
+        this.creditorsAfterOneYear = creditorsAfterOneYear;
     }
 
     public Long getProvisionForLiabilities() {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -88,11 +88,11 @@ public class CurrentPeriodValidator extends BaseValidator {
     private void calculateOtherLiabilitiesOrAssetsTotalNetAssets(CurrentPeriod currentPeriod, Errors errors) {
         OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets();
         Long totalAssetsLessCurrentLiabilities = Optional.ofNullable(otherLiabilitiesOrAssets.getTotalAssetsLessCurrentLiabilities()).orElse(0L);
-        Long creditorsDueAfterOneYear = Optional.ofNullable(otherLiabilitiesOrAssets.getCreditorsAfterOneYear()).orElse(0L);
+        Long creditorsAfterOneYear = Optional.ofNullable(otherLiabilitiesOrAssets.getCreditorsAfterOneYear()).orElse(0L);
         Long accrualsAndDeferredIncome = Optional.ofNullable(otherLiabilitiesOrAssets.getAccrualsAndDeferredIncome()).orElse(0L);
         Long provisionForLiabilities = Optional.ofNullable(otherLiabilitiesOrAssets.getProvisionForLiabilities()).orElse(0L);
 
-        Long calculatedTotal = totalAssetsLessCurrentLiabilities - (creditorsDueAfterOneYear + accrualsAndDeferredIncome + provisionForLiabilities);
+        Long calculatedTotal = totalAssetsLessCurrentLiabilities - (creditorsAfterOneYear + accrualsAndDeferredIncome + provisionForLiabilities);
 
         Long totalNetAssets = Optional.ofNullable(otherLiabilitiesOrAssets.getTotalNetAssets()).orElse(0L);
         validateAggregateTotal(totalNetAssets, calculatedTotal, OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH, errors);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -15,8 +15,7 @@ import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 @Component
 public class CurrentPeriodValidator extends BaseValidator {
 
-    private static final String CURRENT_PERIOD_PATH = "$.current_period";
-    private static final String BALANCE_SHEET_PATH = CURRENT_PERIOD_PATH + ".balance_sheet";
+    private static final String BALANCE_SHEET_PATH = "$.current_period.balance_sheet";
     private static final String FIXED_ASSETS_PATH = BALANCE_SHEET_PATH + ".fixed_assets";
     private static final String TOTAL_PATH = FIXED_ASSETS_PATH + ".total";
     private static final String OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH = BALANCE_SHEET_PATH + ".net_current_assets";

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -1,12 +1,13 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
 
+import java.util.Optional;
+import javax.validation.Valid;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
-
-import javax.validation.Valid;
+import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 
 /**
  * Validates Current Period
@@ -14,10 +15,13 @@ import javax.validation.Valid;
 @Component
 public class CurrentPeriodValidator extends BaseValidator {
 
-    private static String CURRENT_PERIOD_PATH = "$.current_period";
-    private static String BALANCE_SHEET_PATH = CURRENT_PERIOD_PATH + ".balance_sheet";
-    private static String FIXED_ASSETS_PATH = BALANCE_SHEET_PATH + ".fixed_assets";
-    private static String TOTAL_PATH = FIXED_ASSETS_PATH + ".total";
+    private static final String CURRENT_PERIOD_PATH = "$.current_period";
+    private static final String BALANCE_SHEET_PATH = CURRENT_PERIOD_PATH + ".balance_sheet";
+    private static final String FIXED_ASSETS_PATH = BALANCE_SHEET_PATH + ".fixed_assets";
+    private static final String TOTAL_PATH = FIXED_ASSETS_PATH + ".total";
+    private static final String OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH = BALANCE_SHEET_PATH + ".net_current_assets";
+    private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_ASSETS_LESS_CURRENT_LIABILITIES_PATH = BALANCE_SHEET_PATH + ".total_assets_less_current_liabilities";
+    private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH = BALANCE_SHEET_PATH + ".total_net_assets";
 
     public Errors validateCurrentPeriod(@Valid CurrentPeriod currentPeriod) {
 
@@ -26,6 +30,8 @@ public class CurrentPeriodValidator extends BaseValidator {
         if (currentPeriod.getBalanceSheet() != null) {
 
             validateTotalFixedAssets(currentPeriod, errors);
+
+            validateTotalOtherLiabilitiesOrAssets(currentPeriod, errors);
         }
 
         return errors;
@@ -44,5 +50,51 @@ public class CurrentPeriodValidator extends BaseValidator {
 
             validateAggregateTotal(fixedAssetsTotal, calculatedTotal, TOTAL_PATH, errors);
         }
+    }
+
+    private void validateTotalOtherLiabilitiesOrAssets(@Valid CurrentPeriod currentPeriod, Errors errors) {
+        if (currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
+            calculateOtherLiabilitiesOrAssetsNetCurrentAssets(currentPeriod, errors);
+            calculateOtherLiabilitiesOrAssetsTotalAssetsLessCurrentLiabilities(currentPeriod, errors);
+            calculateOtherLiabilitiesOrAssetsTotalNetAssets(currentPeriod,errors);
+        }
+    }
+    private void calculateOtherLiabilitiesOrAssetsNetCurrentAssets(CurrentPeriod currentPeriod, Errors errors) {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets();
+        Long prepaymentsAndAccruedIncome = Optional.ofNullable(otherLiabilitiesOrAssets.getPrepaymentsAndAccruedIncome()).orElse(0L);
+        Long creditorsDueWithinOneYear = Optional.ofNullable(otherLiabilitiesOrAssets.getCreditorsDueWithinOneYear()).orElse(0L);
+
+        Long calculatedTotal = /* current_assets.total_current_assets + */ prepaymentsAndAccruedIncome - creditorsDueWithinOneYear;
+
+        Long netCurrentAssets = Optional.ofNullable(otherLiabilitiesOrAssets.getNetCurrentAssets()).orElse(0L);
+        validateAggregateTotal(netCurrentAssets, calculatedTotal, OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH, errors);
+    }
+
+    private void calculateOtherLiabilitiesOrAssetsTotalAssetsLessCurrentLiabilities(CurrentPeriod currentPeriod, Errors errors) {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets();
+
+        Long netCurrentAssets = Optional.ofNullable(otherLiabilitiesOrAssets.getNetCurrentAssets()).orElse(0L);
+
+        Long fixedAssetsTotal = 0L;
+        if (currentPeriod.getBalanceSheet().getFixedAssets() != null) {
+            fixedAssetsTotal = Optional.ofNullable(currentPeriod.getBalanceSheet().getFixedAssets().getTotalFixedAssets()).orElse(0L);
+        }
+        Long calculatedTotal = fixedAssetsTotal + netCurrentAssets;
+
+        Long totalAssetsLessCurrentLiabilities = Optional.ofNullable(otherLiabilitiesOrAssets.getTotalAssetsLessCurrentLiabilities()).orElse(0L);
+        validateAggregateTotal(totalAssetsLessCurrentLiabilities, calculatedTotal, OTHER_LIABILITIES_OR_ASSETS_TOTAL_ASSETS_LESS_CURRENT_LIABILITIES_PATH, errors);
+    }
+
+    private void calculateOtherLiabilitiesOrAssetsTotalNetAssets(CurrentPeriod currentPeriod, Errors errors) {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets();
+        Long totalAssetsLessCurrentLiabilities = Optional.ofNullable(otherLiabilitiesOrAssets.getTotalAssetsLessCurrentLiabilities()).orElse(0L);
+        Long creditorsDueAfterOneYear = Optional.ofNullable(otherLiabilitiesOrAssets.getCreditorsAfterOneYear()).orElse(0L);
+        Long accrualsAndDeferredIncome = Optional.ofNullable(otherLiabilitiesOrAssets.getAccrualsAndDeferredIncome()).orElse(0L);
+        Long provisionForLiabilities = Optional.ofNullable(otherLiabilitiesOrAssets.getProvisionForLiabilities()).orElse(0L);
+
+        Long calculatedTotal = totalAssetsLessCurrentLiabilities - (creditorsDueAfterOneYear + accrualsAndDeferredIncome + provisionForLiabilities);
+
+        Long totalNetAssets = Optional.ofNullable(otherLiabilitiesOrAssets.getTotalNetAssets()).orElse(0L);
+        validateAggregateTotal(totalNetAssets, calculatedTotal, OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH, errors);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -11,8 +11,7 @@ import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 @Component
 public class PreviousPeriodValidator extends BaseValidator {
 
-    private static String  PREVIOUS_PERIOD_PATH = "$.previous_period";
-    private static String BALANCE_SHEET_PATH = PREVIOUS_PERIOD_PATH + ".balance_sheet";
+    private static final String BALANCE_SHEET_PATH = "$.previous_period.balance_sheet";
     private static String FIXED_ASSETS_PATH = BALANCE_SHEET_PATH + ".fixed_assets";
     private static String TOTAL_PATH = FIXED_ASSETS_PATH + ".total";
     private static final String OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH = BALANCE_SHEET_PATH + ".net_current_assets";

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -1,11 +1,12 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
+import java.util.Optional;
+import javax.validation.Valid;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
+import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
-
-import javax.validation.Valid;
 
 @Component
 public class PreviousPeriodValidator extends BaseValidator {
@@ -14,15 +15,18 @@ public class PreviousPeriodValidator extends BaseValidator {
     private static String BALANCE_SHEET_PATH = PREVIOUS_PERIOD_PATH + ".balance_sheet";
     private static String FIXED_ASSETS_PATH = BALANCE_SHEET_PATH + ".fixed_assets";
     private static String TOTAL_PATH = FIXED_ASSETS_PATH + ".total";
+    private static final String OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH = BALANCE_SHEET_PATH + ".net_current_assets";
+    private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_ASSETS_LESS_CURRENT_LIABILITIES_PATH = BALANCE_SHEET_PATH + ".total_assets_less_current_liabilities";
+    private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH = BALANCE_SHEET_PATH + ".total_net_assets";
 
-    public Errors validatePreviousPeriod(
-        @Valid PreviousPeriod previousPeriod) {
+    public Errors validatePreviousPeriod(@Valid PreviousPeriod previousPeriod) {
 
         Errors errors = new Errors();
 
         if (previousPeriod.getBalanceSheet() != null) {
 
             validateTotalFixedAssets(previousPeriod, errors);
+            validateTotalOtherLiabilitiesOrAssets(previousPeriod, errors);
         }
 
         return errors;
@@ -40,5 +44,51 @@ public class PreviousPeriodValidator extends BaseValidator {
 
             validateAggregateTotal(fixedAssetsTotal, calculatedTotal, TOTAL_PATH, errors);
         }
+    }
+
+    private void validateTotalOtherLiabilitiesOrAssets(@Valid PreviousPeriod previousPeriod, Errors errors) {
+        if (previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
+            calculateOtherLiabilitiesOrAssetsNetCurrentAssets(previousPeriod, errors);
+            calculateOtherLiabilitiesOrAssetsTotalAssetsLessCurrentLiabilities(previousPeriod, errors);
+            calculateOtherLiabilitiesOrAssetsTotalNetAssets(previousPeriod,errors);
+        }
+    }
+    private void calculateOtherLiabilitiesOrAssetsNetCurrentAssets(PreviousPeriod previousPeriod, Errors errors) {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets();
+        Long prepaymentsAndAccruedIncome = Optional.ofNullable(otherLiabilitiesOrAssets.getPrepaymentsAndAccruedIncome()).orElse(0L);
+        Long creditorsDueWithinOneYear = Optional.ofNullable(otherLiabilitiesOrAssets.getCreditorsDueWithinOneYear()).orElse(0L);
+
+        Long calculatedTotal = /* current_assets.total_current_assets + */ prepaymentsAndAccruedIncome - creditorsDueWithinOneYear;
+
+        Long netCurrentAssets = Optional.ofNullable(otherLiabilitiesOrAssets.getNetCurrentAssets()).orElse(0L);
+        validateAggregateTotal(netCurrentAssets, calculatedTotal, OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH, errors);
+    }
+
+    private void calculateOtherLiabilitiesOrAssetsTotalAssetsLessCurrentLiabilities(PreviousPeriod previousPeriod, Errors errors) {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets();
+
+        Long netCurrentAssets = Optional.ofNullable(otherLiabilitiesOrAssets.getNetCurrentAssets()).orElse(0L);
+
+        Long fixedAssetsTotal = 0L;
+        if (previousPeriod.getBalanceSheet().getFixedAssets() != null) {
+            fixedAssetsTotal = Optional.ofNullable(previousPeriod.getBalanceSheet().getFixedAssets().getTotalFixedAssets()).orElse(0L);
+        }
+        Long calculatedTotal = fixedAssetsTotal + netCurrentAssets;
+
+        Long totalAssetsLessCurrentLiabilities = Optional.ofNullable(otherLiabilitiesOrAssets.getTotalAssetsLessCurrentLiabilities()).orElse(0L);
+        validateAggregateTotal(totalAssetsLessCurrentLiabilities, calculatedTotal, OTHER_LIABILITIES_OR_ASSETS_TOTAL_ASSETS_LESS_CURRENT_LIABILITIES_PATH, errors);
+    }
+
+    private void calculateOtherLiabilitiesOrAssetsTotalNetAssets(PreviousPeriod previousPeriod, Errors errors) {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets();
+        Long totalAssetsLessCurrentLiabilities = Optional.ofNullable(otherLiabilitiesOrAssets.getTotalAssetsLessCurrentLiabilities()).orElse(0L);
+        Long creditorsAfterOneYear = Optional.ofNullable(otherLiabilitiesOrAssets.getCreditorsAfterOneYear()).orElse(0L);
+        Long accrualsAndDeferredIncome = Optional.ofNullable(otherLiabilitiesOrAssets.getAccrualsAndDeferredIncome()).orElse(0L);
+        Long provisionForLiabilities = Optional.ofNullable(otherLiabilitiesOrAssets.getProvisionForLiabilities()).orElse(0L);
+
+        Long calculatedTotal = totalAssetsLessCurrentLiabilities - (creditorsAfterOneYear + accrualsAndDeferredIncome + provisionForLiabilities);
+
+        Long totalNetAssets = Optional.ofNullable(otherLiabilitiesOrAssets.getTotalNetAssets()).orElse(0L);
+        validateAggregateTotal(totalNetAssets, calculatedTotal, OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH, errors);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
@@ -56,7 +56,7 @@ public class CurrentPeriodControllerTest {
     private BindingResult bindingResult;
 
     @Mock
-    Errors errors;
+    private Errors errors;
 
     @Mock
     private CurrentPeriodService currentPeriodService;
@@ -124,8 +124,12 @@ public class CurrentPeriodControllerTest {
         doReturn(responseObject).when(currentPeriodService)
             .update(currentPeriod, null, "12345", null);
 
+        when(currentPeriodValidator.validateCurrentPeriod(any())).thenReturn(errors);
+
         ResponseEntity response = currentPeriodController
             .update(currentPeriod, bindingResult, "12345", request);
+
+
 
         assertNotNull(response);
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
@@ -18,38 +18,18 @@ public class CurrentPeriodValidatorTest {
     private static final String CURRENT_PERIOD_PATH = "$.current_period";
     private static final String BALANCE_SHEET_PATH = CURRENT_PERIOD_PATH + ".balance_sheet";
     private static final String FIXED_ASSETS_TOTAL_PATH = BALANCE_SHEET_PATH + ".fixed_assets.total";
+    private static final String OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH = BALANCE_SHEET_PATH + ".net_current_assets";
+    private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_ASSETS_LESS_CURRENT_LIABILITIES_PATH = BALANCE_SHEET_PATH + ".total_assets_less_current_liabilities";
     private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH = BALANCE_SHEET_PATH + ".total_net_assets";
 
     CurrentPeriodValidator validator = new CurrentPeriodValidator();
 
     CurrentPeriod currentPeriod = new CurrentPeriod();
     BalanceSheet balanceSheet = new BalanceSheet();
-    Errors errors = new Errors();
 
     @Test
-    @DisplayName("Test total fixed assets validation")
-    public void validateTotalFixedAssets() {
-
-        FixedAssets fixedAssets = new FixedAssets();
-        fixedAssets.setTangible(5L);
-        fixedAssets.setTotalFixedAssets(10L);
-        balanceSheet.setFixedAssets(fixedAssets);
-        currentPeriod.setBalanceSheet(balanceSheet);
-        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
-
-
-       Errors errors =  validator.validateCurrentPeriod(currentPeriod);
-
-        assertTrue(errors.containsError(
-            new Error("incorrect_total", FIXED_ASSETS_TOTAL_PATH,
-                LocationType.JSON_PATH.getValue(),
-                ErrorType.VALIDATION.getType())));
-
-    }
-
-    @Test
-    @DisplayName("SUCCESS - Test total other liabilities or assets validation")
-    public void validateTotalOtherLiabilitiesOrAssets() {
+    @DisplayName("SUCCESS - Test Balance Sheet validation")
+    void validateBalanceSheet() {
         OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
         otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
         otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
@@ -69,9 +49,103 @@ public class CurrentPeriodValidatorTest {
         currentPeriod.setBalanceSheet(balanceSheet);
         ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
 
-
         Errors errors =  validator.validateCurrentPeriod(currentPeriod);
 
         assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    @DisplayName("ERROR - Fixed Assets - Test validation with total fixed assets error")
+    void validateBalanceSheetWithTotalFixedAssetsError() {
+        FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setTangible(5L);
+        fixedAssets.setTotalFixedAssets(10L);
+        balanceSheet.setFixedAssets(fixedAssets);
+        currentPeriod.setBalanceSheet(balanceSheet);
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+
+        Errors errors =  validator.validateCurrentPeriod(currentPeriod);
+
+        assertTrue(errors.containsError(
+            new Error("incorrect_total", FIXED_ASSETS_TOTAL_PATH,
+                LocationType.JSON_PATH.getValue(),
+                ErrorType.VALIDATION.getType())));
+    }
+
+    @Test
+    @DisplayName("ERROR - Other Liabilities Or Assets - Test validation with net current assets error")
+    void validateBalanceSheetWithOtherLiabilitiesOrAssetsNetCurrentAssetsError() {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
+        otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
+        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
+        otherLiabilitiesOrAssets.setNetCurrentAssets(1L);
+        balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
+        currentPeriod.setBalanceSheet(balanceSheet);
+
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+
+
+        Errors errors =  validator.validateCurrentPeriod(currentPeriod);
+
+        assertTrue(errors.containsError(
+                new Error("incorrect_total", OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH,
+                        LocationType.JSON_PATH.getValue(),
+                        ErrorType.VALIDATION.getType())));
+    }
+
+    @Test
+    @DisplayName("ERROR - Other Liabilities Or Assets - Test validation with total assets less current liabilities error")
+    void validateBalanceSheetWithOtherLiabilitiesOrAssetsTotalAssetsLessCurrentLiabilitiesError() {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
+        otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
+        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
+        otherLiabilitiesOrAssets.setNetCurrentAssets(2L);
+        otherLiabilitiesOrAssets.setTotalAssetsLessCurrentLiabilities(3L);
+        otherLiabilitiesOrAssets.setCreditorsAfterOneYear(1L);
+        otherLiabilitiesOrAssets.setProvisionForLiabilities(1L);
+        otherLiabilitiesOrAssets.setAccrualsAndDeferredIncome(1L);
+        otherLiabilitiesOrAssets.setTotalNetAssets(2L);
+        balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
+
+        FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setTangible(2L);
+        fixedAssets.setTotalFixedAssets(2L);
+        balanceSheet.setFixedAssets(fixedAssets);
+
+        currentPeriod.setBalanceSheet(balanceSheet);
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+
+        Errors errors =  validator.validateCurrentPeriod(currentPeriod);
+
+        assertTrue(errors.containsError(
+                new Error("incorrect_total", OTHER_LIABILITIES_OR_ASSETS_TOTAL_ASSETS_LESS_CURRENT_LIABILITIES_PATH,
+                        LocationType.JSON_PATH.getValue(),
+                        ErrorType.VALIDATION.getType())));
+    }
+
+    @Test
+    @DisplayName("ERROR - Other Liabilities Or Assets - Test validation with total net assets error")
+    void validateBalanceSheetWithOtherLiabilitiesOrAssetsTotalNetAssetsError() {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
+        otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
+        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
+        otherLiabilitiesOrAssets.setNetCurrentAssets(2L);
+        otherLiabilitiesOrAssets.setTotalAssetsLessCurrentLiabilities(2L);
+        balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
+
+        FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setTangible(2L);
+        fixedAssets.setTotalFixedAssets(2L);
+        balanceSheet.setFixedAssets(fixedAssets);
+
+        currentPeriod.setBalanceSheet(balanceSheet);
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+
+        Errors errors =  validator.validateCurrentPeriod(currentPeriod);
+
+        assertTrue(errors.containsError(
+                new Error("incorrect_total", OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH,
+                        LocationType.JSON_PATH.getValue(),
+                        ErrorType.VALIDATION.getType())));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
@@ -1,23 +1,24 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.accounts.model.rest.BalanceSheet;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
+import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
 import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CurrentPeriodValidatorTest {
 
     private static final String CURRENT_PERIOD_PATH = "$.current_period";
     private static final String BALANCE_SHEET_PATH = CURRENT_PERIOD_PATH + ".balance_sheet";
-    private static final String TOTAL_PATH = BALANCE_SHEET_PATH + ".fixed_assets.total";
+    private static final String FIXED_ASSETS_TOTAL_PATH = BALANCE_SHEET_PATH + ".fixed_assets.total";
+    private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH = BALANCE_SHEET_PATH + ".total_net_assets";
 
     CurrentPeriodValidator validator = new CurrentPeriodValidator();
 
@@ -40,9 +41,37 @@ public class CurrentPeriodValidatorTest {
        Errors errors =  validator.validateCurrentPeriod(currentPeriod);
 
         assertTrue(errors.containsError(
-            new Error("incorrect_total", TOTAL_PATH,
+            new Error("incorrect_total", FIXED_ASSETS_TOTAL_PATH,
                 LocationType.JSON_PATH.getValue(),
                 ErrorType.VALIDATION.getType())));
 
+    }
+
+    @Test
+    @DisplayName("SUCCESS - Test total other liabilities or assets validation")
+    public void validateTotalOtherLiabilitiesOrAssets() {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
+        otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
+        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
+        otherLiabilitiesOrAssets.setNetCurrentAssets(2L);
+        otherLiabilitiesOrAssets.setTotalAssetsLessCurrentLiabilities(4L);
+        otherLiabilitiesOrAssets.setCreditorsAfterOneYear(1L);
+        otherLiabilitiesOrAssets.setProvisionForLiabilities(1L);
+        otherLiabilitiesOrAssets.setAccrualsAndDeferredIncome(1L);
+        otherLiabilitiesOrAssets.setTotalNetAssets(1L);
+        balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
+
+        FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setTangible(2L);
+        fixedAssets.setTotalFixedAssets(2L);
+        balanceSheet.setFixedAssets(fixedAssets);
+
+        currentPeriod.setBalanceSheet(balanceSheet);
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+
+
+        Errors errors =  validator.validateCurrentPeriod(currentPeriod);
+
+        assertFalse(errors.hasErrors());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
@@ -84,8 +84,7 @@ public class PreviousPeriodValidatorTest {
         previousPeriod.setBalanceSheet(balanceSheet);
 
         ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
-
-
+        
         Errors errors =  validator.validatePreviousPeriod(previousPeriod);
 
         assertTrue(errors.containsError(

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
@@ -1,49 +1,152 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.accounts.model.rest.BalanceSheet;
 import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
+import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod;
 import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class PreviousPeriodValidatorTest {
 
     private static final String PREVIOUS_PERIOD_PATH = "$.previous_period";
     private static final String BALANCE_SHEET_PATH = PREVIOUS_PERIOD_PATH + ".balance_sheet";
-    private static final String TOTAL_PATH = BALANCE_SHEET_PATH + ".fixed_assets.total";
-
-    private static final long TANGIBLE = 5;
-    private static final long TOTAL_FIXED_ASSETS = 10;
+    private static final String FIXED_ASSETS_TOTAL_PATH = BALANCE_SHEET_PATH + ".fixed_assets.total";
+    private static final String OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH = BALANCE_SHEET_PATH + ".net_current_assets";
+    private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_ASSETS_LESS_CURRENT_LIABILITIES_PATH = BALANCE_SHEET_PATH + ".total_assets_less_current_liabilities";
+    private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH = BALANCE_SHEET_PATH + ".total_net_assets";
 
     PreviousPeriodValidator validator = new PreviousPeriodValidator();
 
     PreviousPeriod previousPeriod = new PreviousPeriod();
     BalanceSheet balanceSheet = new BalanceSheet();
-    Errors errors = new Errors();
 
     @Test
-    @DisplayName("Test total fixed assets validation")
-    public void validateTotalFixedAssets() {
+    @DisplayName("SUCCESS - Test Balance Sheet validation")
+    void validateBalanceSheet() {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
+        otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
+        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
+        otherLiabilitiesOrAssets.setNetCurrentAssets(2L);
+        otherLiabilitiesOrAssets.setTotalAssetsLessCurrentLiabilities(4L);
+        otherLiabilitiesOrAssets.setCreditorsAfterOneYear(1L);
+        otherLiabilitiesOrAssets.setProvisionForLiabilities(1L);
+        otherLiabilitiesOrAssets.setAccrualsAndDeferredIncome(1L);
+        otherLiabilitiesOrAssets.setTotalNetAssets(1L);
+        balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
 
         FixedAssets fixedAssets = new FixedAssets();
-        fixedAssets.setTangible(TANGIBLE);
-        fixedAssets.setTotalFixedAssets(TOTAL_FIXED_ASSETS);
+        fixedAssets.setTangible(2L);
+        fixedAssets.setTotalFixedAssets(2L);
+        balanceSheet.setFixedAssets(fixedAssets);
+
+        previousPeriod.setBalanceSheet(balanceSheet);
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+
+        Errors errors =  validator.validatePreviousPeriod(previousPeriod);
+
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    @DisplayName("ERROR - Fixed Assets - Test validation with total fixed assets error")
+    void validateBalanceSheetWithTotalFixedAssetsError() {
+        FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setTangible(5L);
+        fixedAssets.setTotalFixedAssets(10L);
         balanceSheet.setFixedAssets(fixedAssets);
         previousPeriod.setBalanceSheet(balanceSheet);
         ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
 
-        validator.validateTotalFixedAssets(previousPeriod, errors);
+        Errors errors =  validator.validatePreviousPeriod(previousPeriod);
 
         assertTrue(errors.containsError(
-            new Error("incorrect_total", TOTAL_PATH,
-                LocationType.JSON_PATH.getValue(),
-                ErrorType.VALIDATION.getType())));
+                new Error("incorrect_total", FIXED_ASSETS_TOTAL_PATH,
+                        LocationType.JSON_PATH.getValue(),
+                        ErrorType.VALIDATION.getType())));
+    }
 
+    @Test
+    @DisplayName("ERROR - Other Liabilities Or Assets - Test validation with net current assets error")
+    void validateBalanceSheetWithOtherLiabilitiesOrAssetsNetCurrentAssetsError() {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
+        otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
+        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
+        otherLiabilitiesOrAssets.setNetCurrentAssets(1L);
+        balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
+        previousPeriod.setBalanceSheet(balanceSheet);
+
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+
+
+        Errors errors =  validator.validatePreviousPeriod(previousPeriod);
+
+        assertTrue(errors.containsError(
+                new Error("incorrect_total", OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH,
+                        LocationType.JSON_PATH.getValue(),
+                        ErrorType.VALIDATION.getType())));
+    }
+
+    @Test
+    @DisplayName("ERROR - Other Liabilities Or Assets - Test validation with total assets less current liabilities error")
+    void validateBalanceSheetWithOtherLiabilitiesOrAssetsTotalAssetsLessCurrentLiabilitiesError() {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
+        otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
+        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
+        otherLiabilitiesOrAssets.setNetCurrentAssets(2L);
+        otherLiabilitiesOrAssets.setTotalAssetsLessCurrentLiabilities(3L);
+        otherLiabilitiesOrAssets.setCreditorsAfterOneYear(1L);
+        otherLiabilitiesOrAssets.setProvisionForLiabilities(1L);
+        otherLiabilitiesOrAssets.setAccrualsAndDeferredIncome(1L);
+        otherLiabilitiesOrAssets.setTotalNetAssets(2L);
+        balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
+
+        FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setTangible(2L);
+        fixedAssets.setTotalFixedAssets(2L);
+        balanceSheet.setFixedAssets(fixedAssets);
+
+        previousPeriod.setBalanceSheet(balanceSheet);
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+
+        Errors errors =  validator.validatePreviousPeriod(previousPeriod);
+
+        assertTrue(errors.containsError(
+                new Error("incorrect_total", OTHER_LIABILITIES_OR_ASSETS_TOTAL_ASSETS_LESS_CURRENT_LIABILITIES_PATH,
+                        LocationType.JSON_PATH.getValue(),
+                        ErrorType.VALIDATION.getType())));
+    }
+
+    @Test
+    @DisplayName("ERROR - Other Liabilities Or Assets - Test validation with total net assets error")
+    void validateBalanceSheetWithOtherLiabilitiesOrAssetsTotalNetAssetsError() {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
+        otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
+        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
+        otherLiabilitiesOrAssets.setNetCurrentAssets(2L);
+        otherLiabilitiesOrAssets.setTotalAssetsLessCurrentLiabilities(2L);
+        balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
+
+        FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setTangible(2L);
+        fixedAssets.setTotalFixedAssets(2L);
+        balanceSheet.setFixedAssets(fixedAssets);
+
+        previousPeriod.setBalanceSheet(balanceSheet);
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+
+        Errors errors =  validator.validatePreviousPeriod(previousPeriod);
+
+        assertTrue(errors.containsError(
+                new Error("incorrect_total", OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH,
+                        LocationType.JSON_PATH.getValue(),
+                        ErrorType.VALIDATION.getType())));
     }
 }


### PR DESCRIPTION
- adds remaining fields to the `OtherLiabilitiesOrAssetsEntity` and `OtherLiabilitiesOrAssets` `entity` and `rest` models
- adds the validation logic for the calculation of the figures on from within the `OtherLiabilitiesOrAssets` object for both current and previous periods

NOTE: This PR is dependent on PR #113 being in develop already as we are making a calculation using `CurrentAssets` which is to be used in the validation of the totals in this PR.

Resolves: SFA-240, SFA-468