### PR TITLE
Fix Jurisdiction Bug in iXBRL Template

### DIFF
--- a/src/main/resources/filing/templates/small-full-accounts.html
+++ b/src/main/resources/filing/templates/small-full-accounts.html
@@ -1561,7 +1561,7 @@ ul.accounts-comps-ct {
             <h2 class="center margin-large">Company Registration Number:
                 <br />
                 <ix:nonNumeric name="uk-bus:UKCompaniesHouseRegisteredNumber" contextRef="CY">{{$companyNumber}}</ix:nonNumeric>
-                ({{$company.jurisdiction }})
+                ({{getJurisdiction $companyNumber}})
             </h2>
             {{$period := .small_full_accounts.period}}
             <h2 class="text--center margin-large" >


### PR DESCRIPTION
Fix bug where jurisdiction in England / Wales displayed as 'england-wales' in the ixbrl. Jurisdiction now displays as 'England and Wales', following abridged behaviour.

Resolves bug raised in SFA-836