### PR TITLE
Rename 'totalCurrentAssets' field as 'total'

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/CurrentAssetsEntity.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/CurrentAssetsEntity.java
@@ -5,20 +5,23 @@ import org.springframework.data.mongodb.core.mapping.Field;
 public class CurrentAssetsEntity {
 
     @Field("total")
-    private Long totalCurrentAssets;
+    private Long total;
+
     @Field("stocks")
     private Long stocks;
+
     @Field("debtors")
     private Long debtors;
+
     @Field("cash_at_bank_and_in_hand")
     private Long cashAtBankAndInHand;
 
-    public Long getTotalCurrentAssets() {
-        return totalCurrentAssets;
+    public Long getTotal() {
+        return total;
     }
 
-    public void setTotalCurrentAssets(Long totalCurrentAssets) {
-        this.totalCurrentAssets = totalCurrentAssets;
+    public void setTotal(Long total) {
+        this.total = total;
     }
 
     public Long getStocks() {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/CurrentAssets.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/CurrentAssets.java
@@ -23,7 +23,7 @@ public class CurrentAssets {
 
     @NotNull
     @JsonProperty("total")
-    private Long totalCurrentAssets;
+    private Long total;
 
     public Long getStocks() {
         return stocks;
@@ -49,11 +49,11 @@ public class CurrentAssets {
         this.cashAtBankAndInHand = cashAtBankAndInHand;
     }
 
-    public Long getTotalCurrentAssets() {
-        return totalCurrentAssets;
+    public Long getTotal() {
+        return total;
     }
 
-    public void setTotalCurrentAssets(Long totalCurrentAssets) {
-        this.totalCurrentAssets = totalCurrentAssets;
+    public void setTotal(Long total) {
+        this.total = total;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -43,7 +43,7 @@ public class CurrentPeriodValidator extends BaseValidator {
         Long stocks = Optional.ofNullable(currentAssets.getStocks()).orElse(0L);
         Long debtors = Optional.ofNullable(currentAssets. getDebtors()).orElse(0L);
         Long cashAtBankAndInHand = Optional.ofNullable(currentAssets.getCashAtBankAndInHand()).orElse(0L);
-        Long currentAssetsTotal = Optional.ofNullable(currentAssets.getTotalCurrentAssets()).orElse(0L);
+        Long currentAssetsTotal = Optional.ofNullable(currentAssets.getTotal()).orElse(0L);
 
         Long calculatedTotal = stocks + debtors + cashAtBankAndInHand;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -39,7 +39,7 @@ public class PreviousPeriodValidator extends BaseValidator {
         Long stocks = Optional.ofNullable(currentAssets.getStocks()).orElse(0L);
         Long debtors = Optional.ofNullable(currentAssets. getDebtors()).orElse(0L);
         Long cashAtBankAndInHand = Optional.ofNullable(currentAssets.getCashAtBankAndInHand()).orElse(0L);
-        Long currentAssetsTotal = Optional.ofNullable(currentAssets.getTotalCurrentAssets()).orElse(0L);
+        Long currentAssetsTotal = Optional.ofNullable(currentAssets.getTotal()).orElse(0L);
 
         Long calculatedTotal = stocks + debtors + cashAtBankAndInHand;
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CurrentPeriodTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CurrentPeriodTransformerTest.java
@@ -72,7 +72,7 @@ public class CurrentPeriodTransformerTest {
         assertEquals(CURRENT_ASSETS_VALID, data.getBalanceSheetEntity().getCurrentAssets().getStocks());
         assertEquals(CURRENT_ASSETS_VALID, data.getBalanceSheetEntity().getCurrentAssets().getDebtors());
         assertEquals(CURRENT_ASSETS_VALID, data.getBalanceSheetEntity().getCurrentAssets().getCashAtBankAndInHand());
-        assertEquals(CURRENT_ASSETS_TOTAL_VALID, data.getBalanceSheetEntity().getCurrentAssets().getTotalCurrentAssets());
+        assertEquals(CURRENT_ASSETS_TOTAL_VALID, data.getBalanceSheetEntity().getCurrentAssets().getTotal());
 
         assertEquals("kind", data.getKind());
         assertEquals(new HashMap<>(), data.getLinks());
@@ -92,7 +92,7 @@ public class CurrentPeriodTransformerTest {
         currentAssets.setStocks(CURRENT_ASSETS_VALID);
         currentAssets.setDebtors(CURRENT_ASSETS_VALID);
         currentAssets.setCashAtBankAndInHand(CURRENT_ASSETS_VALID);
-        currentAssets.setTotalCurrentAssets(CURRENT_ASSETS_TOTAL_VALID);
+        currentAssets.setTotal(CURRENT_ASSETS_TOTAL_VALID);
 
         balanceSheet.setCurrentAssets(currentAssets);
     }
@@ -127,7 +127,7 @@ public class CurrentPeriodTransformerTest {
         assertEquals(CURRENT_ASSETS_VALID, currentPeriod.getBalanceSheet().getCurrentAssets().getStocks());
         assertEquals(CURRENT_ASSETS_VALID, currentPeriod.getBalanceSheet().getCurrentAssets().getDebtors());
         assertEquals(CURRENT_ASSETS_VALID, currentPeriod.getBalanceSheet().getCurrentAssets().getCashAtBankAndInHand());
-        assertEquals(CURRENT_ASSETS_TOTAL_VALID, currentPeriod.getBalanceSheet().getCurrentAssets().getTotalCurrentAssets());
+        assertEquals(CURRENT_ASSETS_TOTAL_VALID, currentPeriod.getBalanceSheet().getCurrentAssets().getTotal());
         assertEquals("kind", currentPeriod.getKind());
         assertEquals(new HashMap<>(), currentPeriod.getLinks());
     }
@@ -148,7 +148,7 @@ public class CurrentPeriodTransformerTest {
         currentAssetsEntity.setStocks(CURRENT_ASSETS_VALID);
         currentAssetsEntity.setDebtors(CURRENT_ASSETS_VALID);
         currentAssetsEntity.setCashAtBankAndInHand(CURRENT_ASSETS_VALID);
-        currentAssetsEntity.setTotalCurrentAssets(CURRENT_ASSETS_TOTAL_VALID);
+        currentAssetsEntity.setTotal(CURRENT_ASSETS_TOTAL_VALID);
 
         balanceSheetEntity.setCurrentAssets(currentAssetsEntity);
     }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
@@ -80,7 +80,7 @@ public class CurrentPeriodValidatorTest {
         currentAssets.setStocks(null);
         currentAssets.setDebtors(null);
         currentAssets.setCashAtBankAndInHand(5L);
-        currentAssets.setTotalCurrentAssets(10L);
+        currentAssets.setTotal(10L);
 
         balanceSheet.setCurrentAssets(currentAssets);
         currentPeriod.setBalanceSheet(balanceSheet);
@@ -103,7 +103,7 @@ public class CurrentPeriodValidatorTest {
         currentAssets.setStocks(5L);
         currentAssets.setDebtors(5L);
         currentAssets.setCashAtBankAndInHand(5L);
-        currentAssets.setTotalCurrentAssets(15L);
+        currentAssets.setTotal(15L);
 
         balanceSheet.setCurrentAssets(currentAssets);
 
@@ -146,7 +146,7 @@ public class CurrentPeriodValidatorTest {
         currentAssets.setStocks(5L);
         currentAssets.setDebtors(5L);
         currentAssets.setCashAtBankAndInHand(5L);
-        currentAssets.setTotalCurrentAssets(10L);
+        currentAssets.setTotal(10L);
 
         balanceSheet.setCurrentAssets(currentAssets);
     }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
@@ -81,7 +81,7 @@ public class PreviousPeriodValidatorTest {
         currentAssets.setStocks(null);
         currentAssets.setDebtors(null);
         currentAssets.setCashAtBankAndInHand(5L);
-        currentAssets.setTotalCurrentAssets(10L);
+        currentAssets.setTotal(10L);
 
         balanceSheet.setCurrentAssets(currentAssets);
         previousPeriod.setBalanceSheet(balanceSheet);
@@ -104,7 +104,7 @@ public class PreviousPeriodValidatorTest {
         currentAssets.setStocks(5L);
         currentAssets.setDebtors(5L);
         currentAssets.setCashAtBankAndInHand(5L);
-        currentAssets.setTotalCurrentAssets(15L);
+        currentAssets.setTotal(15L);
 
         balanceSheet.setCurrentAssets(currentAssets);
 
@@ -147,7 +147,7 @@ public class PreviousPeriodValidatorTest {
         currentAssets.setStocks(5L);
         currentAssets.setDebtors(5L);
         currentAssets.setCashAtBankAndInHand(5L);
-        currentAssets.setTotalCurrentAssets(10L);
+        currentAssets.setTotal(10L);
 
         balanceSheet.setCurrentAssets(currentAssets);
     }


### PR DESCRIPTION
Rename 'totalCurrentAssets' field as 'total'

Fixes a bug raised when posting an empty balance sheet