### PR TITLE
Plugging tnep validation into the Filing Generator

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImpl.java
@@ -46,6 +46,9 @@ public class TnepValidationServiceImpl implements TnepValidationService {
     @Override
     public boolean validate(String ixbrl, String location) {
 
+        boolean isIxbrlValid = false;
+
+        LOGGER.info("TnepValidationServiceImpl: Ixbrl validation has started");
         try {
             Results results = validatIxbrlAgainstTnep(ixbrl, location);
 
@@ -53,21 +56,21 @@ public class TnepValidationServiceImpl implements TnepValidationService {
                 addToLog(false, null, results, location,
                     "Ixbrl is valid. It has passed the TNEP validation");
 
-                return true;
+                isIxbrlValid = true;
 
             } else {
                 addToLog(true, null, results, location,
                     "Ixbrl is invalid. It has failed the TNEP validation");
-
-                return false;
             }
 
         } catch (Exception e) {
             addToLog(true, e, null, location,
                 "Exception has been thrown when calling TNEP validator. Unable to validate Ixbrl");
-
-            return false;
         }
+
+        LOGGER.info("TnepValidationServiceImpl: Ixbrl validation has finished");
+
+        return isIxbrlValid;
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/FileTransferTool.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/filetransfer/FileTransferTool.java
@@ -31,9 +31,11 @@ public class FileTransferTool {
      * variables.
      *
      * @param fileLocation - Contains the public location of the file.
-     * @return {@link String} containing the downloaded file.
+     * @return {@link String} containing the downloaded file. Return null if file not downloaded.
      */
     public String downloadFileFromPublicLocation(String fileLocation) {
+
+        LOGGER.info("FileTransferTool: Start process to download file from location");
 
         String downloadedFile = null;
 
@@ -41,8 +43,9 @@ public class FileTransferTool {
 
         if (httpURLConnection != null) {
             downloadedFile = downloadFileUsingHttpUrlConnection(httpURLConnection);
-            httpURLConnection.disconnect();
         }
+
+        LOGGER.info("FileTransferTool: Process to download file has finished");
 
         return downloadedFile;
     }
@@ -52,6 +55,9 @@ public class FileTransferTool {
         try {
             HttpURLConnection httpConn = httpURLConnectionHandler.openConnection(fileLocation);
             httpConn.setRequestMethod("GET");
+
+            LOGGER.info(
+                "FileTransferTool: openAndSetHttpUrlConnection has successfully set a HttpURLConnection");
 
             return httpConn;
         } catch (IOException ex) {
@@ -81,6 +87,8 @@ public class FileTransferTool {
 
                 try (InputStream response = httpURLConnection.getInputStream()) {
                     downloadedFile = new String(IOUtils.toByteArray(response));
+                    LOGGER.info(
+                        "FileTransferTool: downloadFileUsingHttpUrlConnection has successfully download the file's content");
                 }
 
             } else {
@@ -94,6 +102,8 @@ public class FileTransferTool {
             logError(ex,
                 "FileTransfer: Exception thrown when downloading file",
                 "Fail to download file as exception thrown when getting the response code or downloading the file");
+        } finally {
+            httpURLConnection.disconnect();
         }
 
         return downloadedFile;


### PR DESCRIPTION
- Code changes made to plug the tnep validation service into the Filing Generator.
Since TnepValidationService needs the ixbrl location and the ixbrl data; the Filing Generator has an extra call made to the FileTransferTool to download the ixbrl data.

- Update FilingServiceImplTest's Junit for these latest changes.
- Add more loggings to the `TnepValidationService` class 
- Add more loggings to the `FileTransferTool` class and add small change to disconnect after file is downloaded. 

Resolves: 
SFA-988