### PR TITLE
Correct capital and reserves error messages

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/BalanceSheet.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/BalanceSheet.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.Range;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 @JsonInclude(Include.NON_NULL)
 public class BalanceSheet {
@@ -30,6 +31,7 @@ public class BalanceSheet {
     private CurrentAssets currentAssets;
 
     @Valid
+    @NotNull
     @JsonProperty("capital_and_reserves")
     private CapitalAndReserves capitalAndReserves;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/CapitalAndReserves.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/CapitalAndReserves.java
@@ -31,6 +31,7 @@ public class CapitalAndReserves {
     @JsonProperty("share_premium_account")
     private Long sharePremiumAccount;
 
+    @NotNull
     @JsonProperty("total_shareholders_funds")
     private Long totalShareholdersFunds;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -1,16 +1,12 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
-import java.util.Optional;
-import javax.validation.Valid;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
-import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
-import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
-import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
-import uk.gov.companieshouse.api.accounts.model.rest.CapitalAndReserves;
+import uk.gov.companieshouse.api.accounts.model.rest.*;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+
+import javax.validation.Valid;
+import java.util.Optional;
 
 /**
  * Validates Current Period
@@ -54,27 +50,22 @@ public class CurrentPeriodValidator extends BaseValidator {
         // If any capital and reserves fields are submitted then total shareholder funds cannot be null
         if (capitalAndReserves != null) {
 
-            if (capitalAndReserves.getTotalShareholdersFunds() == null) {
-                addError(errors, mandatoryElementMissing, TOTAL_SHAREHOLDER_FUNDS_PATH);
-            } else {
+            // Validate calculated total equals total shareholders funds
+            Long calledUpShareCapital = Optional.ofNullable(capitalAndReserves.getCalledUpShareCapital()).orElse(0L);
+            Long sharePremiumAccount = Optional.ofNullable(capitalAndReserves.getSharePremiumAccount()).orElse(0L);
+            Long otherReserves = Optional.ofNullable(capitalAndReserves.getOtherReserves()).orElse(0L);
+            Long profitAndLoss = Optional.ofNullable(capitalAndReserves.getProfitAndLoss()).orElse(0L);
+            Long totalShareholderFunds = Optional.ofNullable(capitalAndReserves.getTotalShareholdersFunds()).orElse(0L);
+            Long calculatedTotal = calledUpShareCapital + otherReserves + sharePremiumAccount + profitAndLoss;
+            validateAggregateTotal(totalShareholderFunds, calculatedTotal, TOTAL_SHAREHOLDER_FUNDS_PATH, errors);
 
-                // Validate calculated total equals total shareholders funds
-                Long calledUpShareCapital = Optional.ofNullable(capitalAndReserves.getCalledUpShareCapital()).orElse(0L);
-                Long sharePremiumAccount = Optional.ofNullable(capitalAndReserves.getSharePremiumAccount()).orElse(0L);
-                Long otherReserves = Optional.ofNullable(capitalAndReserves.getOtherReserves()).orElse(0L);
-                Long profitAndLoss = Optional.ofNullable(capitalAndReserves.getProfitAndLoss()).orElse(0L);
-                Long totalShareholderFunds = Optional.ofNullable(capitalAndReserves.getTotalShareholdersFunds()).orElse(0L);
-                Long calculatedTotal = calledUpShareCapital + otherReserves + sharePremiumAccount + profitAndLoss;
-                validateAggregateTotal(totalShareholderFunds, calculatedTotal, TOTAL_SHAREHOLDER_FUNDS_PATH, errors);
-
-                Long totalNetAssets = 0L;
-                // Total shareholder funds must equal total net assets
-                if (currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
-                    totalNetAssets = currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets().getTotalNetAssets();
-                }
-                if (!totalNetAssets.equals(totalShareholderFunds)) {
-                    addError(errors, shareholderFundsMismatch, TOTAL_SHAREHOLDER_FUNDS_PATH);
-                }
+            Long totalNetAssets = 0L;
+            // Total shareholder funds must equal total net assets
+            if (currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
+                totalNetAssets = currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets().getTotalNetAssets();
+            }
+            if (!totalNetAssets.equals(totalShareholderFunds)) {
+                addError(errors, shareholderFundsMismatch, TOTAL_SHAREHOLDER_FUNDS_PATH);
             }
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -2,7 +2,11 @@ package uk.gov.companieshouse.api.accounts.validation;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.api.accounts.model.rest.*;
+import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
+import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
+import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
+import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
+import uk.gov.companieshouse.api.accounts.model.rest.CapitalAndReserves;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 
 import javax.validation.Valid;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -2,7 +2,11 @@ package uk.gov.companieshouse.api.accounts.validation;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.api.accounts.model.rest.*;
+import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
+import uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod;
+import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
+import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
+import uk.gov.companieshouse.api.accounts.model.rest.CapitalAndReserves;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 
 import javax.validation.Valid;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -1,16 +1,12 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
-import java.util.Optional;
-import javax.validation.Valid;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
-import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
-import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
-import uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod;
-import uk.gov.companieshouse.api.accounts.model.rest.CapitalAndReserves;
+import uk.gov.companieshouse.api.accounts.model.rest.*;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+
+import javax.validation.Valid;
+import java.util.Optional;
 
 @Component
 public class PreviousPeriodValidator extends BaseValidator {
@@ -52,26 +48,22 @@ public class PreviousPeriodValidator extends BaseValidator {
         // If any capital and reserves fields are submitted then total shareholder funds cannot be null
         if (capitalAndReserves != null) {
 
-            if (capitalAndReserves.getTotalShareholdersFunds() == null) {
-                addError(errors, mandatoryElementMissing, TOTAL_SHAREHOLDER_FUNDS_PATH);
-            } else {
-                // Validate calculated total equals total shareholders funds
-                Long calledUpShareCapital = Optional.ofNullable(capitalAndReserves.getCalledUpShareCapital()).orElse(0L);
-                Long sharePremiumAccount = Optional.ofNullable(capitalAndReserves.getSharePremiumAccount()).orElse(0L);
-                Long otherReserves = Optional.ofNullable(capitalAndReserves.getOtherReserves()).orElse(0L);
-                Long profitAndLoss = Optional.ofNullable(capitalAndReserves.getProfitAndLoss()).orElse(0L);
-                Long totalShareholderFunds = Optional.ofNullable(capitalAndReserves.getTotalShareholdersFunds()).orElse(0L);
-                Long calculatedTotal = calledUpShareCapital + otherReserves + sharePremiumAccount + profitAndLoss;
-                validateAggregateTotal(totalShareholderFunds, calculatedTotal, TOTAL_SHAREHOLDER_FUNDS_PATH, errors);
+            // Validate calculated total equals total shareholders funds
+            Long calledUpShareCapital = Optional.ofNullable(capitalAndReserves.getCalledUpShareCapital()).orElse(0L);
+            Long sharePremiumAccount = Optional.ofNullable(capitalAndReserves.getSharePremiumAccount()).orElse(0L);
+            Long otherReserves = Optional.ofNullable(capitalAndReserves.getOtherReserves()).orElse(0L);
+            Long profitAndLoss = Optional.ofNullable(capitalAndReserves.getProfitAndLoss()).orElse(0L);
+            Long totalShareholderFunds = Optional.ofNullable(capitalAndReserves.getTotalShareholdersFunds()).orElse(0L);
+            Long calculatedTotal = calledUpShareCapital + otherReserves + sharePremiumAccount + profitAndLoss;
+            validateAggregateTotal(totalShareholderFunds, calculatedTotal, TOTAL_SHAREHOLDER_FUNDS_PATH, errors);
 
-                Long totalNetAssets = 0L;
-                // Total shareholder funds must equal total net assets
-                if (previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
-                    totalNetAssets = previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets().getTotalNetAssets();
-                }
-                if (!totalNetAssets.equals(totalShareholderFunds)) {
-                    addError(errors, shareholderFundsMismatch, TOTAL_SHAREHOLDER_FUNDS_PATH);
-                }
+            Long totalNetAssets = 0L;
+            // Total shareholder funds must equal total net assets
+            if (previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
+                totalNetAssets = previousPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets().getTotalNetAssets();
+            }
+            if (!totalNetAssets.equals(totalShareholderFunds)) {
+                addError(errors, shareholderFundsMismatch, TOTAL_SHAREHOLDER_FUNDS_PATH);
             }
         }
     }


### PR DESCRIPTION
- make capital and reserves object mandatory
- make total-shareholders-funds mandatory as well as called up share capital fields

If balance sheet is empty, error should be thrown for missing capital and reserves object
If capital and reserves is empty - error should be thrown for missing called up share capital AND total shareholders fields

SFA-948

<img width="942" alt="screen shot 2018-11-29 at 16 03 24" src="https://user-images.githubusercontent.com/15984133/49235045-12a0dc00-f3f1-11e8-9131-9ffaf02e39a7.png">
<img width="949" alt="screen shot 2018-11-29 at 16 02 37" src="https://user-images.githubusercontent.com/15984133/49235057-16ccf980-f3f1-11e8-85f9-8be8d8a18537.png">
<img width="958" alt="screen shot 2018-11-29 at 16 01 06" src="https://user-images.githubusercontent.com/15984133/49235066-1cc2da80-f3f1-11e8-84d2-edc415781f87.png">
<img width="958" alt="screen shot 2018-11-29 at 16 00 26" src="https://user-images.githubusercontent.com/15984133/49235078-22b8bb80-f3f1-11e8-86a6-35483a255d2c.png">
