### PR TITLE
Updating tnep validation class

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImpl.java
@@ -54,6 +54,7 @@ public class TnepValidationServiceImpl implements TnepValidationService {
                     "Ixbrl is valid. It has passed the TNEP validation");
 
                 return true;
+
             } else {
                 addToLog(true, null, results, location,
                     "Ixbrl is invalid. It has failed the TNEP validation");

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImpl.java
@@ -25,15 +25,15 @@ public class TnepValidationServiceImpl implements TnepValidationService {
 
     private static final String IXBRL_VALIDATOR_URI = "IXBRL_VALIDATOR_URI";
 
-    private static final Logger LOG = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
+    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
 
     private RestTemplate restTemplate;
-
     private EnvironmentReader environmentReader;
 
     @Autowired
     public TnepValidationServiceImpl(RestTemplate restTemplate,
         EnvironmentReader environmentReader) {
+
         this.restTemplate = restTemplate;
         this.environmentReader = environmentReader;
     }
@@ -47,63 +47,48 @@ public class TnepValidationServiceImpl implements TnepValidationService {
     public boolean validate(String ixbrl, String location) {
 
         try {
-            //Connect to the TNEP validator via http POST using multipart file upload
-            LinkedMultiValueMap<String, Object> map = createFileMessageResource(ixbrl, location);
+            Results results = validatIxbrlAgainstTnep(ixbrl, location);
 
-            HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = setHttpHeaders(map);
+            if (hasPassedTnepValidation(results)) {
+                addToLog(false, null, results, location,
+                    "Ixbrl is valid. It has passed the TNEP validation");
 
-            Results results = postForValidation(requestEntity);
+                return true;
+            } else {
+                addToLog(true, null, results, location,
+                    "Ixbrl is invalid. It has failed the TNEP validation");
 
-            return logValidationResponse(location, results);
+                return false;
+            }
 
         } catch (Exception e) {
+            addToLog(true, e, null, location,
+                "Exception has been thrown when calling TNEP validator. Unable to validate Ixbrl");
 
-            return logErroredValidation(location, e);
+            return false;
         }
     }
 
     /**
-     * Log the response of the validation - Successful or failed
+     * Call TNEP validator service, via http POST using multipart file upload, to check if ixbrl is
+     * valid.
      *
-     * @return boolean
+     * @param ixbrl - ixbrl content to be validated.
+     * @param location - ixbrl location, public location.
+     * @return {@link Results} with the information from calling the Tnep service.
+     * @throws URISyntaxException
      */
-    private boolean logValidationResponse(String location, Results results) {
-        if (results != null && "OK".equalsIgnoreCase(results.getValidationStatus())) {
+    private Results validatIxbrlAgainstTnep(String ixbrl, String location)
+        throws URISyntaxException {
 
-            return logSuccessfulValidation(location, results);
+        LinkedMultiValueMap<String, Object> map = createFileMessageResource(ixbrl, location);
+        HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = setHttpHeaders(map);
 
-        } else {
-
-            return logFailedValidation(location, results);
-        }
+        return postForValidation(requestEntity);
     }
 
-    /**
-     * Log any error caught whilst validating
-     *
-     * @return boolean
-     */
-    private boolean logErroredValidation(String location, Exception e) {
-        Map<String, Object> logMap = new HashMap<>();
-        logMap.put("error", "Unable to validate ixbrl");
-        logMap.put("location", location);
-        LOG.error(e, logMap);
-
-        return false;
-    }
-
-    private boolean logFailedValidation(String location, Results results) {
-        Map<String, Object> logMap = generateLogMap(location, results);
-        LOG.error("Ixbrl validation failed", logMap);
-
-        return false;
-    }
-
-    private boolean logSuccessfulValidation(String location, Results results) {
-        Map<String, Object> logMap = generateLogMap(location, results);
-        LOG.debug("Ixbrl validation succeeded", logMap);
-
-        return true;
+    private boolean hasPassedTnepValidation(Results results) {
+        return results != null && "OK".equalsIgnoreCase(results.getValidationStatus());
     }
 
     /**
@@ -116,6 +101,24 @@ public class TnepValidationServiceImpl implements TnepValidationService {
 
         return restTemplate
             .postForObject(new URI(getIxbrlValidatorUri()), requestEntity, Results.class);
+    }
+
+    private void addToLog(boolean hasValidationFailed, Exception e, Results results,
+        String location, String message) {
+
+        Map<String, Object> logMap = new HashMap<>();
+        logMap.put("message", message);
+        logMap.put("location", location);
+
+        if (results != null) {
+            logMap.put("results", results);
+        }
+
+        if (hasValidationFailed) {
+            LOGGER.error("TnepValidationServiceImpl: validation has failed", e, logMap);
+        } else {
+            LOGGER.debug("TnepValidationServiceImpl: validation has passed", logMap);
+        }
     }
 
     /**
@@ -148,14 +151,6 @@ public class TnepValidationServiceImpl implements TnepValidationService {
     protected String getIxbrlValidatorUri() {
 
         return environmentReader.getMandatoryString(IXBRL_VALIDATOR_URI);
-    }
-
-    private Map<String, Object> generateLogMap(String location, Results results) {
-        Map<String, Object> logMap = new HashMap<>();
-        logMap.put("location", location);
-        logMap.put("results", results);
-
-        return logMap;
     }
 
     private class FileMessageResource extends ByteArrayResource {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImplTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.companieshouse.api.accounts.utility.filetransfer.FileTransferTool;
 import uk.gov.companieshouse.api.accounts.validation.Results;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 
@@ -33,15 +34,17 @@ class TnepValidationServiceImplTest {
     private static final String VALIDATION_STATUS_OK = "OK";
 
     @Mock
-    RestTemplate restTemplate;
+    private RestTemplate restTemplateMock;
     @Mock
-    EnvironmentReader environmentReader;
+    private EnvironmentReader environmentReaderMock;
 
     private TnepValidationServiceImpl tnepValidationService;
 
     @BeforeEach
     void setup() {
-        tnepValidationService = new TnepValidationServiceImpl(restTemplate, environmentReader);
+        tnepValidationService = new TnepValidationServiceImpl(
+            restTemplateMock,
+            environmentReaderMock);
     }
 
     @Test
@@ -53,7 +56,7 @@ class TnepValidationServiceImplTest {
 
         mockEnvironmentReaderGetMandatoryString(ENV_VARIABLE_IXBRL_VALIDATOR_URI_VALUE);
 
-        when(restTemplate.postForObject(any(URI.class), any(HttpEntity.class), eq(Results.class)))
+        when(restTemplateMock.postForObject(any(URI.class), any(HttpEntity.class), eq(Results.class)))
             .thenReturn(results);
 
         assertTrue(validateIxbrl());
@@ -68,7 +71,7 @@ class TnepValidationServiceImplTest {
 
         mockEnvironmentReaderGetMandatoryString(ENV_VARIABLE_IXBRL_VALIDATOR_URI_VALUE);
 
-        when(restTemplate.postForObject(any(URI.class), any(HttpEntity.class), eq(Results.class)))
+        when(restTemplateMock.postForObject(any(URI.class), any(HttpEntity.class), eq(Results.class)))
             .thenReturn(results);
 
         assertFalse(validateIxbrl());
@@ -79,7 +82,7 @@ class TnepValidationServiceImplTest {
 
         mockEnvironmentReaderGetMandatoryString(ENV_VARIABLE_IXBRL_VALIDATOR_URI_VALUE);
 
-        when(restTemplate.postForObject(any(URI.class), any(HttpEntity.class), eq(Results.class)))
+        when(restTemplateMock.postForObject(any(URI.class), any(HttpEntity.class), eq(Results.class)))
             .thenReturn(null);
 
         assertFalse(validateIxbrl());
@@ -90,7 +93,7 @@ class TnepValidationServiceImplTest {
 
         mockEnvironmentReaderGetMandatoryString(ENV_VARIABLE_IXBRL_VALIDATOR_URI_VALUE);
 
-        when(restTemplate.postForObject(any(URI.class), any(HttpEntity.class), eq(Results.class)))
+        when(restTemplateMock.postForObject(any(URI.class), any(HttpEntity.class), eq(Results.class)))
             .thenThrow(new RestClientException(VALIDATION_STATUS_UNIT_TEST_FAILURE));
 
         assertFalse(validateIxbrl());
@@ -105,7 +108,7 @@ class TnepValidationServiceImplTest {
 
     private void mockEnvironmentReaderGetMandatoryString(String returnedMandatoryValue) {
 
-        when(environmentReader.getMandatoryString(ENV_VARIABLE_IXBRL_VALIDATOR_URI))
+        when(environmentReaderMock.getMandatoryString(ENV_VARIABLE_IXBRL_VALIDATOR_URI))
             .thenReturn(returnedMandatoryValue);
     }
 


### PR DESCRIPTION
Small change to move validation functionality to the main method ( `validate()`) so that it is clearer when ixbrl has passed or failed validation. 

There were different methods doing the same thing: `adding to the log`. I have unified this in one method and a boolean variable will control if message should be added to error or to debug. 

Resolves:  
SFA-988