### PR TITLE
Add parent transaction link to company accounts resource

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/links/CompanyAccountLinkType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/links/CompanyAccountLinkType.java
@@ -3,7 +3,8 @@ package uk.gov.companieshouse.api.accounts.links;
 public enum CompanyAccountLinkType implements LinkType {
 
     SELF("self"),
-    SMALL_FULL("small_full_accounts");
+    SMALL_FULL("small_full_accounts"),
+    TRANSACTION("transaction");
 
     private String link;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
@@ -37,8 +37,6 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
     private static final Logger LOGGER = LoggerFactory
         .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
 
-    private static final String TRANSACTION_PATH = "/transactions";
-
     @Autowired
     private TransactionManager transactionManager;
     @Autowired

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
@@ -56,7 +56,7 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
         String companyAccountLink = createSelfLink(transaction, id);
         companyAccount.setKind(Kind.COMPANY_ACCOUNTS.getValue());
         addEtag(companyAccount);
-        addLinks(companyAccount, companyAccountLink, transaction.getId());
+        addLinks(companyAccount, companyAccountLink, transaction);
 
         CompanyAccountEntity companyAccountEntity = companyAccountTransformer
             .transform(companyAccount);
@@ -104,10 +104,10 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
         companyAccountRepository.save(companyAccountEntity);
     }
 
