### PR TITLE
Adding document generator model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <jackson-datatype-jsr310.version>2.9.6</jackson-datatype-jsr310.version>
     <spring-test.version>5.0.8.RELEASE</spring-test.version>
     <hibernate-validator.version>6.0.13.Final</hibernate-validator.version>
+    <gson.version>2.8.0</gson.version>
 
     <!-- Maven and Surefire plugins -->
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
@@ -118,12 +119,15 @@
       <artifactId>hibernate-validator</artifactId>
       <version>${hibernate-validator.version}</version>
     </dependency>
-
-
     <dependency>
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>company-accounts-library</artifactId>
       <version>${company-accounts-library.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
     </dependency>
 
     <!-- Test -->

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/documentgenerator/DocumentGeneratorRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/documentgenerator/DocumentGeneratorRequest.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.api.accounts.model.ixbrl.documentgenerator;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.Gson;
+
+public class DocumentGeneratorRequest {
+
+    @JsonProperty("resource_uri")
+    private String resourceUri;
+
+    @JsonProperty("resource_id")
+    private String resourceID;
+
+    @JsonProperty("mime_type")
+    private String mimeType;
+
+    @JsonProperty("document_type")
+    private String documentType;
+
+    public String getResourceUri() {
+        return resourceUri;
+    }
+
+    public void setResourceUri(String resourceUri) {
+        this.resourceUri = resourceUri;
+    }
+
+    public String getResourceID() {
+        return resourceID;
+    }
+
+    public void setResourceID(String resourceID) {
+        this.resourceID = resourceID;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    public String getDocumentType() {
+        return documentType;
+    }
+
+    public void setDocumentType(String documentType) {
+        this.documentType = documentType;
+    }
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(this);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/documentgenerator/DocumentGeneratorResponse.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/documentgenerator/DocumentGeneratorResponse.java
@@ -1,0 +1,68 @@
+package uk.gov.companieshouse.api.accounts.model.ixbrl.documentgenerator;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.Gson;
+import java.util.Map;
+
+public class DocumentGeneratorResponse {
+
+    @JsonProperty("links")
+    private Links links;
+
+    @JsonProperty("size")
+    private String size;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("description_identifier")
+    private String descriptionIdentifier;
+
+    @JsonProperty("description_values")
+    private Map<String, String> descriptionValues;
+
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public String getSize() {
+        return size;
+    }
+
+    public void setSize(String size) {
+        this.size = size;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDescriptionIdentifier() {
+        return descriptionIdentifier;
+    }
+
+    public void setDescriptionIdentifier(String descriptionIdentifier) {
+        this.descriptionIdentifier = descriptionIdentifier;
+    }
+
+    public Map<String, String> getDescriptionValues() {
+        return descriptionValues;
+    }
+
+    public void setDescriptionValues(Map<String, String> descriptionValues) {
+        this.descriptionValues = descriptionValues;
+    }
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(this);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/documentgenerator/Links.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/ixbrl/documentgenerator/Links.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.api.accounts.model.ixbrl.documentgenerator;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Links {
+
+    @JsonProperty("location")
+    private String location;
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+}


### PR DESCRIPTION

Code changes to add the `doc. generator model` that will be used by the `Filing Generator` when calling the new Doc. Generator end point

Resolve: SFA-595