### PR TITLE
Adding functionality to download a file from a public location

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/FileTransferTool.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/FileTransferTool.java
@@ -26,7 +26,9 @@ public class FileTransferTool {
     }
 
     /**
-     * It will download a file from a public location using a httpUrlConnection
+     * It will download a file from a public location using a httpUrlConnection. The
+     * httpUrlConnection will use proxy settings if they have been set in the environment
+     * variables.
      *
      * @param fileLocation - Contains the public location of the file.
      * @return {@link String} containing the downloaded file.
@@ -63,7 +65,7 @@ public class FileTransferTool {
     }
 
     /**
-     * Downloads the file form public location when the correct http code is returned.
+     * Downloads the file from a public location when the correct http code is returned.
      *
      * @param httpURLConnection
      * @return {@link String} containing the downloaded file.

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/FileTransferTool.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/FileTransferTool.java
@@ -1,0 +1,105 @@
+package uk.gov.companieshouse.api.accounts.utility.filetransfer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.io.IOUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Component
+public class FileTransferTool {
+
+    private static final Logger LOGGER = LoggerFactory
+        .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
+
+    private final HttpURLConnectionHandler httpURLConnectionHandler;
+
+    @Autowired
+    FileTransferTool(HttpURLConnectionHandler httpURLConnectionHandler) {
+        this.httpURLConnectionHandler = httpURLConnectionHandler;
+    }
+
+    /**
+     * It will download a file from a public location using a httpUrlConnection
+     *
+     * @param fileLocation - Contains the public location of the file.
+     * @return {@link String} containing the downloaded file.
+     */
+    public String downloadFileFromPublicLocation(String fileLocation) {
+
+        String downloadedFile = null;
+
+        HttpURLConnection httpURLConnection = openAndSetHttpUrlConnection(fileLocation);
+
+        if (httpURLConnection != null) {
+            downloadedFile = downloadFileUsingHttpUrlConnection(httpURLConnection);
+            httpURLConnection.disconnect();
+        }
+
+        return downloadedFile;
+    }
+
+    private HttpURLConnection openAndSetHttpUrlConnection(String fileLocation) {
+
+        try {
+            HttpURLConnection httpConn = httpURLConnectionHandler.openConnection(fileLocation);
+            httpConn.setRequestMethod("GET");
+
+            return httpConn;
+        } catch (IOException ex) {
+            logError(ex,
+                "FileTransfer: opening connection has failed",
+                "Fail to download file as error occurred when opening connection for location: "
+                    + fileLocation);
+        }
+
+        return null;
+    }
+
+    /**
+     * Downloads the file form public location when the correct http code is returned.
+     *
+     * @param httpURLConnection
+     * @return {@link String} containing the downloaded file.
+     */
+    private String downloadFileUsingHttpUrlConnection(HttpURLConnection httpURLConnection) {
+
+        String downloadedFile = null;
+
+        try {
+            int responseCode = httpURLConnection.getResponseCode();
+
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+
+                try (InputStream response = httpURLConnection.getInputStream()) {
+                    downloadedFile = new String(IOUtils.toByteArray(response));
+                }
+
+            } else {
+                logError(null,
+                    "FileTransfer: wrong response code",
+                    "Fail to download file as wrong response code has been returned: "
+                        + responseCode);
+            }
+
+        } catch (IOException ex) {
+            logError(ex,
+                "FileTransfer: Exception thrown when downloading file",
+                "Fail to download file as exception thrown when getting the response code or downloading the file");
+        }
+
+        return downloadedFile;
+    }
+
+    private void logError(IOException exception, String errorKey, String errorMessageMessage) {
+        Map<String, Object> logMap = new HashMap<>();
+        logMap.put("message", errorMessageMessage);
+        LOGGER.error(errorKey, exception, logMap);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/HttpURLConnectionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/HttpURLConnectionHandler.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.api.accounts.utility.filetransfer;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+public interface HttpURLConnectionHandler {
+
+    /**
+     * Create HttpURLConnection using the url file location provided.
+     *
+     * @param urlFileLocation - location of the file to be downloaded
+     * @return - {@link HttpURLConnection}
+     * @throws IOException
+     */
+    HttpURLConnection openConnection(String urlFileLocation) throws IOException;
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/HttpURLConnectionHandlerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/HttpURLConnectionHandlerImpl.java
@@ -1,0 +1,58 @@
+package uk.gov.companieshouse.api.accounts.utility.filetransfer;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URL;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+
+@Component
+public class HttpURLConnectionHandlerImpl implements HttpURLConnectionHandler {
+
+    private static final String PROXY_ADDRESSS_ENV_VAR = "HTTP_URL_CONNECTION_HTTP_PROXY_ADDR";
+    private static final String PROXY_PORT_ENV_VAR = "HTTP_URL_CONNECTION_HTTP_PROXY_PORT";
+    private final String connectionHandlerProxyAddress;
+    private final Integer connectionHandlerProxyPort;
+    private final EnvironmentReader environmentReader;
+
+    @Autowired
+    public HttpURLConnectionHandlerImpl(EnvironmentReader environmentReader) {
+
+        this.environmentReader = environmentReader;
+
+        connectionHandlerProxyAddress = environmentReader.getOptionalString(PROXY_ADDRESSS_ENV_VAR);
+        connectionHandlerProxyPort = environmentReader.getOptionalInteger(PROXY_PORT_ENV_VAR);
+    }
+
+    /**
+     * Create HttpURLConnection using the url file location provided and it will add proxy settings
+     * if the environment variables for proxy are set.
+     *
+     * @param urlFileLocation - location of the file to be downloaded
+     * @return - {@link HttpURLConnection} with or without proxy settings.
+     * @throws IOException
+     */
+    @Override
+    public HttpURLConnection openConnection(String urlFileLocation) throws IOException {
+
+        URL url = new URL(urlFileLocation);
+
+        if (StringUtils.isNotBlank(connectionHandlerProxyAddress) &&
+            connectionHandlerProxyPort != null) {
+
+            InetSocketAddress inetSocketAddress =
+                new InetSocketAddress(connectionHandlerProxyAddress, connectionHandlerProxyPort);
+
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, inetSocketAddress);
+
+            return (HttpURLConnection) url.openConnection(proxy);
+
+        } else {
+            return (HttpURLConnection) url.openConnection();
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/HttpURLConnectionHandlerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/HttpURLConnectionHandlerImpl.java
@@ -30,7 +30,7 @@ public class HttpURLConnectionHandlerImpl implements HttpURLConnectionHandler {
 
     /**
      * Create HttpURLConnection using the url file location provided and it will add proxy settings
-     * if the environment variables for proxy are set.
+     * if the environment variables for the proxy have been set.
      *
      * @param urlFileLocation - location of the file to be downloaded
      * @return - {@link HttpURLConnection} with or without proxy settings.

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/HttpURLConnectionHandlerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/HttpURLConnectionHandlerImpl.java
@@ -13,8 +13,8 @@ import uk.gov.companieshouse.environment.EnvironmentReader;
 @Component
 public class HttpURLConnectionHandlerImpl implements HttpURLConnectionHandler {
 
-    private static final String PROXY_ADDRESSS_ENV_VAR = "HTTP_URL_CONNECTION_HTTP_PROXY_ADDR";
-    private static final String PROXY_PORT_ENV_VAR = "HTTP_URL_CONNECTION_HTTP_PROXY_PORT";
+    private static final String PROXY_ADDRESS_ENV_VAR = "HTTP_URL_CONNECTION_PROXY_ADDR";
+    private static final String PROXY_PORT_ENV_VAR = "HTTP_URL_CONNECTION_PROXY_PORT";
     private final String connectionHandlerProxyAddress;
     private final Integer connectionHandlerProxyPort;
     private final EnvironmentReader environmentReader;
@@ -24,7 +24,7 @@ public class HttpURLConnectionHandlerImpl implements HttpURLConnectionHandler {
 
         this.environmentReader = environmentReader;
 
-        connectionHandlerProxyAddress = environmentReader.getOptionalString(PROXY_ADDRESSS_ENV_VAR);
+        connectionHandlerProxyAddress = environmentReader.getOptionalString(PROXY_ADDRESS_ENV_VAR);
         connectionHandlerProxyPort = environmentReader.getOptionalInteger(PROXY_PORT_ENV_VAR);
     }
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/FileTransferToolTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/FileTransferToolTest.java
@@ -1,0 +1,140 @@
+package uk.gov.companieshouse.api.accounts.utility.filetransfer;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+class FileTransferToolTest {
+
+    private static final String IXBRL_LOCATION = "s3://test-bucket/accounts/ixbrl-generated-name.html";
+    private static final String IXBRL = getIxbrl();
+
+    @Mock
+    private HttpURLConnection httpURLConnectionMock;
+    @Mock
+    private HttpURLConnectionHandler httpURLConnectionHandlerMock;
+
+    private FileTransferTool fileTransferTool;
+
+    private static String getIxbrl() {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<html xmlns:ixt2=\"http://www.xbrl.org/inlineXBRL/transformation/2011-07-31\">\n"
+            + "  <head>\n"
+            + "    <meta content=\"application/xhtml+xml; charset=UTF-8\" http-equiv=\"content-type\" />\n"
+            + "    <title>\n"
+            + "            TEST COMPANY\n"
+            + "        </title>\n"
+            + "  <body xml:lang=\"en\">\n"
+            + "    <div class=\"accounts-body \">\n"
+            + "      <div id=\"your-account-type\" class=\"wholedoc\">\n"
+            + "      </div>\n"
+            + "    </div>\n"
+            + "   </body>\n"
+            + "</html>\n";
+    }
+
+    @BeforeEach
+    void setBeforeEach() {
+        fileTransferTool = new FileTransferTool(httpURLConnectionHandlerMock);
+    }
+
+    @Test
+    @DisplayName("File is downloaded form location successfully")
+    void shouldDownloadFileSuccessfully() throws IOException {
+
+        when(httpURLConnectionHandlerMock.openConnection(anyString()))
+            .thenReturn(httpURLConnectionMock);
+
+        when(httpURLConnectionMock.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+
+        InputStream inputStreamResponse = new ByteArrayInputStream(IXBRL.getBytes());
+        when(httpURLConnectionMock.getInputStream()).thenReturn(inputStreamResponse);
+
+        assertNotNull(fileTransferTool.downloadFileFromPublicLocation(IXBRL_LOCATION));
+        verifyHttpURLConnectionHandlerMockCalls();
+        verifyHttpURLConnectionMockCalls();
+        verify(httpURLConnectionMock, times(1)).getInputStream();
+    }
+
+
+    @Test
+    @DisplayName("File is not downloaded as open connection throw exception")
+    void shouldFailToDownloadFileAsOpenConnectionThrowException() throws IOException {
+
+        when(httpURLConnectionHandlerMock.openConnection(anyString()))
+            .thenThrow(IOException.class);
+
+        assertNull(fileTransferTool.downloadFileFromPublicLocation(IXBRL_LOCATION));
+        verifyHttpURLConnectionHandlerMockCalls();
+    }
+
+    @Test
+    @DisplayName("File is not downloaded as wrong http code is returned")
+    void shouldFailToDownloadFileAsWrongHttpCodeIsReturned() throws IOException {
+
+        when(httpURLConnectionHandlerMock.openConnection(anyString()))
+            .thenReturn(httpURLConnectionMock);
+
+        when(httpURLConnectionMock.getResponseCode()).thenReturn(HttpURLConnection.HTTP_NO_CONTENT);
+
+        assertNull(fileTransferTool.downloadFileFromPublicLocation(IXBRL_LOCATION));
+        verifyHttpURLConnectionHandlerMockCalls();
+        verifyHttpURLConnectionMockCalls();
+    }
+
+    @Test
+    @DisplayName("File is not downloaded as exception is thrown when getting response code")
+    void shouldFailToDownloadFileAsExceptionThrownWhenGettingResponseCode() throws IOException {
+
+        when(httpURLConnectionHandlerMock.openConnection(anyString()))
+            .thenReturn(httpURLConnectionMock);
+
+        when(httpURLConnectionMock.getResponseCode()).thenThrow(IOException.class);
+
+        assertNull(fileTransferTool.downloadFileFromPublicLocation(IXBRL_LOCATION));
+        verifyHttpURLConnectionHandlerMockCalls();
+        verifyHttpURLConnectionMockCalls();
+    }
+
+    @Test
+    @DisplayName("File is not downloaded as exception is thrown when trying to access to the file")
+    void shouldFailToDownloadFileAsExceptionThrownWhenGettingInputStream() throws IOException {
+
+        when(httpURLConnectionHandlerMock.openConnection(anyString()))
+            .thenReturn(httpURLConnectionMock);
+
+        when(httpURLConnectionMock.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+        when(httpURLConnectionMock.getInputStream()).thenThrow(IOException.class);
+
+        assertNull(fileTransferTool.downloadFileFromPublicLocation(IXBRL_LOCATION));
+        verifyHttpURLConnectionHandlerMockCalls();
+        verifyHttpURLConnectionMockCalls();
+    }
+
+    private void verifyHttpURLConnectionHandlerMockCalls() throws IOException {
+        verify(httpURLConnectionHandlerMock, times(1)).openConnection(anyString());
+    }
+
+    private void verifyHttpURLConnectionMockCalls() throws IOException {
+        verify(httpURLConnectionMock, times(1)).getResponseCode();
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/FileTransferToolTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/FileTransferToolTest.java
@@ -74,7 +74,6 @@ class FileTransferToolTest {
         verify(httpURLConnectionMock, times(1)).getInputStream();
     }
 
-
     @Test
     @DisplayName("File is not downloaded as open connection throw exception")
     void shouldFailToDownloadFileAsOpenConnectionThrowException() throws IOException {
@@ -136,5 +135,4 @@ class FileTransferToolTest {
     private void verifyHttpURLConnectionMockCalls() throws IOException {
         verify(httpURLConnectionMock, times(1)).getResponseCode();
     }
-
 }


### PR DESCRIPTION
This changes are needed to download the ixbrl file from a public location. This will be used ``
- Adding FileTransferTool class to download file from public location.
- Creating HttpURLConnectionHandler interface to hide the URL.open connection so that it can be Junit tested.
This is used by the FileTransferTool to create HttpURLConnection.

Resolves: SFA-989