### PR TITLE
Capital and reserves validation corrections

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/CapitalAndReserves.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/CapitalAndReserves.java
@@ -14,6 +14,7 @@ public class CapitalAndReserves {
     private static final int MIN_RANGE_ONE = 1;
     private static final int MIN_RANGE_NEGATIVE = -99999999;
 
+    @NotNull
     @Range(min=MIN_RANGE_ONE,max=MAX_RANGE, message = "value.outside.range")
     @JsonProperty("called_up_share_capital")
     private Long calledUpShareCapital;
@@ -30,7 +31,6 @@ public class CapitalAndReserves {
     @JsonProperty("share_premium_account")
     private Long sharePremiumAccount;
 
-    @NotNull
     @JsonProperty("total_shareholders_funds")
     private Long totalShareholdersFunds;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -80,6 +80,7 @@ public class CurrentPeriodValidator extends BaseValidator {
             }
         }
     }
+
     private void validateTotalCurrentAssets(CurrentPeriod currentPeriod, Errors errors) {
 
         CurrentAssets currentAssets = currentPeriod.getBalanceSheet().getCurrentAssets();

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -12,7 +12,6 @@ import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.CapitalAndReserves;
-import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 
 /**
@@ -24,7 +23,7 @@ public class CurrentPeriodValidator extends BaseValidator {
     @Value("${shareholders.mismatch}")
     private String shareholderFundsMismatch;
 
-    @Value("${mandatory_element_missing}")
+    @Value("${mandatory.element.missing}")
     private String mandatoryElementMissing;
 
     private static final String BALANCE_SHEET_PATH = "$.current_period.balance_sheet";

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -12,6 +12,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.CapitalAndReserves;
+import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 
 /**
@@ -22,6 +23,9 @@ public class CurrentPeriodValidator extends BaseValidator {
 
     @Value("${shareholders.mismatch}")
     private String shareholderFundsMismatch;
+
+    @Value("${mandatory_element_missing}")
+    private String mandatoryElementMissing;
 
     private static final String BALANCE_SHEET_PATH = "$.current_period.balance_sheet";
     private static final String FIXED_ASSETS_PATH = BALANCE_SHEET_PATH + ".fixed_assets";
@@ -49,28 +53,33 @@ public class CurrentPeriodValidator extends BaseValidator {
 
         CapitalAndReserves capitalAndReserves = currentPeriod.getBalanceSheet().getCapitalAndReserves();
 
+        // If any capital and reserves fields are submitted then total shareholder funds cannot be null
         if (capitalAndReserves != null) {
 
-            Long calledUpShareCapital = Optional.ofNullable(capitalAndReserves.getCalledUpShareCapital()).orElse(0L);
-            Long sharePremiumAccount = Optional.ofNullable(capitalAndReserves.getSharePremiumAccount()).orElse(0L);
-            Long otherReserves = Optional.ofNullable(capitalAndReserves.getOtherReserves()).orElse(0L);
-            Long profitAndLoss = Optional.ofNullable(capitalAndReserves.getProfitAndLoss()).orElse(0L);
+            if (capitalAndReserves.getTotalShareholdersFunds() == null) {
+                addError(errors, mandatoryElementMissing, TOTAL_SHAREHOLDER_FUNDS_PATH);
+            } else {
 
-            Long totalShareholderFunds = Optional.ofNullable(capitalAndReserves.getTotalShareholdersFunds()).orElse(0L);
-            Long calculatedTotal = calledUpShareCapital + otherReserves + sharePremiumAccount + profitAndLoss;
-            validateAggregateTotal(totalShareholderFunds, calculatedTotal, TOTAL_SHAREHOLDER_FUNDS_PATH, errors);
+                // Validate calculated total equals total shareholders funds
+                Long calledUpShareCapital = Optional.ofNullable(capitalAndReserves.getCalledUpShareCapital()).orElse(0L);
+                Long sharePremiumAccount = Optional.ofNullable(capitalAndReserves.getSharePremiumAccount()).orElse(0L);
+                Long otherReserves = Optional.ofNullable(capitalAndReserves.getOtherReserves()).orElse(0L);
+                Long profitAndLoss = Optional.ofNullable(capitalAndReserves.getProfitAndLoss()).orElse(0L);
+                Long totalShareholderFunds = Optional.ofNullable(capitalAndReserves.getTotalShareholdersFunds()).orElse(0L);
+                Long calculatedTotal = calledUpShareCapital + otherReserves + sharePremiumAccount + profitAndLoss;
+                validateAggregateTotal(totalShareholderFunds, calculatedTotal, TOTAL_SHAREHOLDER_FUNDS_PATH, errors);
 
-            Long totalNetAssets = 0L;
-            // Total shareholder funds must equal total net assets
-            if (currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
-                 totalNetAssets = currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets().getTotalNetAssets();
-            }
-                    if (!totalNetAssets.equals(totalShareholderFunds)) {
-                        addError(errors, shareholderFundsMismatch, TOTAL_SHAREHOLDER_FUNDS_PATH);
-                    }
+                Long totalNetAssets = 0L;
+                // Total shareholder funds must equal total net assets
+                if (currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
+                    totalNetAssets = currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets().getTotalNetAssets();
+                }
+                if (!totalNetAssets.equals(totalShareholderFunds)) {
+                    addError(errors, shareholderFundsMismatch, TOTAL_SHAREHOLDER_FUNDS_PATH);
+                }
             }
         }
-
+    }
     private void validateTotalCurrentAssets(CurrentPeriod currentPeriod, Errors errors) {
 
         CurrentAssets currentAssets = currentPeriod.getBalanceSheet().getCurrentAssets();

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -18,7 +18,7 @@ public class PreviousPeriodValidator extends BaseValidator {
     @Value("${shareholders.mismatch}")
     private String shareholderFundsMismatch;
 
-    @Value("${mandatory_element_missing}")
+    @Value("${mandatory.element.missing}")
     private String mandatoryElementMissing;
 
     private static final String BALANCE_SHEET_PATH = "$.previous_period.balance_sheet";

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -18,6 +18,9 @@ public class PreviousPeriodValidator extends BaseValidator {
     @Value("${shareholders.mismatch}")
     private String shareholderFundsMismatch;
 
+    @Value("${mandatory_element_missing}")
+    private String mandatoryElementMissing;
+
     private static final String BALANCE_SHEET_PATH = "$.previous_period.balance_sheet";
     private static final String FIXED_ASSETS_PATH = BALANCE_SHEET_PATH + ".fixed_assets";
     private static final String FIXED_ASSETS_TOTAL_PATH = FIXED_ASSETS_PATH + ".total";
@@ -46,24 +49,29 @@ public class PreviousPeriodValidator extends BaseValidator {
     private void validateTotalShareholderFunds(PreviousPeriod previousPeriod, Errors errors) {
         CapitalAndReserves capitalAndReserves = previousPeriod.getBalanceSheet().getCapitalAndReserves();
 
+        // If any capital and reserves fields are submitted then total shareholder funds cannot be null
         if (capitalAndReserves != null) {
 
-            Long calledUpShareCapital = Optional.ofNullable(capitalAndReserves.getCalledUpShareCapital()).orElse(0L);
-            Long sharePremiumAccount = Optional.ofNullable(capitalAndReserves.getSharePremiumAccount()).orElse(0L);
-            Long otherReserves = Optional.ofNullable(capitalAndReserves.getOtherReserves()).orElse(0L);
-            Long profitAndLoss = Optional.ofNullable(capitalAndReserves.getProfitAndLoss()).orElse(0L);
+            if (capitalAndReserves.getTotalShareholdersFunds() == null) {
+                addError(errors, mandatoryElementMissing, TOTAL_SHAREHOLDER_FUNDS_PATH);
+            } else {
+                // Validate calculated total equals total shareholders funds
+                Long calledUpShareCapital = Optional.ofNullable(capitalAndReserves.getCalledUpShareCapital()).orElse(0L);
+                Long sharePremiumAccount = Optional.ofNullable(capitalAndReserves.getSharePremiumAccount()).orElse(0L);
+                Long otherReserves = Optional.ofNullable(capitalAndReserves.getOtherReserves()).orElse(0L);
+                Long profitAndLoss = Optional.ofNullable(capitalAndReserves.getProfitAndLoss()).orElse(0L);
+                Long totalShareholderFunds = Optional.ofNullable(capitalAndReserves.getTotalShareholdersFunds()).orElse(0L);
+                Long calculatedTotal = calledUpShareCapital + otherReserves + sharePremiumAccount + profitAndLoss;
+                validateAggregateTotal(totalShareholderFunds, calculatedTotal, TOTAL_SHAREHOLDER_FUNDS_PATH, errors);
 
-            Long totalShareholderFunds = Optional.ofNullable(capitalAndReserves.getTotalShareholdersFunds()).orElse(0L);
-            Long calculatedTotal = calledUpShareCapital + otherReserves + sharePremiumAccount + profitAndLoss;
-            validateAggregateTotal(totalShareholderFunds, calculatedTotal, TOTAL_SHAREHOLDER_FUNDS_PATH, errors);
-
-            Long totalNetAssets = 0L;
-            // Total shareholder funds must equal total net assets
-            if (previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
-                totalNetAssets = previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets().getTotalNetAssets();
-            }
-            if (!totalNetAssets.equals(totalShareholderFunds)) {
-                addError(errors, shareholderFundsMismatch, TOTAL_SHAREHOLDER_FUNDS_PATH);
+                Long totalNetAssets = 0L;
+                // Total shareholder funds must equal total net assets
+                if (previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
+                    totalNetAssets = previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets().getTotalNetAssets();
+                }
+                if (!totalNetAssets.equals(totalShareholderFunds)) {
+                    addError(errors, shareholderFundsMismatch, TOTAL_SHAREHOLDER_FUNDS_PATH);
+                }
             }
         }
     }

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -11,3 +11,4 @@ incorrect.total=incorrect_total
 invalid.value=invalid_value
 date.invalid=date_is_invalid
 shareholders.mismatch=shareholder_funds_mismatch
+mandatory_element_missing=mandatory_element_missing

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -11,4 +11,4 @@ incorrect.total=incorrect_total
 invalid.value=invalid_value
 date.invalid=date_is_invalid
 shareholders.mismatch=shareholder_funds_mismatch
-mandatory_element_missing=mandatory_element_missing
+mandatory.element.missing=mandatory_element_missing

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
@@ -42,7 +42,6 @@ public class CurrentPeriodValidatorTest {
         errors = new Errors();
     }
 
-
     @Test
     @DisplayName("SUCCESS - Test Balance Sheet validation with no errors")
     void validateBalanceSheet() {
@@ -66,10 +65,10 @@ public class CurrentPeriodValidatorTest {
         balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
 
         CapitalAndReserves capitalAndReserves = new CapitalAndReserves();
-        capitalAndReserves.setCalledUpShareCapital(0L);
+        capitalAndReserves.setCalledUpShareCapital(1L);
         capitalAndReserves.setOtherReserves(0L);
         capitalAndReserves.setProfitAndLoss(0L);
-        capitalAndReserves.setSharePremiumAccount(1L);
+        capitalAndReserves.setSharePremiumAccount(0L);
         capitalAndReserves.setTotalShareholdersFunds(1L);
         balanceSheet.setCapitalAndReserves(capitalAndReserves);
 
@@ -82,6 +81,7 @@ public class CurrentPeriodValidatorTest {
         Errors errors = validator.validateCurrentPeriod(currentPeriod);
 
         assertFalse(errors.hasErrors());
+
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
@@ -159,8 +159,7 @@ public class CurrentPeriodValidatorTest {
                         LocationType.JSON_PATH.getValue(),
                         ErrorType.VALIDATION.getType())));
     }
-
-
+    
     @Test
     @DisplayName("ERROR - Test validate whole current period with multiple errors")
     void validateCurrentPeriod() {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
@@ -159,7 +159,7 @@ public class CurrentPeriodValidatorTest {
                         LocationType.JSON_PATH.getValue(),
                         ErrorType.VALIDATION.getType())));
     }
-    
+
     @Test
     @DisplayName("ERROR - Test validate whole current period with multiple errors")
     void validateCurrentPeriod() {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
@@ -67,10 +67,10 @@ public class PreviousPeriodValidatorTest {
         balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
 
         CapitalAndReserves capitalAndReserves = new CapitalAndReserves();
-        capitalAndReserves.setCalledUpShareCapital(0L);
+        capitalAndReserves.setCalledUpShareCapital(1L);
         capitalAndReserves.setOtherReserves(0L);
         capitalAndReserves.setProfitAndLoss(0L);
-        capitalAndReserves.setSharePremiumAccount(1L);
+        capitalAndReserves.setSharePremiumAccount(0L);
         capitalAndReserves.setTotalShareholdersFunds(1L);
         balanceSheet.setCapitalAndReserves(capitalAndReserves);
 


### PR DESCRIPTION
Make called up share capital a mandatory field with @nonNull annotation in model
Remove @nonNull annotation from total ShareholdersFund field and add custom validators to throw mandatory element missing element IF other capital and reserves fields are provided.

SFA-908