### PR TITLE
Add StatementService to create, update and/or find the Legal Statements 

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/Kind.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/Kind.java
@@ -12,6 +12,7 @@ public enum Kind {
     CREDITORS_DUE_WITHIN_ONE_YEAR_NOTE("small-full-accounts#creditors-due-within-one-year-note"),
     DEBTORS_NOTE("small-full-accounts#debtors-note"),
     INTANGIBLE_ASSETS_NOTE("small-full-accounts#intangible-assets-note"),
+    SMALL_FULL_STATEMENT("small-full-accounts#statements"),
     STOCKS_NOTE("small-full-accounts#stocks-note"),
     TANGIBLE_ASSETS_NOTE("small-full-accounts#tangible-assets-note");
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/ResourceName.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/ResourceName.java
@@ -6,7 +6,8 @@ public enum ResourceName {
     SMALL_FULL("small-full"),
     CURRENT_PERIOD("current-period"),
     PREVIOUS_PERIOD("previous-period"),
-    APPROVAL("approval");
+    APPROVAL("approval"),
+    STATEMENTS("statements");
 
     private String name;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/links/SmallFullLinkType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/links/SmallFullLinkType.java
@@ -12,6 +12,7 @@ public enum SmallFullLinkType implements LinkType {
     INTANGIBLE_ASSETS_NOTE("intangible_assets_note"),
     PAYMENT("payment"),
     PREVIOUS_PERIOD("previous_period"),
+    STATEMENTS("statements"),
     STOCKS_NOTE("stocks_note"),
     TANGIBLE_ASSETS_NOTE("tangible_assets_note");
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
@@ -39,7 +39,7 @@ public class StatementService implements ResourceService<Statement> {
 
     private static final String PERIOD_END_ON_PLACE_HOLDER = "{period_end_on}";
     private static final String LEGAL_STATEMENT_SECTION_477_KEY = "section_477";
-    private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
         .ofPattern("d MMMM yyyy");
 
     private StatementTransformer transformer;
@@ -175,7 +175,6 @@ public class StatementService implements ResourceService<Statement> {
     private LocalDate getPeriodEndOn(CompanyAccount companyAccount) {
 
         return companyAccount.getPeriodEndOn();
-
     }
 
     /**
@@ -185,6 +184,7 @@ public class StatementService implements ResourceService<Statement> {
      * @param rest
      * @param transaction
      * @param companyAccountId
+     * @param periodEndOn
      */
     private void setMetadataOnRestObject(Statement rest,
         Transaction transaction,
@@ -239,6 +239,7 @@ public class StatementService implements ResourceService<Statement> {
      *
      * @param statements
      * @param legalStatementKey
+     * @param placeHolder
      * @param placeHolderReplacement
      */
     private void updateLegalStatementByReplacingPlaceHolder(Map<String, String> statements,
@@ -262,12 +263,12 @@ public class StatementService implements ResourceService<Statement> {
     }
 
     /**
-     * Converts the date to format d MMMM yyyy: 1 January 2018.
+     * Converts the date to format d MMMM yyyy. E.g: 1 January 2018.
      *
      * @param date - date to be formatted
      * @return
      */
     private String convertDateToString(LocalDate date) {
-        return dateTimeFormatter.format(date);
+        return DATE_TIME_FORMATTER.format(date);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
@@ -1,0 +1,285 @@
+package uk.gov.companieshouse.api.accounts.service.impl;
+
+import com.mongodb.MongoException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.GenerateEtagUtil;
+import uk.gov.companieshouse.api.accounts.AttributeName;
+import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
+import uk.gov.companieshouse.api.accounts.Kind;
+import uk.gov.companieshouse.api.accounts.ResourceName;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
+import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
+import uk.gov.companieshouse.api.accounts.links.TransactionLinkType;
+import uk.gov.companieshouse.api.accounts.model.entity.StatementEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
+import uk.gov.companieshouse.api.accounts.model.rest.Statement;
+import uk.gov.companieshouse.api.accounts.repository.StatementRepository;
+import uk.gov.companieshouse.api.accounts.service.ResourceService;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.accounts.transaction.Transaction;
+import uk.gov.companieshouse.api.accounts.transformer.StatementTransformer;
+import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Service
+public class StatementService implements ResourceService<Statement> {
+
+    private static final Logger LOGGER = LoggerFactory
+        .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
+
+    private static final String PERIOD_END_ON_PLACE_HOLDER = "{period_end_on}";
+    private static final String LEGAL_STATEMENT_SECTION_477_KEY = "section_477";
+    private static final String DATE_FORMAT_D_MMMM_YYYY = "d MMMM yyyy";
+
+    private StatementTransformer transformer;
+    private StatementRepository statementRepository;
+    private KeyIdGenerator keyIdGenerator;
+    private SmallFullService smallFullService;
+    private StatementsServiceProperties statementsServiceProperties;
+
+    @Autowired
+    public StatementService(StatementTransformer transformer,
+        StatementRepository statementRepository,
+        KeyIdGenerator keyIdGenerator,
+        SmallFullService smallFullService,
+        StatementsServiceProperties statementsServiceProperties) {
+
+        this.transformer = transformer;
+        this.statementRepository = statementRepository;
+        this.keyIdGenerator = keyIdGenerator;
+        this.smallFullService = smallFullService;
+        this.statementsServiceProperties = statementsServiceProperties;
+    }
+
+    @Override
+    public ResponseObject<Statement> create(Statement rest, Transaction transaction,
+        String companyAccountId, HttpServletRequest request) throws DataException {
+
+        CompanyAccount companyAccount =
+            ((CompanyAccount) request.getAttribute(AttributeName.COMPANY_ACCOUNT.getValue()));
+
+        setMetadataOnRestObject(rest, transaction, companyAccountId,
+            getPeriodEndOn(companyAccount));
+
+        StatementEntity statementEntity = transformer.transform(rest);
+        statementEntity.setId(generateID(companyAccountId));
+
+        try {
+            statementRepository.insert(statementEntity);
+
+        } catch (DuplicateKeyException ex) {
+
+            LOGGER.errorRequest(request, ex,
+                getDebugMap(transaction, companyAccountId, statementEntity.getId()));
+
+            return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
+
+        } catch (MongoException ex) {
+
+            DataException dataException = new DataException(
+                "Failed to insert " + ResourceName.STATEMENTS.getName(), ex);
+
+            LOGGER.errorRequest(request, dataException,
+                getDebugMap(transaction, companyAccountId, statementEntity.getId()));
+
+            throw dataException;
+        }
+
+        smallFullService.addLink(companyAccountId,
+            SmallFullLinkType.STATEMENTS,
+            statementEntity.getData().getLinks().get(BasicLinkType.SELF.getLink()),
+            request);
+
+        return new ResponseObject<>(ResponseStatus.CREATED, rest);
+    }
+
+    @Override
+    public ResponseObject<Statement> update(Statement rest, Transaction transaction,
+        String companyAccountId, HttpServletRequest request) throws DataException {
+
+        CompanyAccount companyAccount =
+            ((CompanyAccount) request.getAttribute(AttributeName.COMPANY_ACCOUNT.getValue()));
+
+        setMetadataOnRestObject(rest, transaction, companyAccountId,
+            getPeriodEndOn(companyAccount));
+
+        StatementEntity statementEntity = transformer.transform(rest);
+        statementEntity.setId(generateID(companyAccountId));
+
+        try {
+            statementRepository.save(statementEntity);
+
+        } catch (MongoException ex) {
+
+            DataException dataException = new DataException(
+                "Failed to update " + ResourceName.STATEMENTS.getName(), ex);
+
+            LOGGER.errorRequest(request, dataException,
+                getDebugMap(transaction, companyAccountId, statementEntity.getId()));
+
+            throw dataException;
+        }
+
+        return new ResponseObject<>(ResponseStatus.UPDATED, rest);
+    }
+
+    @Override
+    public ResponseObject<Statement> findById(String id, HttpServletRequest request)
+        throws DataException {
+
+        StatementEntity statementEntity;
+
+        try {
+            statementEntity = statementRepository.findById(id).orElse(null);
+
+        } catch (MongoException ex) {
+
+            final Map<String, Object> debugMap = new HashMap<>();
+            debugMap.put("id", id);
+
+            DataException dataException = new DataException("Failed to find Statements", ex);
+            LOGGER.errorRequest(request, dataException, debugMap);
+
+            throw dataException;
+        }
+
+        if (statementEntity == null) {
+            return new ResponseObject<>(ResponseStatus.NOT_FOUND);
+        }
+
+        return new ResponseObject<>(ResponseStatus.FOUND, transformer.transform(statementEntity));
+    }
+
+    @Override
+    public String generateID(String companyAccountId) {
+        return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.STATEMENTS.getName());
+    }
+
+    /**
+     * Get the period end on stored from the CompanyAccount request's attribute
+     *
+     * @param companyAccount
+     * @return period end on formatted.
+     */
+    private LocalDate getPeriodEndOn(CompanyAccount companyAccount) {
+
+        return companyAccount.getPeriodEndOn();
+
+    }
+
+    /**
+     * Sets the links, the etag, kind and statements(after replacing place holder) in the rest
+     * object.
+     *
+     * @param rest
+     * @param transaction
+     * @param companyAccountId
+     */
+    private void setMetadataOnRestObject(Statement rest,
+        Transaction transaction,
+        String companyAccountId,
+        LocalDate periodEndOn) {
+
+        rest.setLinks(createSelfLink(transaction, companyAccountId));
+        rest.setEtag(GenerateEtagUtil.generateEtag());
+        rest.setKind(Kind.SMALL_FULL_STATEMENT.getValue());
+        rest.setLegalStatements(getLegalStatements(periodEndOn));
+
+    }
+
+    private Map<String, String> createSelfLink(Transaction transaction, String companyAccountId) {
+        Map<String, String> selfLink = new HashMap<>();
+        selfLink.put(BasicLinkType.SELF.getLink(), generateSelfLink(transaction, companyAccountId));
+
+        return selfLink;
+    }
+
+    private String generateSelfLink(Transaction transaction, String companyAccountId) {
+        return transaction.getLinks().get(TransactionLinkType.SELF.getLink()) + "/"
+            + ResourceName.COMPANY_ACCOUNT.getName() + "/"
+            + companyAccountId + "/"
+            + ResourceName.SMALL_FULL.getName() + "/"
+            + ResourceName.STATEMENTS.getName();
+    }
+
+    /**
+     * Gets the Legal Statements. Replace period_end_on placeholder in the statements for
+     * periodEndOn value
+     *
+     * @return
+     */
+    private Map<String, String> getLegalStatements(LocalDate periodEndOn) {
+        Map<String, String> legalStatements = getLegalStatementsFromProperties();
+
+        if (legalStatements.containsKey(LEGAL_STATEMENT_SECTION_477_KEY)) {
+            updateLegalStatementByReplacingPlaceHolder(
+                legalStatements,
+                LEGAL_STATEMENT_SECTION_477_KEY,
+                PERIOD_END_ON_PLACE_HOLDER,
+                convertDateToString(periodEndOn, DATE_FORMAT_D_MMMM_YYYY));
+        }
+
+        return legalStatements;
+    }
+
+    /**
+     * Replace the place holder in the legal statement passed in, with the placeHolderReplacements
+     * value.
+     *
+     * @param statements
+     * @param legalStatementKey
+     * @param placeHolderReplacement
+     */
+    private void updateLegalStatementByReplacingPlaceHolder(Map<String, String> statements,
+        String legalStatementKey,
+        String placeHolder,
+        String placeHolderReplacement) {
+
+        String statementUpdated =
+            statements.get(legalStatementKey).replace(placeHolder, placeHolderReplacement);
+
+        statements.replace(legalStatementKey, statementUpdated);
+    }
+
+    /**
+     * Get the legal statements from LegalStatements.properties file.
+     *
+     * @return
+     */
+    private Map<String, String> getLegalStatementsFromProperties() {
+        return statementsServiceProperties.getStatements();
+    }
+
+    /**
+     * Converts the date to format passed in.
+     *
+     * @param date - date to be formatted
+     * @param dateFormat - date format that the date needs to be formatted to
+     * @return
+     */
+    private String convertDateToString(LocalDate date, String dateFormat) {
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateFormat);
+        return dtf.format(date);
+    }
+
+    private Map<String, Object> getDebugMap(Transaction transaction, String companyAccountId,
+        String id) {
+
+        final Map<String, Object> debugMap = new HashMap<>();
+        debugMap.put("transaction_id", transaction.getId());
+        debugMap.put("company_accounts_id", companyAccountId);
+        debugMap.put("id", id);
+
+        return debugMap;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
@@ -39,7 +39,8 @@ public class StatementService implements ResourceService<Statement> {
 
     private static final String PERIOD_END_ON_PLACE_HOLDER = "{period_end_on}";
     private static final String LEGAL_STATEMENT_SECTION_477_KEY = "section_477";
-    private static final String DATE_FORMAT_D_MMMM_YYYY = "d MMMM yyyy";
+    private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter
+        .ofPattern("d MMMM yyyy");
 
     private StatementTransformer transformer;
     private StatementRepository statementRepository;
@@ -226,7 +227,7 @@ public class StatementService implements ResourceService<Statement> {
                 legalStatements,
                 LEGAL_STATEMENT_SECTION_477_KEY,
                 PERIOD_END_ON_PLACE_HOLDER,
-                convertDateToString(periodEndOn, DATE_FORMAT_D_MMMM_YYYY));
+                convertDateToString(periodEndOn));
         }
 
         return legalStatements;
@@ -261,14 +262,12 @@ public class StatementService implements ResourceService<Statement> {
     }
 
     /**
-     * Converts the date to format passed in.
+     * Converts the date to format d MMMM yyyy: 1 January 2018.
      *
      * @param date - date to be formatted
-     * @param dateFormat - date format that the date needs to be formatted to
      * @return
      */
-    private String convertDateToString(LocalDate date, String dateFormat) {
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateFormat);
-        return dtf.format(date);
+    private String convertDateToString(LocalDate date) {
+        return dateTimeFormatter.format(date);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
@@ -166,7 +166,7 @@ public class StatementService implements ResourceService<Statement> {
     }
 
     /**
-     * Get the period end on stored from the CompanyAccount request's attribute
+     * Get the period end on stored in CompanyAccount
      *
      * @param companyAccount
      * @return period end on formatted.
@@ -178,7 +178,7 @@ public class StatementService implements ResourceService<Statement> {
     }
 
     /**
-     * Sets the links, the etag, kind and statements(after replacing place holder) in the rest
+     * Sets the links, the etag, kind and statements(after replacing the placeholder) in the rest
      * object.
      *
      * @param rest

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementsServiceProperties.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementsServiceProperties.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.api.accounts.service.impl;
+
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@Component
+@PropertySource("classpath:LegalStatements.properties")
+@ConfigurationProperties(prefix = "balance.sheet")
+public class StatementsServiceProperties {
+
+    private Map<String, String> statements;
+
+    public Map<String, String> getStatements() {
+        return statements;
+    }
+
+    public void setStatements(Map<String, String> statements) {
+        this.statements = statements;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformer.java
@@ -1,10 +1,12 @@
 package uk.gov.companieshouse.api.accounts.transformer;
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.accounts.model.entity.StatementDataEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.StatementEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.Statement;
 
+@Component
 public class StatementTransformer implements GenericTransformer<Statement, StatementEntity> {
 
     @Override

--- a/src/main/resources/LegalStatements.properties
+++ b/src/main/resources/LegalStatements.properties
@@ -1,0 +1,6 @@
+# Legal statements that must be agreed to
+balance.sheet.statements.section_477 = For the year ending {period_end_on} the company was entitled to exemption under section 477 of the Companies Act 2006 relating to small companies.
+balance.sheet.statements.audit_not_required_by_members = The members have not required the company to obtain an audit in accordance with section 476 of the Companies Act 2006.
+balance.sheet.statements.directors_responsibility = The directors acknowledge their responsibilities for complying with the requirements of the Act with respect to accounting records and the preparation of accounts.
+balance.sheet.statements.small_companies_regime = These accounts have been prepared and delivered in accordance with the provisions applicable to companies subject to the small companies regime.
+balance.sheet.statements.no_profit_and_loss = The directors have chosen not to file a copy of the company's profit and loss account.

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StatementServiceTest.java
@@ -1,0 +1,252 @@
+package uk.gov.companieshouse.api.accounts.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.MongoException;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.dao.DuplicateKeyException;
+import uk.gov.companieshouse.api.accounts.Kind;
+import uk.gov.companieshouse.api.accounts.ResourceName;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
+import uk.gov.companieshouse.api.accounts.model.entity.StatementDataEntity;
+import uk.gov.companieshouse.api.accounts.model.entity.StatementEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
+import uk.gov.companieshouse.api.accounts.model.rest.Statement;
+import uk.gov.companieshouse.api.accounts.repository.StatementRepository;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.accounts.transaction.Transaction;
+import uk.gov.companieshouse.api.accounts.transformer.StatementTransformer;
+import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+@PropertySource("classpath:LegalStatements.properties")
+public class StatementServiceTest {
+
+
+    private static final String ETAG = "etag";
+    private static final String LEGAL_STATEMENT_ID = "abcdef";
+    private static final String COMPANY_ACCOUNTS_ID = "123123";
+    private static final String TRANSACTION_SELF_LINK = "/transactions/123456-123456-123456";
+    private static final String STATEMENT_SELF_LINK = TRANSACTION_SELF_LINK + "/"
+        + ResourceName.COMPANY_ACCOUNT.getName() + "/"
+        + COMPANY_ACCOUNTS_ID + "/"
+        + ResourceName.SMALL_FULL.getName() + "/"
+        + ResourceName.STATEMENTS.getName();
+
+    private static final String LEGAL_STATEMENT_SECTION_477_KEY = "section_477";
+    private static final String LEGAL_STATEMENT_SECTION_477 = "Testing place holder: {period_end_on}";
+
+    private StatementEntity statementEntity;
+    private Map<String, String> legalStatements;
+
+    @Mock
+    private HttpServletRequest requestMock;
+    @Mock
+    private CompanyAccount companyAccountMock;
+    @Mock
+    private Transaction transactionMock;
+    @Mock
+    private Statement statementMock;
+    @Mock
+    private StatementTransformer statementTransformerMock;
+    @Mock
+    private StatementRepository statementRepositoryMock;
+    @Mock
+    private KeyIdGenerator KeyIdGeneratorMock;
+    @Mock
+    private SmallFullService smallFullServiceMock;
+    @Mock
+    private StatementsServiceProperties statementsServicePropertiesMock;
+    @Mock
+    private StatementEntity statementEntityMock;
+
+    @InjectMocks
+    private StatementService statementService;
+
+    @BeforeAll
+    void setUpBeforeAll() {
+        statementEntity = createStatementEntity();
+        legalStatements = createLegalStatements();
+    }
+
+    @Test
+    @DisplayName("Tests the successful creation of a Statement resource")
+    void shouldCreateStatement() throws DataException {
+        when(requestMock.getAttribute(anyString())).thenReturn(companyAccountMock);
+        when(companyAccountMock.getPeriodEndOn()).thenReturn(LocalDate.of(2018, Month.NOVEMBER, 1));
+        when(statementsServicePropertiesMock.getStatements()).thenReturn(legalStatements);
+        when(statementTransformerMock.transform(statementMock)).thenReturn(statementEntity);
+
+        ResponseObject<Statement> result =
+            statementService.create(statementMock, transactionMock, "", requestMock);
+
+        assertNotNull(result);
+        assertEquals(ResponseStatus.CREATED, result.getStatus());
+        assertEquals(statementMock, result.getData());
+    }
+
+    @Test
+    @DisplayName("Tests the duplicate key when creating a Statement resource")
+    void shouldNotCreateStatementHttpDuplicateKeyError() throws DataException {
+        when(requestMock.getAttribute(anyString())).thenReturn(companyAccountMock);
+        when(statementTransformerMock.transform(statementMock)).thenReturn(statementEntity);
+        when(statementRepositoryMock.insert(ArgumentMatchers.any(StatementEntity.class)))
+            .thenThrow(DuplicateKeyException.class);
+
+        ResponseObject<Statement> result =
+            statementService.create(statementMock, transactionMock, "", requestMock);
+
+        assertNotNull(result);
+        assertEquals(ResponseStatus.DUPLICATE_KEY_ERROR, result.getStatus());
+        assertNull(result.getData());
+    }
+
+    @Test
+    @DisplayName("Tests the mongo exception when creating a Statement resource")
+    void shouldThrowMongoExceptionWhenCreating() throws DataException {
+        when(requestMock.getAttribute(anyString())).thenReturn(companyAccountMock);
+        when(statementTransformerMock.transform(statementMock)).thenReturn(statementEntity);
+        when(statementRepositoryMock.insert(ArgumentMatchers.any(StatementEntity.class)))
+            .thenThrow(MongoException.class);
+
+        assertThrows(DataException.class,
+            () -> statementService.create(statementMock, transactionMock, "", requestMock));
+    }
+
+    @Test
+    @DisplayName("Tests the successful update of a Statement resource")
+    void shouldUpdateStatement() throws DataException {
+        when(requestMock.getAttribute(anyString())).thenReturn(companyAccountMock);
+        when(statementTransformerMock.transform(statementMock)).thenReturn(statementEntity);
+
+        ResponseObject<Statement> result =
+            statementService.update(statementMock, transactionMock, "", requestMock);
+
+        assertNotNull(result);
+        assertEquals(ResponseStatus.UPDATED, result.getStatus());
+    }
+
+    @Test
+    @DisplayName("Tests the mongo exception when updating a Statement resource")
+    void shouldThrowMongoExceptionWhenUpdating() throws DataException {
+        when(requestMock.getAttribute(anyString())).thenReturn(companyAccountMock);
+        when(statementTransformerMock.transform(statementMock)).thenReturn(statementEntity);
+        when(statementRepositoryMock.save(ArgumentMatchers.any(StatementEntity.class)))
+            .thenThrow(MongoException.class);
+
+        assertThrows(DataException.class,
+            () -> statementService.update(statementMock, transactionMock, "", requestMock));
+    }
+
+    @Test
+    @DisplayName("Tests the successful find of an an Statement resource")
+    void shouldFindStatementResource() throws DataException {
+        when(statementRepositoryMock.findById(anyString()))
+            .thenReturn(Optional.ofNullable(statementEntity));
+
+        Statement statement = createStatement();
+        when(statementTransformerMock.transform(any(StatementEntity.class))).thenReturn(statement);
+
+        ResponseObject<Statement> result = statementService.findById(anyString(), requestMock);
+
+        assertNotNull(result);
+        assertEquals(statement, result.getData());
+        assertEquals(ResponseStatus.FOUND, result.getStatus());
+    }
+
+    @Test
+    @DisplayName("Tests the unsuccessful find of an an Statement resource")
+    void shouldNotFindStatementResource() throws DataException {
+        when(statementRepositoryMock.findById(anyString()))
+            .thenReturn(Optional.ofNullable(null));
+
+        ResponseObject<Statement> result = statementService.findById(anyString(), requestMock);
+
+        assertNotNull(result);
+        assertNull(result.getData());
+        assertEquals(ResponseStatus.NOT_FOUND, result.getStatus());
+    }
+
+    @Test
+    @DisplayName("Tests the mongo exception thrown on find a Statement resource")
+    void shouldThrowMongoExceptionWhenFindingById() throws DataException {
+        when(statementRepositoryMock.findById(anyString()))
+            .thenThrow(MongoException.class);
+
+        assertThrows(DataException.class,
+            () -> statementService.findById(anyString(), requestMock));
+    }
+
+    private StatementEntity createStatementEntity() {
+        StatementEntity statementEntity = new StatementEntity();
+        statementEntity.setId(LEGAL_STATEMENT_ID);
+        statementEntity.setData(createStatementDataEntity());
+
+        return statementEntity;
+    }
+    private Map<String, String> createLegalStatements() {
+        Map<String, String> statements = new HashMap<>();
+        statements.put(LEGAL_STATEMENT_SECTION_477_KEY, LEGAL_STATEMENT_SECTION_477);
+
+        return statements;
+    }
+
+    private StatementDataEntity createStatementDataEntity() {
+        StatementDataEntity statementDataEntity = new StatementDataEntity();
+        statementDataEntity.setEtag(ETAG);
+        statementDataEntity.setKind(Kind.SMALL_FULL_STATEMENT.getValue());
+        statementDataEntity.setLinks(createSelfLink());
+        statementDataEntity.setHasAgreedToLegalStatements(true); //TO SET real values
+        statementDataEntity.setLegalStatements(new HashMap<>()); //to set real values
+
+        return statementDataEntity;
+    }
+
+    private Map<String, String> createSelfLink() {
+        Map<String, String> selfLink = new HashMap<>();
+        selfLink
+            .put(BasicLinkType.SELF.getLink(), STATEMENT_SELF_LINK);
+        return selfLink;
+    }
+
+    private Statement createStatement() {
+        Statement statement = new Statement();
+        statement.setEtag(ETAG);
+        statement.setKind(Kind.SMALL_FULL_STATEMENT.getValue());
+        statement.setLinks(createSelfLink());
+        statement.setHasAgreedToLegalStatements(true); //TO SET real values
+        statement.setLegalStatements(new HashMap<>()); //to set real values
+
+        return statement;
+    }
+
+}


### PR DESCRIPTION
Changes to add the  Legal Statemt service. 
**Changes:** 
Add "statements" to the existing enums so that it can be used in the Statment service:
- kind
- ResourceName
- SmallFullLinkType

Add New properties , _LegalStatements.properties_ :
- This contains all the  Legal Statements that must be agreed to. By doing this, hardcode values are avoided in the Statement Service and it can be easily modified if it is needed (Removing existing or adding new statements).

Class added to load the _LegalStatements.properties_ :
- Sot that it can be used easier from the Statement Service.

Statement Service:
- Changes to add statement service and implement create, update and find.
- Logic around Legal Statements: **section_477**'s legal Statement contains an placeholder for the **period_end_on**, which is replaced by the **period_end_on** from the **Company Accounts**. 
This placeholder {period_end_on} could not be bound to any value as it gets updated in the service

Resolves: SFA-867