-    private void addLinks(CompanyAccount companyAccount, String companyAccountLink, String transactionId) {
+    private void addLinks(CompanyAccount companyAccount, String companyAccountLink, Transaction transaction) {
         Map<String, String> map = new HashMap<>();
         map.put(CompanyAccountLinkType.SELF.getLink(), companyAccountLink);
-        map.put(CompanyAccountLinkType.TRANSACTION.getLink(), TRANSACTION_PATH + "/" + transactionId);
+        map.put(CompanyAccountLinkType.TRANSACTION.getLink(), getTransactionSelfLink(transaction));
         companyAccount.setLinks(map);
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
@@ -36,6 +36,8 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
 
     private static final Logger LOGGER = LoggerFactory
         .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
+
+    private static final String TRANSACTION_PATH = "/transactions";
     @Autowired
     private TransactionManager transactionManager;
     @Autowired
@@ -54,7 +56,7 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
         String companyAccountLink = createSelfLink(transaction, id);
         companyAccount.setKind(Kind.COMPANY_ACCOUNTS.getValue());
         addEtag(companyAccount);
-        addLinks(companyAccount, companyAccountLink);
+        addLinks(companyAccount, companyAccountLink, transaction.getId());
 
         CompanyAccountEntity companyAccountEntity = companyAccountTransformer
             .transform(companyAccount);
@@ -102,9 +104,10 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
         companyAccountRepository.save(companyAccountEntity);
     }
 
-    private void addLinks(CompanyAccount companyAccount, String companyAccountLink) {
+    private void addLinks(CompanyAccount companyAccount, String companyAccountLink, String transactionId) {
         Map<String, String> map = new HashMap<>();
         map.put(CompanyAccountLinkType.SELF.getLink(), companyAccountLink);
+        map.put(CompanyAccountLinkType.TRANSACTION.getLink(), TRANSACTION_PATH + "/" + transactionId);
         companyAccount.setLinks(map);
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
@@ -38,6 +38,7 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
         .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
 
     private static final String TRANSACTION_PATH = "/transactions";
+
     @Autowired
     private TransactionManager transactionManager;
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
@@ -47,6 +47,10 @@ import uk.gov.companieshouse.api.accounts.transformer.CompanyAccountTransformer;
 @TestInstance(Lifecycle.PER_CLASS)
 public class CompanyAccountServiceImplTest {
 
+    private static final String SELF_LINK = "self";
+    private static final String TRANSACTION_LINK = "transaction";
+    private static final String MOCK_TRANSACTION_SELF_LINK = "selfLinkTest";
+
     @InjectMocks
     private CompanyAccountServiceImpl companyAccountService;
 
@@ -68,10 +72,6 @@ public class CompanyAccountServiceImplTest {
     @Mock
     private TransactionManager transactionManagerMock;
 
-    private static final String SELF_LINK = "self";
-    private static final String TRANSACTION_LINK = "transaction";
-    private static final String MOCK_TRANSACTION_SELF_LINK = "selfLinkTest";
-
     @Test
     @DisplayName("Tests the successful creation of an company account resource")
     void createAccountWithSuccess() throws DataException, PatchException {
@@ -86,7 +86,7 @@ public class CompanyAccountServiceImplTest {
 
         ArgumentCaptor<CompanyAccount> companyAccountArgument = ArgumentCaptor.forClass(CompanyAccount.class);
         verify(companyAccountTransformer).transform(companyAccountArgument.capture());
-        
+
         assertNotNull(companyAccountArgument.getValue().getLinks().get(SELF_LINK));
         assertNotNull(companyAccountArgument.getValue().getLinks().get(TRANSACTION_LINK));
         assertEquals(MOCK_TRANSACTION_SELF_LINK, companyAccountArgument.getValue().getLinks().get(TRANSACTION_LINK));

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -67,14 +68,28 @@ public class CompanyAccountServiceImplTest {
     @Mock
     private TransactionManager transactionManagerMock;
 
+    private static final String SELF_LINK = "self";
+    private static final String TRANSACTION_LINK = "transaction";
+
     @Test
     @DisplayName("Tests the successful creation of an company account resource")
     void createAccountWithSuccess() throws DataException, PatchException {
         doReturn(companyAccountEntityMock).when(companyAccountTransformer).transform(any(CompanyAccount.class));
 
-        ResponseObject response = companyAccountService.create(companyAccountMock, createDummyTransaction(TransactionStatus.OPEN), request);
+        CompanyAccount companyAccount = new CompanyAccount();
+
+        ResponseObject response = companyAccountService.create(companyAccount, createDummyTransaction(TransactionStatus.OPEN), request);
+
         assertNotNull(response);
         assertNotNull(response.getData());
+
+        ArgumentCaptor<CompanyAccount> companyAccountArgument = ArgumentCaptor.forClass(CompanyAccount.class);
+        verify(companyAccountTransformer).transform(companyAccountArgument.capture());
+        
+        assertNotNull(companyAccountArgument.getValue().getLinks().get(SELF_LINK));
+        assertNotNull(companyAccountArgument.getValue().getLinks().get(TRANSACTION_LINK));
+        assertEquals("/transactions/id", companyAccountArgument.getValue().getLinks().get(TRANSACTION_LINK));
+
         verify(companyAccountRepository).insert(companyAccountEntityMock);
     }
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
@@ -70,6 +70,7 @@ public class CompanyAccountServiceImplTest {
 
     private static final String SELF_LINK = "self";
     private static final String TRANSACTION_LINK = "transaction";
+    private static final String MOCK_TRANSACTION_SELF_LINK = "selfLinkTest";
 
     @Test
     @DisplayName("Tests the successful creation of an company account resource")
@@ -88,7 +89,7 @@ public class CompanyAccountServiceImplTest {
         
         assertNotNull(companyAccountArgument.getValue().getLinks().get(SELF_LINK));
         assertNotNull(companyAccountArgument.getValue().getLinks().get(TRANSACTION_LINK));
-        assertEquals("/transactions/id", companyAccountArgument.getValue().getLinks().get(TRANSACTION_LINK));
+        assertEquals(MOCK_TRANSACTION_SELF_LINK, companyAccountArgument.getValue().getLinks().get(TRANSACTION_LINK));
 
         verify(companyAccountRepository).insert(companyAccountEntityMock);
     }
@@ -160,7 +161,7 @@ public class CompanyAccountServiceImplTest {
      */
     private Map<String, String> createLinksMap() {
         Map<String, String> links = new HashMap<>();
-        links.put(CompanyAccountLinkType.SELF.getLink(), "selfLinkTest");
+        links.put(CompanyAccountLinkType.SELF.getLink(), MOCK_TRANSACTION_SELF_LINK);
         return links;
     }
 }


### PR DESCRIPTION
To support the [document generation changes being made](https://github.com/companieshouse/document-generator/pull/72) for small-full accounts, this change introduces a parent transaction link to the company accounts resource.