### PR TITLE
Corrected package naming

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/BalanceSheet.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/BalanceSheet.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.currentAssets.CurrentAssets;
+import uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.currentassets.CurrentAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
 
 public class BalanceSheet {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/currentassets/CashAtBankInHand.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/currentassets/CashAtBankInHand.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.currentAssets;
+package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.currentassets;
 
 public class CashAtBankInHand {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/currentassets/CurrentAssets.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/currentassets/CurrentAssets.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.currentAssets;
+package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.currentassets;
 
 public class CurrentAssets {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/currentassets/Debtors.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/currentassets/Debtors.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.currentAssets;
+package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.currentassets;
 
 public class Debtors {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/currentassets/Stocks.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/currentassets/Stocks.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.currentAssets;
+package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.currentassets;
 
 public class Stocks {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/fixedassets/FixedAssets.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/fixedassets/FixedAssets.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.fixedAssets;
+package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.fixedassets;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/fixedassets/TangibleAssets.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/balancesheet/fixedassets/TangibleAssets.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.fixedAssets;
+package uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.fixedassets;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -65,7 +65,7 @@ public class CurrentPeriodValidator extends BaseValidator {
             Long tangible = fixedAssets.getTangible();
             Long fixedAssetsTotal = fixedAssets.getTotal();
 
-            // Will calculate the total of all fixedAssets fields as they are added to the balance sheet
+            // Will calculate the total of all fixedassets fields as they are added to the balance sheet
             Long calculatedTotal = tangible;
 
             validateAggregateTotal(fixedAssetsTotal, calculatedTotal, FIXED_ASSETS_TOTAL_PATH, errors);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -61,7 +61,7 @@ public class PreviousPeriodValidator extends BaseValidator {
             Long tangible = fixedAssets.getTangible();
             Long fixedAssetsTotal = fixedAssets.getTotal();
 
-            // Will calculate the total of all fixedAssets fields as they are added to the balance sheet
+            // Will calculate the total of all fixedassets fields as they are added to the balance sheet
             Long calculatedTotal = tangible;
 
             validateAggregateTotal(fixedAssetsTotal, calculatedTotal, FIXED_ASSETS_TOTAL_PATH, errors);


### PR DESCRIPTION
Corrected two packages that did not comply with the Companieshouse java coding standards.

uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.current**A**ssets
uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.current**a**ssets

uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.fixed**A**ssets
uk.gov.companieshouse.api.accounts.model.ixbrl.balancesheet.fixed**a**ssets
