### PR TITLE
Fix Net current assets(liabilities) and Total less assets current liabilities showing as mandatory

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/OtherLiabilitiesOrAssets.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/OtherLiabilitiesOrAssets.java
@@ -19,11 +19,9 @@ public class OtherLiabilitiesOrAssets {
     @JsonProperty("creditors_due_within_one_year")
     private Long creditorsDueWithinOneYear;
 
-    @NotNull
     @JsonProperty("net_current_assets")
     private Long netCurrentAssets;
 
-    @NotNull
     @JsonProperty("total_assets_less_current_liabilities")
     private Long totalAssetsLessCurrentLiabilities;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -79,10 +79,6 @@ public class CurrentPeriodValidator extends BaseValidator {
             calculateOtherLiabilitiesOrAssetsNetCurrentAssets(currentPeriod, errors);
             calculateOtherLiabilitiesOrAssetsTotalAssetsLessCurrentLiabilities(currentPeriod, errors);
             calculateOtherLiabilitiesOrAssetsTotalNetAssets(currentPeriod, errors);
-        }
-
-        if (currentPeriod.getBalanceSheet().getCurrentAssets() != null &&
-                currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
             checkOtherLiabilitiesAreMandatory(currentPeriod, errors);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -81,6 +81,10 @@ public class CurrentPeriodValidator extends BaseValidator {
             calculateOtherLiabilitiesOrAssetsNetCurrentAssets(currentPeriod, errors);
             calculateOtherLiabilitiesOrAssetsTotalAssetsLessCurrentLiabilities(currentPeriod, errors);
             calculateOtherLiabilitiesOrAssetsTotalNetAssets(currentPeriod,errors);
+        }
+
+        if (currentPeriod.getBalanceSheet().getCurrentAssets() != null &&
+                currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
             checkOtherLiabilitiesAreMandatory(currentPeriod, errors);
         }
     }
@@ -135,9 +139,12 @@ public class CurrentPeriodValidator extends BaseValidator {
                 otherLiabilitiesOrAssets.getPrepaymentsAndAccruedIncome() != null ||
                 otherLiabilitiesOrAssets.getCreditorsDueWithinOneYear() != null) {
 
-            if (otherLiabilitiesOrAssets.getNetCurrentAssets() == null ||
-                    otherLiabilitiesOrAssets.getTotalAssetsLessCurrentLiabilities() == null) {
+            if (otherLiabilitiesOrAssets.getNetCurrentAssets() == null) {
                 addError(errors, mandatoryElementMissing, OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH);
+            }
+
+            if (otherLiabilitiesOrAssets.getTotalAssetsLessCurrentLiabilities() == null) {
+                addError(errors, mandatoryElementMissing, OTHER_LIABILITIES_OR_ASSETS_TOTAL_ASSETS_LESS_CURRENT_LIABILITIES_PATH);
             }
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -1,15 +1,16 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
 
-import java.util.Optional;
-import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
+import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
-import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
+
+import javax.validation.Valid;
+import java.util.Optional;
 
 /**
  * Validates Current Period
@@ -25,6 +26,9 @@ public class CurrentPeriodValidator extends BaseValidator {
     private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_ASSETS_LESS_CURRENT_LIABILITIES_PATH = OTHER_LIABILITIES_OR_ASSETS_PATH + ".total_assets_less_current_liabilities";
     private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH = OTHER_LIABILITIES_OR_ASSETS_PATH + ".total_net_assets";
     private static final String CURRENT_ASSETS_TOTAL_PATH = BALANCE_SHEET_PATH + ".current_assets.total";
+
+    @Value("${javax.validation.constraints.NotNull.message}")
+    private String mandatoryElementMissing;
 
     public Errors validateCurrentPeriod(@Valid CurrentPeriod currentPeriod) {
 
@@ -77,6 +81,7 @@ public class CurrentPeriodValidator extends BaseValidator {
             calculateOtherLiabilitiesOrAssetsNetCurrentAssets(currentPeriod, errors);
             calculateOtherLiabilitiesOrAssetsTotalAssetsLessCurrentLiabilities(currentPeriod, errors);
             calculateOtherLiabilitiesOrAssetsTotalNetAssets(currentPeriod,errors);
+            checkOtherLiabilitiesAreMandatory(currentPeriod, errors);
         }
     }
     private void calculateOtherLiabilitiesOrAssetsNetCurrentAssets(CurrentPeriod currentPeriod, Errors errors) {
@@ -120,5 +125,20 @@ public class CurrentPeriodValidator extends BaseValidator {
 
         Long totalNetAssets = Optional.ofNullable(otherLiabilitiesOrAssets.getTotalNetAssets()).orElse(0L);
         validateAggregateTotal(totalNetAssets, calculatedTotal, OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH, errors);
+    }
+
+    private void checkOtherLiabilitiesAreMandatory(CurrentPeriod currentPeriod, Errors errors) {
+        CurrentAssets currentAssets = currentPeriod.getBalanceSheet().getCurrentAssets();
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets();
+
+        if (currentAssets.getTotal() != null ||
+                otherLiabilitiesOrAssets.getPrepaymentsAndAccruedIncome() != null ||
+                otherLiabilitiesOrAssets.getCreditorsDueWithinOneYear() != null) {
+
+            if (otherLiabilitiesOrAssets.getNetCurrentAssets() == null ||
+                    otherLiabilitiesOrAssets.getTotalAssetsLessCurrentLiabilities() == null) {
+                addError(errors, mandatoryElementMissing, OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH);
+            }
+        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -27,7 +27,7 @@ public class CurrentPeriodValidator extends BaseValidator {
     private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH = OTHER_LIABILITIES_OR_ASSETS_PATH + ".total_net_assets";
     private static final String CURRENT_ASSETS_TOTAL_PATH = BALANCE_SHEET_PATH + ".current_assets.total";
 
-    @Value("${javax.validation.constraints.NotNull.message}")
+    @Value("${mandatory_element_missing}")
     private String mandatoryElementMissing;
 
     public Errors validateCurrentPeriod(@Valid CurrentPeriod currentPeriod) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -27,7 +27,7 @@ public class CurrentPeriodValidator extends BaseValidator {
     private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH = OTHER_LIABILITIES_OR_ASSETS_PATH + ".total_net_assets";
     private static final String CURRENT_ASSETS_TOTAL_PATH = BALANCE_SHEET_PATH + ".current_assets.total";
 
-    @Value("${mandatory_element_missing}")
+    @Value("${mandatory.element.missing}")
     private String mandatoryElementMissing;
 
     public Errors validateCurrentPeriod(@Valid CurrentPeriod currentPeriod) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -131,7 +131,7 @@ public class CurrentPeriodValidator extends BaseValidator {
         CurrentAssets currentAssets = currentPeriod.getBalanceSheet().getCurrentAssets();
         OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets();
 
-        if (currentAssets.getTotal() != null ||
+        if (currentAssets != null ||
                 otherLiabilitiesOrAssets.getPrepaymentsAndAccruedIncome() != null ||
                 otherLiabilitiesOrAssets.getCreditorsDueWithinOneYear() != null) {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -1,16 +1,15 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
-import java.util.Optional;
-import javax.validation.Valid;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
-import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+
+import javax.validation.Valid;
+import java.util.Optional;
 
 @Component
 public class PreviousPeriodValidator extends BaseValidator {
@@ -79,6 +78,10 @@ public class PreviousPeriodValidator extends BaseValidator {
             calculateOtherLiabilitiesOrAssetsNetCurrentAssets(previousPeriod, errors);
             calculateOtherLiabilitiesOrAssetsTotalAssetsLessCurrentLiabilities(previousPeriod, errors);
             calculateOtherLiabilitiesOrAssetsTotalNetAssets(previousPeriod,errors);
+        }
+
+        if (previousPeriod.getBalanceSheet().getCurrentAssets() != null &&
+                previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
             checkOtherLiabilitiesAreMandatory(previousPeriod, errors);
         }
     }
@@ -133,9 +136,12 @@ public class PreviousPeriodValidator extends BaseValidator {
                 otherLiabilitiesOrAssets.getPrepaymentsAndAccruedIncome() != null ||
                 otherLiabilitiesOrAssets.getCreditorsDueWithinOneYear() != null) {
 
-            if (otherLiabilitiesOrAssets.getNetCurrentAssets() == null ||
-                    otherLiabilitiesOrAssets.getTotalAssetsLessCurrentLiabilities() == null) {
+            if (otherLiabilitiesOrAssets.getNetCurrentAssets() == null) {
                 addError(errors, mandatoryElementMissing, OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH);
+            }
+
+            if (otherLiabilitiesOrAssets.getTotalAssetsLessCurrentLiabilities() == null) {
+                addError(errors, mandatoryElementMissing, OTHER_LIABILITIES_OR_ASSETS_TOTAL_ASSETS_LESS_CURRENT_LIABILITIES_PATH);
             }
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -78,10 +78,6 @@ public class PreviousPeriodValidator extends BaseValidator {
             calculateOtherLiabilitiesOrAssetsNetCurrentAssets(previousPeriod, errors);
             calculateOtherLiabilitiesOrAssetsTotalAssetsLessCurrentLiabilities(previousPeriod, errors);
             calculateOtherLiabilitiesOrAssetsTotalNetAssets(previousPeriod, errors);
-        }
-
-        if (previousPeriod.getBalanceSheet().getCurrentAssets() != null &&
-                previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
             checkOtherLiabilitiesAreMandatory(previousPeriod, errors);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -23,7 +23,7 @@ public class PreviousPeriodValidator extends BaseValidator {
     private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH = OTHER_LIABILITIES_OR_ASSETS_PATH + ".total_net_assets";
     private static final String CURRENT_ASSETS_TOTAL_PATH = BALANCE_SHEET_PATH + ".current_assets.total";
 
-    @Value("${mandatory_element_missing}")
+    @Value("${mandatory.element.missing}")
     private String mandatoryElementMissing;
 
     public Errors validatePreviousPeriod(@Valid PreviousPeriod previousPeriod) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -129,7 +129,7 @@ public class PreviousPeriodValidator extends BaseValidator {
         CurrentAssets currentAssets = previousPeriod.getBalanceSheet().getCurrentAssets();
         OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets();
 
-        if (currentAssets.getTotal() != null ||
+        if (currentAssets != null ||
                 otherLiabilitiesOrAssets.getPrepaymentsAndAccruedIncome() != null ||
                 otherLiabilitiesOrAssets.getCreditorsDueWithinOneYear() != null) {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -23,7 +23,7 @@ public class PreviousPeriodValidator extends BaseValidator {
     private static final String OTHER_LIABILITIES_OR_ASSETS_TOTAL_NET_ASSETS_PATH = OTHER_LIABILITIES_OR_ASSETS_PATH + ".total_net_assets";
     private static final String CURRENT_ASSETS_TOTAL_PATH = BALANCE_SHEET_PATH + ".current_assets.total";
 
-    @Value("${javax.validation.constraints.NotNull.message}")
+    @Value("${mandatory_element_missing}")
     private String mandatoryElementMissing;
 
     public Errors validatePreviousPeriod(@Valid PreviousPeriod previousPeriod) {

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -10,4 +10,4 @@ max.length.exceeded=max_length_exceeded
 incorrect.total=incorrect_total
 invalid.value=invalid_value
 date.invalid=date_is_invalid
-mandatory_element_missing=mandatory_element_missing
+mandatory.element.missing=mandatory_element_missing

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -10,3 +10,4 @@ max.length.exceeded=max_length_exceeded
 incorrect.total=incorrect_total
 invalid.value=invalid_value
 date.invalid=date_is_invalid
+mandatory_element_missing=mandatory_element_missing

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
@@ -164,6 +164,39 @@ public class CurrentPeriodValidatorTest {
     }
 
     @Test
+    @DisplayName("ERROR - Mandatory elements missing for NetCurrentAssets and TotalAssetsLessCurrentLiabilities")
+    void validateMissingField() {
+        CurrentAssets currentAssets = new CurrentAssets();
+        currentAssets.setTotal(3L);
+        balanceSheet.setCurrentAssets(currentAssets);
+
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
+        otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
+        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
+        otherLiabilitiesOrAssets.setCreditorsAfterOneYear(1L);
+        otherLiabilitiesOrAssets.setProvisionForLiabilities(1L);
+        otherLiabilitiesOrAssets.setAccrualsAndDeferredIncome(1L);
+        otherLiabilitiesOrAssets.setTotalNetAssets(1L);
+        balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
+
+        FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setTangible(2L);
+        fixedAssets.setTotal(2L);
+        balanceSheet.setFixedAssets(fixedAssets);
+
+        currentPeriod.setBalanceSheet(balanceSheet);
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+        ReflectionTestUtils.setField(validator, "mandatoryElementMissing", "mandatory_element_missing");
+
+        Errors errors = validator.validateCurrentPeriod(currentPeriod);
+
+        assertTrue(errors.containsError(
+                new Error("mandatory_element_missing", OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH,
+                        LocationType.JSON_PATH.getValue(),
+                        ErrorType.VALIDATION.getType())));
+    }
+
+    @Test
     @DisplayName("Test incorrect total current assets validation")
     public void validateTotalCurrentAssets() {
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
@@ -97,6 +97,7 @@ public class CurrentPeriodValidatorTest {
         currentPeriod.setBalanceSheet(balanceSheet);
 
         ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+        ReflectionTestUtils.setField(validator, "mandatoryElementMissing", "mandatory_element_missing");
 
 
         Errors errors = validator.validateCurrentPeriod(currentPeriod);
@@ -172,6 +173,34 @@ public class CurrentPeriodValidatorTest {
 
         OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
         otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
+        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
+        otherLiabilitiesOrAssets.setCreditorsAfterOneYear(1L);
+        otherLiabilitiesOrAssets.setProvisionForLiabilities(1L);
+        otherLiabilitiesOrAssets.setAccrualsAndDeferredIncome(1L);
+        otherLiabilitiesOrAssets.setTotalNetAssets(1L);
+        balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
+
+        FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setTangible(2L);
+        fixedAssets.setTotal(2L);
+        balanceSheet.setFixedAssets(fixedAssets);
+
+        currentPeriod.setBalanceSheet(balanceSheet);
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+        ReflectionTestUtils.setField(validator, "mandatoryElementMissing", "mandatory_element_missing");
+
+        Errors errors = validator.validateCurrentPeriod(currentPeriod);
+
+        assertTrue(errors.containsError(
+                new Error("mandatory_element_missing", OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH,
+                        LocationType.JSON_PATH.getValue(),
+                        ErrorType.VALIDATION.getType())));
+    }
+
+    @Test
+    @DisplayName("ERROR - Mandatory elements missing with Current Assets Null for NetCurrentAssets and TotalAssetsLessCurrentLiabilities")
+    void validateMissingFieldCurrentAssetsNull() {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
         otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
         otherLiabilitiesOrAssets.setCreditorsAfterOneYear(1L);
         otherLiabilitiesOrAssets.setProvisionForLiabilities(1L);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
@@ -100,6 +100,7 @@ public class PreviousPeriodValidatorTest {
         previousPeriod.setBalanceSheet(balanceSheet);
 
         ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+        ReflectionTestUtils.setField(validator, "mandatoryElementMissing", "mandatory_element_missing");
         
         Errors errors =  validator.validatePreviousPeriod(previousPeriod);
 
@@ -172,6 +173,34 @@ public class PreviousPeriodValidatorTest {
 
         OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
         otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
+        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
+        otherLiabilitiesOrAssets.setCreditorsAfterOneYear(1L);
+        otherLiabilitiesOrAssets.setProvisionForLiabilities(1L);
+        otherLiabilitiesOrAssets.setAccrualsAndDeferredIncome(1L);
+        otherLiabilitiesOrAssets.setTotalNetAssets(1L);
+        balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
+
+        FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setTangible(2L);
+        fixedAssets.setTotal(2L);
+        balanceSheet.setFixedAssets(fixedAssets);
+
+        previousPeriod.setBalanceSheet(balanceSheet);
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+        ReflectionTestUtils.setField(validator, "mandatoryElementMissing", "mandatory_element_missing");
+
+        Errors errors = validator.validatePreviousPeriod(previousPeriod);
+
+        assertTrue(errors.containsError(
+                new Error("mandatory_element_missing", OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH,
+                        LocationType.JSON_PATH.getValue(),
+                        ErrorType.VALIDATION.getType())));
+    }
+
+    @Test
+    @DisplayName("ERROR - Mandatory elements missing with Current Assets Null for NetCurrentAssets and TotalAssetsLessCurrentLiabilities")
+    void validateMissingFieldCurrentAssetsNull() {
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
         otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
         otherLiabilitiesOrAssets.setCreditorsAfterOneYear(1L);
         otherLiabilitiesOrAssets.setProvisionForLiabilities(1L);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
@@ -164,6 +164,39 @@ public class PreviousPeriodValidatorTest {
     }
 
     @Test
+    @DisplayName("ERROR - Mandatory elements missing for NetCurrentAssets and TotalAssetsLessCurrentLiabilities")
+    void validateMissingField() {
+        CurrentAssets currentAssets = new CurrentAssets();
+        currentAssets.setTotal(3L);
+        balanceSheet.setCurrentAssets(currentAssets);
+
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssets();
+        otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
+        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(2L);
+        otherLiabilitiesOrAssets.setCreditorsAfterOneYear(1L);
+        otherLiabilitiesOrAssets.setProvisionForLiabilities(1L);
+        otherLiabilitiesOrAssets.setAccrualsAndDeferredIncome(1L);
+        otherLiabilitiesOrAssets.setTotalNetAssets(1L);
+        balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
+
+        FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setTangible(2L);
+        fixedAssets.setTotal(2L);
+        balanceSheet.setFixedAssets(fixedAssets);
+
+        previousPeriod.setBalanceSheet(balanceSheet);
+        ReflectionTestUtils.setField(validator, "incorrectTotal", "incorrect_total");
+        ReflectionTestUtils.setField(validator, "mandatoryElementMissing", "mandatory_element_missing");
+
+        Errors errors = validator.validatePreviousPeriod(previousPeriod);
+
+        assertTrue(errors.containsError(
+                new Error("mandatory_element_missing", OTHER_LIABILITIES_OR_ASSETS_NET_CURRENT_ASSETS_PATH,
+                        LocationType.JSON_PATH.getValue(),
+                        ErrorType.VALIDATION.getType())));
+    }
+
+    @Test
     @DisplayName("Test incorrect total current assets validation")
     public void validateTotalCurrentAssets() {
 


### PR DESCRIPTION
Net current assets and Total less assets current liabilities are only mandatory when:
- CurrentAssets Total is not null
- Preprayments and accrued income is not null
- Creditors due within one year is not null

**Resolves**: SFA-904