### PR TITLE
Adding Authorization header to the doc. generator call

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
@@ -116,23 +116,30 @@ public class FilingServiceImpl implements FilingService {
      */
     private DocumentGeneratorResponse getDocumentGeneratorResponse(CompanyAccount companyAccount) {
 
+        Map<String, Object> logMap = new HashMap<>();
+
         String companyAccountsURI =
             companyAccount.getLinks().get(CompanyAccountLinkType.SELF.getLink());
 
-        DocumentGeneratorResponse documentGeneratorResponse = documentGeneratorCaller
-            .callDocumentGeneratorService(companyAccountsURI);
+        try {
+            DocumentGeneratorResponse documentGeneratorResponse = documentGeneratorCaller
+                .callDocumentGeneratorService(companyAccountsURI);
 
-        if (documentGeneratorResponse != null) {
-            return documentGeneratorResponse;
+            if (documentGeneratorResponse != null) {
+                return documentGeneratorResponse;
+            }
+            logMap.put("company_account_self_link", companyAccountsURI);
+            logMap.put(LOG_MESSAGE_KEY, "Document generator response call has returned null");
+            LOGGER.error("FilingServiceImpl: Document Generator call failed", logMap);
+
+            return null;
+
+        } catch (IllegalArgumentException e) {
+            logMap.put(LOG_MESSAGE_KEY, "Document Generator has thrown an Illegal exception");
+            LOGGER.error("FilingServiceImpl: Document Generator call failed", e, logMap);
+
+            return null;
         }
-
-        Map<String, Object> logMap = new HashMap<>();
-        logMap.put("company_account_self_link", companyAccountsURI);
-        logMap.put(LOG_MESSAGE_KEY, "Document generator response call has returned null");
-
-        LOGGER.error("FilingServiceImpl: Document Generator call failed", logMap);
-
-        return null;
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/ixbrl/DocumentGeneratorCaller.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/ixbrl/DocumentGeneratorCaller.java
@@ -58,9 +58,8 @@ public class DocumentGeneratorCaller {
             LOGGER.info("DocumentGeneratorCaller: Calling the document generator");
 
             ResponseEntity<DocumentGeneratorResponse> response =
-                restTemplate.exchange(
+                restTemplate.postForEntity(
                     getDocumentGeneratorURL(),
-                    HttpMethod.POST,
                     createHttpEntity(accountsResourceUri),
                     DocumentGeneratorResponse.class);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImplTest.java
@@ -4,6 +4,7 @@ package uk.gov.companieshouse.api.accounts.service.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
@@ -147,6 +148,22 @@ class FilingServiceImplTest {
 
         verifyDocumentGeneratorCallerMock();
         verifyDocumentGeneratorResponseValidatorMock();
+        assertNull(filing);
+    }
+
+    @Test
+    @DisplayName("Tests the filing not generated when document generator call throws an exception")
+    void shouldNotGenerateFilingAsDocumentGeneratorCallThrowsAnException() {
+
+        documentGeneratorResponse = createDocumentGeneratorResponse();
+
+        doThrow(IllegalArgumentException.class)
+            .when(documentGeneratorCallerMock)
+            .callDocumentGeneratorService(ACCOUNTS_SELF_REF);
+
+        Filing filing = filingService.generateAccountFiling(transaction, companyAccount);
+
+        verifyDocumentGeneratorCallerMock();
         assertNull(filing);
     }
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/ixbrl/DocumentGeneratorCallerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/ixbrl/DocumentGeneratorCallerTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClientException;
@@ -65,8 +64,7 @@ class DocumentGeneratorCallerTest {
 
         doReturn(createDocumentGeneratorResponseEntity(HttpStatus.CREATED))
             .when(restTemplateMock)
-            .exchange(anyString(),
-                any(HttpMethod.class),
+            .postForEntity(anyString(),
                 any(HttpEntity.class),
                 eq(DocumentGeneratorResponse.class));
 
@@ -85,8 +83,7 @@ class DocumentGeneratorCallerTest {
 
         doReturn(createDocumentGeneratorResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR))
             .when(restTemplateMock)
-            .exchange(anyString(),
-                any(HttpMethod.class),
+            .postForEntity(anyString(),
                 any(HttpEntity.class),
                 eq(DocumentGeneratorResponse.class));
 
@@ -98,14 +95,13 @@ class DocumentGeneratorCallerTest {
     }
 
     @Test
-    @DisplayName("Document Generator Caller fails to generate the DocumentGeneratorResponse. An exception is thrown")
+    @DisplayName("Document Generator Caller fails to generate the DocumentGeneratorResponse. An RestClientException is thrown")
     void shouldNotGenerateDocumentGeneratorResponseDocumentGeneratorThrowsException() {
 
         mockTransactionServiceProperties(API_KEY_VALUE);
 
         when(restTemplateMock
-            .exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class),
-                eq(DocumentGeneratorResponse.class)))
+            .postForEntity(anyString(), any(HttpEntity.class), eq(DocumentGeneratorResponse.class)))
             .thenThrow(RestClientException.class);
 
         DocumentGeneratorResponse response = documentGeneratorCaller
@@ -116,7 +112,7 @@ class DocumentGeneratorCallerTest {
     }
 
     @Test
-    @DisplayName("Document Generator Caller fails when api key has not been set. Exception thrown")
+    @DisplayName("Document Generator Caller fails when api key has not been set. IllegalArgumentException thrown")
     void shouldGenerateDocumentGeneratorThrowAnExceptionAsApiKeyNotSet() {
 
         mockTransactionServiceProperties("");
@@ -133,8 +129,7 @@ class DocumentGeneratorCallerTest {
      */
     private void verifyRestTemplateMockNumOfCalls() {
         verify(restTemplateMock, times(1))
-            .exchange(anyString(),
-                any(HttpMethod.class),
+            .postForEntity(anyString(),
                 any(HttpEntity.class),
                 eq(DocumentGeneratorResponse.class));
     }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/ixbrl/DocumentGeneratorCallerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/ixbrl/DocumentGeneratorCallerTest.java
@@ -61,7 +61,7 @@ class DocumentGeneratorCallerTest {
     @DisplayName("Document Generator Caller generates the DocumentGeneratorResponse successfully. Correct status code returned")
     void shouldGenerateDocumentGeneratorResponseCallDocumentGeneratorIsSuccessful() {
 
-        when(transactionServicePropertiesMock.getApiKey()).thenReturn(API_KEY_VALUE);
+        mockTransactionServiceProperties(API_KEY_VALUE);
 
         doReturn(createDocumentGeneratorResponseEntity(HttpStatus.CREATED))
             .when(restTemplateMock)
@@ -81,7 +81,7 @@ class DocumentGeneratorCallerTest {
     @DisplayName("Document Generator Caller fails to generate the DocumentGeneratorResponse. Wrong status code returned")
     void shouldNotGenerateDocumentGeneratorResponseCallDocumentGeneratorIsUnsuccessful() {
 
-        when(transactionServicePropertiesMock.getApiKey()).thenReturn(API_KEY_VALUE);
+        mockTransactionServiceProperties(API_KEY_VALUE);
 
         doReturn(createDocumentGeneratorResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR))
             .when(restTemplateMock)
@@ -101,7 +101,7 @@ class DocumentGeneratorCallerTest {
     @DisplayName("Document Generator Caller fails to generate the DocumentGeneratorResponse. An exception is thrown")
     void shouldNotGenerateDocumentGeneratorResponseDocumentGeneratorThrowsException() {
 
-        when(transactionServicePropertiesMock.getApiKey()).thenReturn(API_KEY_VALUE);
+        mockTransactionServiceProperties(API_KEY_VALUE);
 
         when(restTemplateMock
             .exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class),
@@ -119,9 +119,13 @@ class DocumentGeneratorCallerTest {
     @DisplayName("Document Generator Caller fails when api key has not been set. Exception thrown")
     void shouldGenerateDocumentGeneratorThrowAnExceptionAsApiKeyNotSet() {
 
-        when(transactionServicePropertiesMock.getApiKey()).thenReturn("");
+        mockTransactionServiceProperties("");
         assertThrows(IllegalArgumentException.class,
             () -> documentGeneratorCaller.callDocumentGeneratorService(ACCOUNTS_RESOURCE_URI));
+    }
+
+    private void mockTransactionServiceProperties(String apiKeyValue) {
+        when(transactionServicePropertiesMock.getApiKey()).thenReturn(apiKeyValue);
     }
 
     /**


### PR DESCRIPTION
- Changes in the Document Generator caller to add the authorization header to the doc. genenerator request since Filing Generator is not able to communicate with the doc. generator in AWS.
- Filing Generator changes to cater for the error coming from the doc. Generator
- Updating the Junit test for this change.

Resolves: SFA-962