### PR TITLE
Initial classes for Statements

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/StatementDataEntity.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/StatementDataEntity.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.api.accounts.model.entity;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class StatementDataEntity extends BaseDataEntity {
+
+    @Field("legal_statements")
+    private Map<String, String> legalStatements = new HashMap<>();
+
+    @Field("has_agreed_to_legal_statements")
+    private Boolean hasAgreedToLegalStatements;
+
+    public Map<String, String> getLegalStatements() {
+        return legalStatements;
+    }
+
+    public void setLegalStatements(Map<String, String> legalStatements) {
+        this.legalStatements = legalStatements;
+    }
+
+    public Boolean getHasAgreedToLegalStatements() {
+        return hasAgreedToLegalStatements;
+    }
+
+    public void setHasAgreedToLegalStatements(Boolean hasAgreedToLegalStatements) {
+        this.hasAgreedToLegalStatements = hasAgreedToLegalStatements;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/StatementEntity.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/StatementEntity.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.api.accounts.model.entity;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "statements")
+public class StatementEntity extends BaseEntity {
+
+    private StatementDataEntity data;
+
+    public StatementDataEntity getData() {
+        return data;
+    }
+
+    public void setData(StatementDataEntity data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/Statement.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/Statement.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.api.accounts.model.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Statement extends RestObject {
+
+    @JsonProperty("has_agreed_to_legal_statements")
+    private Boolean hasAgreedToLegalStatements;
+
+    @JsonProperty("legal_statements")
+    private Map<String, String> legalStatements = new HashMap<>();
+
+    public Boolean getHasAgreedToLegalStatements() {
+        return hasAgreedToLegalStatements;
+    }
+
+    public void setHasAgreedToLegalStatements(Boolean hasAgreedToLegalStatements) {
+        this.hasAgreedToLegalStatements = hasAgreedToLegalStatements;
+    }
+
+    public Map<String, String> getLegalStatements() {
+        return legalStatements;
+    }
+
+    public void setLegalStatements(Map<String, String> legalStatements) {
+        this.legalStatements = legalStatements;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/repository/StatementRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/repository/StatementRepository.java
@@ -1,0 +1,10 @@
+package uk.gov.companieshouse.api.accounts.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.companieshouse.api.accounts.model.entity.StatementEntity;
+
+@Repository
+public interface StatementRepository extends MongoRepository<StatementEntity, String> {
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformer.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.api.accounts.transformer;
+
+import org.springframework.beans.BeanUtils;
+import uk.gov.companieshouse.api.accounts.model.entity.StatementDataEntity;
+import uk.gov.companieshouse.api.accounts.model.entity.StatementEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.Statement;
+
+public class StatementTransformer implements GenericTransformer<Statement, StatementEntity> {
+
+    @Override
+    public StatementEntity transform(Statement entity) {
+        StatementDataEntity statementDataEntity = new StatementDataEntity();
+        StatementEntity statementEntity = new StatementEntity();
+        BeanUtils.copyProperties(entity, statementDataEntity);
+        statementEntity.setData(statementDataEntity);
+        return statementEntity;
+    }
+
+    @Override
+    public Statement transform(StatementEntity entity) {
+        Statement statement = new Statement();
+        StatementDataEntity statementDataEntity = entity.getData();
+        BeanUtils.copyProperties(statementDataEntity, statement);
+        return statement;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformerTest.java
@@ -1,0 +1,93 @@
+package uk.gov.companieshouse.api.accounts.transformer;
+
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.accounts.model.entity.StatementDataEntity;
+import uk.gov.companieshouse.api.accounts.model.entity.StatementEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.Statement;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class StatementTransformerTest {
+
+
+    private StatementTransformer statementTransformer = new StatementTransformer();
+
+    @Test
+    @DisplayName("Tests statement transformer with empty object which should result in null values")
+    public void testTransformerWithEmptyObject() {
+        StatementEntity statementEntity = statementTransformer.transform(new Statement());
+
+        Assertions.assertNotNull(statementEntity);
+        Assertions.assertNull(statementEntity.getData().getEtag());
+        Assertions.assertNull(statementEntity.getData().getKind());
+        Assertions.assertEquals(new HashMap<>(), statementEntity.getData().getLinks());
+    }
+
+    @Test
+    @DisplayName("Tests statement transformer with populated object and validates values returned")
+    public void testRestToEntityTransformerWithPopulatedObject() {
+        Statement statement = new Statement();
+        statement.setEtag("etag");
+        statement.setKind("kind");
+        statement.setLinks(new HashMap<>());
+        statement.setHasAgreedToLegalStatements(false);
+        statement.setLegalStatements(getPopulatedMapStatement());
+
+        StatementEntity statementEntity = statementTransformer.transform(statement);
+
+        Assertions.assertNotNull(statementEntity);
+        Assertions.assertEquals("etag", statementEntity.getData().getEtag());
+        Assertions.assertEquals("kind", statementEntity.getData().getKind());
+        Assertions.assertEquals(new HashMap<>(), statementEntity.getData().getLinks());
+        Assertions.assertFalse(statementEntity.getData().getHasAgreedToLegalStatements());
+        Assertions.assertEquals("def", statementEntity.getData().getLegalStatements().get("abc"));
+        Assertions.assertEquals("jkl", statementEntity.getData().getLegalStatements().get("ghi"));
+    }
+
+    @Test
+    @DisplayName("Tests statement transformer with populated object and validates values returned")
+    public void testEntityToRestTransformerWithPopulatedObject() {
+        StatementEntity statementEntity = new StatementEntity();
+        StatementDataEntity statementDataEntity = new StatementDataEntity();
+        statementDataEntity.setEtag("etag");
+        statementDataEntity.setKind("kind");
+        statementDataEntity.setLinks(new HashMap<>());
+        statementDataEntity.setHasAgreedToLegalStatements(true);
+        statementDataEntity.setLegalStatements(getPopulatedMapStatement());
+        statementEntity.setData(statementDataEntity);
+
+        Statement statement = statementTransformer.transform(statementEntity);
+
+        Assertions.assertNotNull(statement);
+        Assertions.assertEquals("etag", statement.getEtag());
+        Assertions.assertEquals("kind", statement.getKind());
+        Assertions.assertEquals(new HashMap<>(), statement.getLinks());
+        Assertions.assertTrue(statement.getHasAgreedToLegalStatements());
+        Assertions.assertEquals("def", statement.getLegalStatements().get("abc"));
+        Assertions.assertEquals("jkl", statement.getLegalStatements().get("ghi"));
+    }
+
+    private Map<String, String> getPopulatedMapStatement(){
+        Map<String, String> result = new HashMap<>();
+        result.put("abc", "def");
+        result.put("ghi","jkl");
+        return result;
+    }
+
+    private Map<String, Object> setDebugMap(String[] ... vargs) {
+        Map<String, Object> debugMap = new HashMap<>();
+        for (String[] entry : vargs){
+            debugMap.put(entry[0],entry[1]);
+        }
+        return debugMap;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformerTest.java
@@ -1,9 +1,14 @@
 package uk.gov.companieshouse.api.accounts.transformer;
 
 
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -27,10 +32,10 @@ public class StatementTransformerTest {
     public void testTransformerWithEmptyObject() {
         StatementEntity statementEntity = statementTransformer.transform(new Statement());
 
-        Assertions.assertNotNull(statementEntity);
-        Assertions.assertNull(statementEntity.getData().getEtag());
-        Assertions.assertNull(statementEntity.getData().getKind());
-        Assertions.assertEquals(new HashMap<>(), statementEntity.getData().getLinks());
+        assertNotNull(statementEntity);
+        assertNull(statementEntity.getData().getEtag());
+        assertNull(statementEntity.getData().getKind());
+        assertEquals(new HashMap<>(), statementEntity.getData().getLinks());
     }
 
     @Test
@@ -45,13 +50,13 @@ public class StatementTransformerTest {
 
         StatementEntity statementEntity = statementTransformer.transform(statement);
 
-        Assertions.assertNotNull(statementEntity);
-        Assertions.assertEquals("etag", statementEntity.getData().getEtag());
-        Assertions.assertEquals("kind", statementEntity.getData().getKind());
-        Assertions.assertEquals(new HashMap<>(), statementEntity.getData().getLinks());
-        Assertions.assertFalse(statementEntity.getData().getHasAgreedToLegalStatements());
-        Assertions.assertEquals("def", statementEntity.getData().getLegalStatements().get("abc"));
-        Assertions.assertEquals("jkl", statementEntity.getData().getLegalStatements().get("ghi"));
+        assertNotNull(statementEntity);
+        assertEquals("etag", statementEntity.getData().getEtag());
+        assertEquals("kind", statementEntity.getData().getKind());
+        assertEquals(new HashMap<>(), statementEntity.getData().getLinks());
+        assertFalse(statementEntity.getData().getHasAgreedToLegalStatements());
+        assertEquals("def", statementEntity.getData().getLegalStatements().get("abc"));
+        assertEquals("jkl", statementEntity.getData().getLegalStatements().get("ghi"));
     }
 
     @Test
@@ -68,19 +73,19 @@ public class StatementTransformerTest {
 
         Statement statement = statementTransformer.transform(statementEntity);
 
-        Assertions.assertNotNull(statement);
-        Assertions.assertEquals("etag", statement.getEtag());
-        Assertions.assertEquals("kind", statement.getKind());
-        Assertions.assertEquals(new HashMap<>(), statement.getLinks());
-        Assertions.assertTrue(statement.getHasAgreedToLegalStatements());
-        Assertions.assertEquals("def", statement.getLegalStatements().get("abc"));
-        Assertions.assertEquals("jkl", statement.getLegalStatements().get("ghi"));
+        assertNotNull(statement);
+        assertEquals("etag", statement.getEtag());
+        assertEquals("kind", statement.getKind());
+        assertEquals(new HashMap<>(), statement.getLinks());
+        assertTrue(statement.getHasAgreedToLegalStatements());
+        assertEquals("def", statement.getLegalStatements().get("abc"));
+        assertEquals("jkl", statement.getLegalStatements().get("ghi"));
     }
 
-    private Map<String, String> getPopulatedMapStatement(){
+    private Map<String, String> getPopulatedMapStatement() {
         Map<String, String> result = new HashMap<>();
         result.put("abc", "def");
-        result.put("ghi","jkl");
+        result.put("ghi", "jkl");
         return result;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformerTest.java
@@ -82,12 +82,4 @@ public class StatementTransformerTest {
         result.put("ghi","jkl");
         return result;
     }
-
-    private Map<String, Object> setDebugMap(String[] ... vargs) {
-        Map<String, Object> debugMap = new HashMap<>();
-        for (String[] entry : vargs){
-            debugMap.put(entry[0],entry[1]);
-        }
-        return debugMap;
-    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.accounts.model.entity.StatementDataEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.StatementEntity;
@@ -18,8 +19,8 @@ import uk.gov.companieshouse.api.accounts.model.rest.Statement;
 @TestInstance(Lifecycle.PER_CLASS)
 public class StatementTransformerTest {
 
-
-    private StatementTransformer statementTransformer = new StatementTransformer();
+    @InjectMocks
+    private StatementTransformer statementTransformer;
 
     @Test
     @DisplayName("Tests statement transformer with empty object which should result in null values")


### PR DESCRIPTION
Added the Model classes for:
- `StatementEntity`
- `StatementDataEntity`
- `Statement`

Added database handling:
- `StatementRepository`

Added transformer between models:
- `StatementTransformer`

Helps Resolve: SFA-867