### PR TITLE
Cross validate debtors note with Balance sheet values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.companieshouse</groupId>
   <artifactId>company-accounts.api.ch.gov.uk</artifactId>
-  <version>unversioned</version>
+  <version>d3c258c</version>
   <packaging>jar</packaging>
   <name>company-accounts-api</name>
   <description>Company accounts API to handle company accounts data</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.companieshouse</groupId>
   <artifactId>company-accounts.api.ch.gov.uk</artifactId>
-  <version>d3c258c</version>
+  <version>unversioned</version>
   <packaging>jar</packaging>
   <name>company-accounts-api</name>
   <description>Company accounts API to handle company accounts data</description>

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/notes/Debtors/CurrentPeriod.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/notes/Debtors/CurrentPeriod.java
@@ -2,15 +2,13 @@ package uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.validation.constraints.Size;
 import org.hibernate.validator.constraints.Range;
-import uk.gov.companieshouse.api.accounts.model.rest.RestObject;
 import uk.gov.companieshouse.api.accounts.validation.CharSetValid;
 import uk.gov.companieshouse.charset.CharSet;
 
-import javax.validation.constraints.Size;
-
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class CurrentPeriod extends RestObject {
+public class CurrentPeriod {
 
     private static final int MAX_FIELD_LENGTH = 20000;
     private static final int MAX_RANGE = 99999999;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/notes/Debtors/CurrentPeriod.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/notes/Debtors/CurrentPeriod.java
@@ -3,13 +3,14 @@ package uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.Range;
+import uk.gov.companieshouse.api.accounts.model.rest.RestObject;
 import uk.gov.companieshouse.api.accounts.validation.CharSetValid;
 import uk.gov.companieshouse.charset.CharSet;
 
 import javax.validation.constraints.Size;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class CurrentPeriod {
+public class CurrentPeriod extends RestObject {
 
     private static final int MAX_FIELD_LENGTH = 20000;
     private static final int MAX_RANGE = 99999999;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/notes/Debtors/CurrentPeriod.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/notes/Debtors/CurrentPeriod.java
@@ -19,22 +19,22 @@ public class CurrentPeriod {
     @JsonProperty("details")
     private String details;
 
-    @Range(min=MIN_RANGE,max=MAX_RANGE, message = "value.outside.range")
+    @Range(min = MIN_RANGE, max = MAX_RANGE, message = "value.outside.range")
     @JsonProperty("greater_than_one_year")
     private Long greaterThanOneYear;
 
-    @Range(min=MIN_RANGE,max=MAX_RANGE, message = "value.outside.range")
+    @Range(min = MIN_RANGE, max = MAX_RANGE, message = "value.outside.range")
     @JsonProperty("other_debtors")
     private Long otherDebtors;
 
-    @Range(min=MIN_RANGE,max=MAX_RANGE, message = "value.outside.range")
+    @Range(min = MIN_RANGE, max = MAX_RANGE, message = "value.outside.range")
     @JsonProperty("prepayments_and_accrued_income")
     private Long prepaymentsAndAccruedIncome;
 
     @JsonProperty("total")
     private Long total;
 
-    @Range(min=MIN_RANGE,max=MAX_RANGE, message = "value.outside.range")
+    @Range(min = MIN_RANGE, max = MAX_RANGE, message = "value.outside.range")
     @JsonProperty("trade_debtors")
     private Long tradeDebtors;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/repository/DebtorsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/repository/DebtorsRepository.java
@@ -1,7 +1,9 @@
 package uk.gov.companieshouse.api.accounts.repository;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 import uk.gov.companieshouse.api.accounts.model.entity.notes.debtors.DebtorsEntity;
 
+@Repository
 public interface DebtorsRepository  extends MongoRepository<DebtorsEntity, String> {
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
@@ -59,7 +59,7 @@ public class DebtorsService implements ResourceService<Debtors> {
                                           String companyAccountsId, HttpServletRequest request)
         throws DataException {
 
-        Errors errors = debtorsValidator.validateDebtors(rest, transaction);
+        Errors errors = debtorsValidator.validateDebtors(rest, transaction, companyAccountsId, request);
 
         if (errors.hasErrors()) {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
@@ -42,9 +42,9 @@ public class DebtorsService implements ResourceService<Debtors> {
     private DebtorsValidator debtorsValidator;
 
     @Autowired
-    public DebtorsService(DebtorsRepository repository, DebtorsTransformer transformer,
-                          SmallFullService smallFullService, KeyIdGenerator keyIdGenerator,
-                          DebtorsValidator debtorsValidator) {
+    public DebtorsService (DebtorsRepository repository, DebtorsTransformer transformer,
+            SmallFullService smallFullService, KeyIdGenerator keyIdGenerator,
+            DebtorsValidator debtorsValidator) {
 
         this.repository = repository;
         this.transformer = transformer;
@@ -54,12 +54,11 @@ public class DebtorsService implements ResourceService<Debtors> {
     }
 
     @Override
-    public ResponseObject<Debtors> create(Debtors rest, Transaction transaction,
-                                          String companyAccountsId,
-                                          HttpServletRequest request) throws DataException {
+    public ResponseObject<Debtors> create (Debtors rest, Transaction transaction,
+            String companyAccountsId, HttpServletRequest request) throws DataException {
 
-        Errors errors =
-                debtorsValidator.validateDebtors(rest, transaction, companyAccountsId, request);
+        Errors errors = debtorsValidator.validateDebtors(rest, transaction, companyAccountsId,
+                request);
 
         if (errors.hasErrors()) {
 
@@ -76,16 +75,16 @@ public class DebtorsService implements ResourceService<Debtors> {
             repository.insert(entity);
         } catch (DuplicateKeyException e) {
 
-            LOGGER.errorRequest(request, e,
-                    getDebugMap(transaction, companyAccountsId, entity.getId()));
+            LOGGER.errorRequest(request, e, getDebugMap(transaction, companyAccountsId,
+                    entity.getId()));
 
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
         } catch (MongoException e) {
 
             DataException dataException =
                     new DataException("Failed to insert " + ResourceName.DEBTORS.getName(), e);
-            LOGGER.errorRequest(request, dataException,
-                    getDebugMap(transaction, companyAccountsId, entity.getId()));
+            LOGGER.errorRequest(request, dataException, getDebugMap(transaction,
+                    companyAccountsId, entity.getId()));
 
             throw dataException;
         }
@@ -97,9 +96,8 @@ public class DebtorsService implements ResourceService<Debtors> {
     }
 
     @Override
-    public ResponseObject<Debtors> update(Debtors rest, Transaction transaction,
-                                          String companyAccountsId,
-                                          HttpServletRequest request) throws DataException {
+    public ResponseObject<Debtors> update (Debtors rest, Transaction transaction,
+            String companyAccountsId, HttpServletRequest request) throws DataException {
         setMetadataOnRestObject(rest, transaction, companyAccountsId);
 
         DebtorsEntity entity = transformer.transform(rest);
@@ -110,8 +108,8 @@ public class DebtorsService implements ResourceService<Debtors> {
         } catch (MongoException me) {
             DataException dataException =
                     new DataException("Failed to update" + ResourceName.DEBTORS.getName(), me);
-            LOGGER.errorRequest(request, dataException,
-                    getDebugMap(transaction, companyAccountsId, entity.getId()));
+            LOGGER.errorRequest(request, dataException, getDebugMap(transaction,
+                    companyAccountsId, entity.getId()));
 
             throw dataException;
         }
@@ -119,8 +117,7 @@ public class DebtorsService implements ResourceService<Debtors> {
     }
 
     @Override
-    public ResponseObject<Debtors> findById(String id,
-                                            HttpServletRequest request) throws DataException {
+    public ResponseObject<Debtors> findById (String id, HttpServletRequest request) throws DataException {
         DebtorsEntity entity;
 
         try {
@@ -142,31 +139,31 @@ public class DebtorsService implements ResourceService<Debtors> {
     }
 
     @Override
-    public String generateID(String companyAccountId) {
+    public String generateID (String companyAccountId) {
         return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.DEBTORS.getName());
     }
 
-    private String generateSelfLink(Transaction transaction, String companyAccountId) {
+    private String generateSelfLink (Transaction transaction, String companyAccountId) {
 
-        return transaction.getLinks().get(TransactionLinkType.SELF.getLink()) + "/" +
-                ResourceName.COMPANY_ACCOUNT.getName() + "/" + companyAccountId + "/" +
-                ResourceName.SMALL_FULL.getName() + "/" + ResourceName.DEBTORS.getName();
+        return transaction.getLinks().get(TransactionLinkType.SELF.getLink()) + "/"
+                + ResourceName.COMPANY_ACCOUNT.getName() + "/" + companyAccountId + "/"
+                + ResourceName.SMALL_FULL.getName() + "/" + ResourceName.DEBTORS.getName();
     }
 
-    public String getSelfLinkFromDebtorsEntity(DebtorsEntity entity) {
+    public String getSelfLinkFromDebtorsEntity (DebtorsEntity entity) {
 
         return entity.getData().getLinks().get(BasicLinkType.SELF.getLink());
     }
 
-    private Map<String, String> createSelfLink(Transaction transaction, String companyAccountsId) {
+    private Map<String, String> createSelfLink (Transaction transaction, String companyAccountsId) {
 
         Map<String, String> map = new HashMap<>();
         map.put(BasicLinkType.SELF.getLink(), generateSelfLink(transaction, companyAccountsId));
         return map;
     }
 
-    private void setMetadataOnRestObject(Debtors rest, Transaction transaction,
-                                         String companyAccountsId) {
+    private void setMetadataOnRestObject (Debtors rest, Transaction transaction,
+            String companyAccountsId) {
 
         rest.setLinks(createSelfLink(transaction, companyAccountsId));
         rest.setEtag(GenerateEtagUtil.generateEtag());

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
@@ -42,10 +42,9 @@ public class DebtorsService implements ResourceService<Debtors> {
     private DebtorsValidator debtorsValidator;
 
     @Autowired
-    public DebtorsService(DebtorsRepository repository,
-                          DebtorsTransformer transformer,
-                          SmallFullService smallFullService,
-                          KeyIdGenerator keyIdGenerator, DebtorsValidator debtorsValidator) {
+    public DebtorsService(DebtorsRepository repository, DebtorsTransformer transformer,
+                          SmallFullService smallFullService, KeyIdGenerator keyIdGenerator,
+                          DebtorsValidator debtorsValidator) {
 
         this.repository = repository;
         this.transformer = transformer;
@@ -56,10 +55,11 @@ public class DebtorsService implements ResourceService<Debtors> {
 
     @Override
     public ResponseObject<Debtors> create(Debtors rest, Transaction transaction,
-                                          String companyAccountsId, HttpServletRequest request)
-        throws DataException {
+                                          String companyAccountsId,
+                                          HttpServletRequest request) throws DataException {
 
-        Errors errors = debtorsValidator.validateDebtors(rest, transaction, companyAccountsId, request);
+        Errors errors =
+            debtorsValidator.validateDebtors(rest, transaction, companyAccountsId, request);
 
         if (errors.hasErrors()) {
 
@@ -76,26 +76,30 @@ public class DebtorsService implements ResourceService<Debtors> {
             repository.insert(entity);
         } catch (DuplicateKeyException e) {
 
-            LOGGER.errorRequest(request, e, getDebugMap(transaction, companyAccountsId, entity.getId()));
+            LOGGER.errorRequest(request, e,
+                getDebugMap(transaction, companyAccountsId, entity.getId()));
 
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
         } catch (MongoException e) {
 
-            DataException dataException = new DataException("Failed to insert " + ResourceName.DEBTORS.getName(), e);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction, companyAccountsId, entity.getId()));
+            DataException dataException =
+                new DataException("Failed to insert " + ResourceName.DEBTORS.getName(), e);
+            LOGGER.errorRequest(request, dataException,
+                getDebugMap(transaction, companyAccountsId, entity.getId()));
 
             throw dataException;
         }
 
-        smallFullService
-            .addLink(companyAccountsId, SmallFullLinkType.DEBTORS_NOTE,
-                getSelfLinkFromDebtorsEntity(entity), request);
+        smallFullService.addLink(companyAccountsId, SmallFullLinkType.DEBTORS_NOTE,
+            getSelfLinkFromDebtorsEntity(entity), request);
 
         return new ResponseObject<>(ResponseStatus.CREATED, rest);
     }
 
     @Override
-    public ResponseObject<Debtors> update(Debtors rest, Transaction transaction, String companyAccountsId, HttpServletRequest request) throws DataException {
+    public ResponseObject<Debtors> update(Debtors rest, Transaction transaction,
+                                          String companyAccountsId,
+                                          HttpServletRequest request) throws DataException {
         setMetadataOnRestObject(rest, transaction, companyAccountsId);
 
         DebtorsEntity entity = transformer.transform(rest);
@@ -104,8 +108,10 @@ public class DebtorsService implements ResourceService<Debtors> {
         try {
             repository.save(entity);
         } catch (MongoException me) {
-            DataException dataException = new DataException("Failed to update" + ResourceName.DEBTORS.getName(), me);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction, companyAccountsId, entity.getId()));
+            DataException dataException =
+                new DataException("Failed to update" + ResourceName.DEBTORS.getName(), me);
+            LOGGER.errorRequest(request, dataException,
+                getDebugMap(transaction, companyAccountsId, entity.getId()));
 
             throw dataException;
         }
@@ -113,7 +119,8 @@ public class DebtorsService implements ResourceService<Debtors> {
     }
 
     @Override
-    public ResponseObject<Debtors> findById(String id, HttpServletRequest request) throws DataException {
+    public ResponseObject<Debtors> findById(String id,
+                                            HttpServletRequest request) throws DataException {
         DebtorsEntity entity;
 
         try {
@@ -141,10 +148,9 @@ public class DebtorsService implements ResourceService<Debtors> {
 
     private String generateSelfLink(Transaction transaction, String companyAccountId) {
 
-        return transaction.getLinks().get(TransactionLinkType.SELF.getLink()) + "/"
-            + ResourceName.COMPANY_ACCOUNT.getName() + "/"
-            + companyAccountId + "/" + ResourceName.SMALL_FULL.getName() + "/"
-            + ResourceName.DEBTORS.getName();
+        return transaction.getLinks().get(TransactionLinkType.SELF.getLink()) + "/" +
+            ResourceName.COMPANY_ACCOUNT.getName() + "/" + companyAccountId + "/" +
+            ResourceName.SMALL_FULL.getName() + "/" + ResourceName.DEBTORS.getName();
     }
 
     public String getSelfLinkFromDebtorsEntity(DebtorsEntity entity) {
@@ -159,7 +165,8 @@ public class DebtorsService implements ResourceService<Debtors> {
         return map;
     }
 
-    private void setMetadataOnRestObject(Debtors rest, Transaction transaction, String companyAccountsId) {
+    private void setMetadataOnRestObject(Debtors rest, Transaction transaction,
+                                         String companyAccountsId) {
 
         rest.setLinks(createSelfLink(transaction, companyAccountsId));
         rest.setEtag(GenerateEtagUtil.generateEtag());

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
@@ -59,7 +59,7 @@ public class DebtorsService implements ResourceService<Debtors> {
                                           HttpServletRequest request) throws DataException {
 
         Errors errors =
-            debtorsValidator.validateDebtors(rest, transaction, companyAccountsId, request);
+                debtorsValidator.validateDebtors(rest, transaction, companyAccountsId, request);
 
         if (errors.hasErrors()) {
 
@@ -77,21 +77,21 @@ public class DebtorsService implements ResourceService<Debtors> {
         } catch (DuplicateKeyException e) {
 
             LOGGER.errorRequest(request, e,
-                getDebugMap(transaction, companyAccountsId, entity.getId()));
+                    getDebugMap(transaction, companyAccountsId, entity.getId()));
 
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
         } catch (MongoException e) {
 
             DataException dataException =
-                new DataException("Failed to insert " + ResourceName.DEBTORS.getName(), e);
+                    new DataException("Failed to insert " + ResourceName.DEBTORS.getName(), e);
             LOGGER.errorRequest(request, dataException,
-                getDebugMap(transaction, companyAccountsId, entity.getId()));
+                    getDebugMap(transaction, companyAccountsId, entity.getId()));
 
             throw dataException;
         }
 
         smallFullService.addLink(companyAccountsId, SmallFullLinkType.DEBTORS_NOTE,
-            getSelfLinkFromDebtorsEntity(entity), request);
+                getSelfLinkFromDebtorsEntity(entity), request);
 
         return new ResponseObject<>(ResponseStatus.CREATED, rest);
     }
@@ -109,9 +109,9 @@ public class DebtorsService implements ResourceService<Debtors> {
             repository.save(entity);
         } catch (MongoException me) {
             DataException dataException =
-                new DataException("Failed to update" + ResourceName.DEBTORS.getName(), me);
+                    new DataException("Failed to update" + ResourceName.DEBTORS.getName(), me);
             LOGGER.errorRequest(request, dataException,
-                getDebugMap(transaction, companyAccountsId, entity.getId()));
+                    getDebugMap(transaction, companyAccountsId, entity.getId()));
 
             throw dataException;
         }
@@ -149,8 +149,8 @@ public class DebtorsService implements ResourceService<Debtors> {
     private String generateSelfLink(Transaction transaction, String companyAccountId) {
 
         return transaction.getLinks().get(TransactionLinkType.SELF.getLink()) + "/" +
-            ResourceName.COMPANY_ACCOUNT.getName() + "/" + companyAccountId + "/" +
-            ResourceName.SMALL_FULL.getName() + "/" + ResourceName.DEBTORS.getName();
+                ResourceName.COMPANY_ACCOUNT.getName() + "/" + companyAccountId + "/" +
+                ResourceName.SMALL_FULL.getName() + "/" + ResourceName.DEBTORS.getName();
     }
 
     public String getSelfLinkFromDebtorsEntity(DebtorsEntity entity) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CrossValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CrossValidator.java
@@ -7,7 +7,13 @@ import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 public interface CrossValidator<T> {
 
     /**
-     * @inheritDoc Cross validate values from note values with corresponding balance sheet value
+     * @inheritDoc Cross validate values from note with corresponding balance sheet value
+     * @param  errors the errors object used to contain all errors whilst validating
+     * @param  request
+     * @param  companyAccountsId
+     * @param  t the note object that needs to be validated
+     *
+     * @return the errors object containing all errors added whilst validating
      */
     Errors crossValidate(Errors errors, HttpServletRequest request, String CompanyAccountsId,
                          T t) throws DataException;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CrossValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CrossValidator.java
@@ -4,8 +4,23 @@ import javax.servlet.http.HttpServletRequest;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 
-public interface CrossValidator {
+public interface CrossValidator<T> {
 
-    Errors crossValidate(Errors errors, HttpServletRequest request,
-                         String CompanyAccountsId) throws DataException;
+    /**
+     * @inheritDoc
+     *
+     * Cross validate values from note current period values with corresponding balance sheet value
+     */
+    Errors crossValidateCurrentPeriod(Errors errors, HttpServletRequest request,
+                                      String CompanyAccountsId,
+                                      T t) throws DataException;
+
+    /**
+     * @inheritDoc
+     *
+     * Cross validate values from note previous period values with corresponding balance sheet value
+     */
+
+    Errors crossValidatePreviousPeriod(Errors errors, HttpServletRequest request,
+                                       String CompanyAccountsId, T t) throws DataException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CrossValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CrossValidator.java
@@ -7,20 +7,9 @@ import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 public interface CrossValidator<T> {
 
     /**
-     * @inheritDoc
-     *
-     * Cross validate values from note current period values with corresponding balance sheet value
+     * @inheritDoc Cross validate values from note values with corresponding balance sheet value
      */
-    Errors crossValidateCurrentPeriod(Errors errors, HttpServletRequest request,
-                                      String CompanyAccountsId,
-                                      T t) throws DataException;
+    Errors crossValidate(Errors errors, HttpServletRequest request, String CompanyAccountsId,
+                         T t) throws DataException;
 
-    /**
-     * @inheritDoc
-     *
-     * Cross validate values from note previous period values with corresponding balance sheet value
-     */
-
-    Errors crossValidatePreviousPeriod(Errors errors, HttpServletRequest request,
-                                       String CompanyAccountsId, T t) throws DataException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CrossValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CrossValidator.java
@@ -1,0 +1,11 @@
+package uk.gov.companieshouse.api.accounts.validation;
+
+import javax.servlet.http.HttpServletRequest;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+
+public interface CrossValidator {
+
+    Errors crossValidate(Errors errors, HttpServletRequest request,
+                         String CompanyAccountsId) throws DataException;
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -214,11 +214,11 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
      */
 
     @Override
-    public Errors crossValidate(Errors errors, HttpServletRequest request, String CompanyAccountsId,
+    public Errors crossValidate(Errors errors, HttpServletRequest request, String companyAccountsId,
                                 Debtors debtors) throws DataException {
 
-        crossValidateCurrentPeriod(errors, request, debtors, CompanyAccountsId);
-        crossValidatePreviousPeriod(errors, request, CompanyAccountsId, debtors);
+        crossValidateCurrentPeriod(errors, request, debtors, companyAccountsId);
+        crossValidatePreviousPeriod(errors, request, companyAccountsId, debtors);
 
         return errors;
     }
@@ -248,35 +248,29 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         }
 
         // if balance sheet value is null and note value isn't add error
-        if (previousPeriodResponseObject.getData() == null &&
-            !isDebtorsNotePreviousTotalNull(debtors)) {
+        if (isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject) &&
+            (!isDebtorsNotePreviousTotalNull(debtors))) {
 
             addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
-        } else {
-            if (isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject) &&
-                (!isDebtorsNotePreviousTotalNull(debtors))) {
+        }
 
-                addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
-            }
+        // if neither are null and values do not match add error
+        if (!isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject) &&
+            (!isDebtorsNotePreviousTotalNull(debtors))
 
-            // if neither are null and values do not match add error
-            if (!isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject) &&
-                (!isDebtorsNotePreviousTotalNull(debtors))
+            && (!debtors.getPreviousPeriod().getTotal().equals(
+            previousPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
+                                        .getDebtors()))) {
 
-                && (!debtors.getPreviousPeriod().getTotal().equals(
-                previousPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
-                                            .getDebtors()))) {
-
-                addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
-            }
+            addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
         }
     }
 
     private void crossValidateCurrentPeriod(Errors errors, HttpServletRequest request,
                                             Debtors debtors,
-                                            String CompanyAccountsId) throws DataException {
+                                            String companyAccountsId) throws DataException {
 
-        String currentPeriodId = currentPeriodService.generateID(CompanyAccountsId);
+        String currentPeriodId = currentPeriodService.generateID(companyAccountsId);
 
         // get current period object
         ResponseObject<CurrentPeriod> currentPeriodResponseObject;
@@ -290,7 +284,7 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         }
 
         // if note is null and balance sheet isn't null add error
-        if ((debtors.getCurrentPeriod() == null || debtors.getCurrentPeriod().getTotal() == null) &&
+       if (isDebtorsNoteCurrentTotalNull(debtors) &&
             currentPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
                                        .getDebtors() != null) {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -66,7 +66,6 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         Errors errors = new Errors();
 
         crossValidate(errors, request, companyAccountsId, debtors);
-        crossValidatePreviousPeriod(errors, request, companyAccountsId, debtors);
 
         if (debtors != null) {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -1,20 +1,27 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
+import com.mongodb.MongoException;
 import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.exception.ServiceException;
+import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.Debtors;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.service.CompanyService;
+import uk.gov.companieshouse.api.accounts.service.impl.CurrentPeriodService;
+import uk.gov.companieshouse.api.accounts.service.impl.DebtorsService;
+import uk.gov.companieshouse.api.accounts.service.impl.PreviousPeriodService;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.transaction.Transaction;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 
 @Component
-public class DebtorsValidator extends BaseValidator {
+public class DebtorsValidator extends BaseValidator implements CrossValidator {
 
     @Value("${invalid.note}")
     private String invalidNote;
@@ -22,28 +29,47 @@ public class DebtorsValidator extends BaseValidator {
     @Value("${inconsistent.data}")
     private String inconsistentData;
 
+    @Value("${current.balancesheet.not.equal}")
+    private String currentBalanceSheetNotEqual;
+
+    @Value("${previous.balancesheet.not.equal}")
+    private String previousBalanceSheetNotEqual;
+
     private static final String DEBTORS_PATH = "$.debtors";
     private static final String DEBTORS_PATH_PREVIOUS = DEBTORS_PATH + ".previous_period";
     private static final String CURRENT_TOTAL_PATH = DEBTORS_PATH + ".current_period.total";
     private static final String PREVIOUS_TOTAL_PATH = DEBTORS_PATH_PREVIOUS + ".total";
     private static final String PREVIOUS_TRADE_DEBTORS = DEBTORS_PATH_PREVIOUS + ".trade_debtors";
-    private static final String PREVIOUS_PREPAYMENTS = DEBTORS_PATH_PREVIOUS + ".prepayments_and_accrued_income";
+    private static final String PREVIOUS_PREPAYMENTS =
+        DEBTORS_PATH_PREVIOUS + ".prepayments_and_accrued_income";
     private static final String PREVIOUS_OTHER_DEBTORS = DEBTORS_PATH_PREVIOUS + ".other_debtors";
-    private static final String PREVIOUS_GREATER_THAN_ONE_YEAR = DEBTORS_PATH_PREVIOUS + ".greater_than_one_year";
+    private static final String PREVIOUS_GREATER_THAN_ONE_YEAR =
+        DEBTORS_PATH_PREVIOUS + ".greater_than_one_year";
 
     private CompanyService companyService;
+    private DebtorsService debtorsService;
 
     @Autowired
-    public DebtorsValidator(CompanyService companyService) {
+    private CurrentPeriodService currentPeriodService;
+
+    @Autowired
+    private PreviousPeriodService previousPeriodService;;
+
+    @Autowired
+    public DebtorsValidator(CompanyService companyService, DebtorsService debtorsService) throws DataException {
         this.companyService = companyService;
+        this.debtorsService = debtorsService;
     }
 
-    public Errors validateDebtors(@Valid Debtors debtors,
-                                  Transaction transaction) throws DataException {
+    public Errors validateDebtors(@Valid Debtors debtors, Transaction transaction,
+                                  String companyAccountsId,
+                                  HttpServletRequest request) throws DataException {
 
         Errors errors = new Errors();
 
         if (debtors != null) {
+
+            crossValidate(errors, request, companyAccountsId);
 
             if (debtors.getCurrentPeriod() != null) {
 
@@ -62,7 +88,8 @@ public class DebtorsValidator extends BaseValidator {
                 }
             }
 
-        } return errors;
+        }
+        return errors;
     }
 
     private void validatePreviousPeriodDebtors(Errors errors, Debtors debtors) {
@@ -114,7 +141,8 @@ public class DebtorsValidator extends BaseValidator {
                 Optional.ofNullable(debtors.getCurrentPeriod().getTradeDebtors()).orElse(0L);
             Long prepayments =
                 Optional.ofNullable(debtors.getCurrentPeriod().getPrepaymentsAndAccruedIncome())
-                        .orElse(0L); Long otherDebtors =
+                        .orElse(0L);
+            Long otherDebtors =
                 Optional.ofNullable(debtors.getCurrentPeriod().getOtherDebtors()).orElse(0L);
             Long moreThanOneYear =
                 Optional.ofNullable(debtors.getCurrentPeriod().getGreaterThanOneYear()).orElse(0L);
@@ -133,7 +161,8 @@ public class DebtorsValidator extends BaseValidator {
             Long traderDebtors =
                 Optional.ofNullable(debtors.getPreviousPeriod().getTradeDebtors()).orElse(0L);
             Long prepayments =
-                Optional.ofNullable(debtors.getPreviousPeriod().getPrepaymentsAndAccruedIncome()).orElse(0L);
+                Optional.ofNullable(debtors.getPreviousPeriod().getPrepaymentsAndAccruedIncome())
+                        .orElse(0L);
             Long otherDebtors =
                 Optional.ofNullable(debtors.getPreviousPeriod().getOtherDebtors()).orElse(0L);
             Long moreThanOneYear =
@@ -183,6 +212,60 @@ public class DebtorsValidator extends BaseValidator {
             addInconsistentDataError(errors, PREVIOUS_TOTAL_PATH);
         }
     }
+
+
+    @Override
+    public Errors crossValidate(Errors errors, HttpServletRequest request,
+                                String CompanyAccountsId) throws DataException {
+
+        String currentPeriodId = currentPeriodService.generateID(CompanyAccountsId);
+
+        // Get Debtors resource
+        ResponseObject<Debtors> debtorsResponseObject;
+
+        try {
+            debtorsResponseObject = debtorsService.findById(currentPeriodId, request);
+        } catch (MongoException e) {
+            throw new DataException(e.getMessage(), e);
+        }
+
+        Long currentDebtorsTotalValue =
+            debtorsResponseObject.getData().getCurrentPeriod().getTotal();
+        Long previousDebtorsValue = debtorsResponseObject.getData().getPreviousPeriod().getTotal();
+
+        // get current period object
+        ResponseObject<CurrentPeriod> currentPeriodResponseObject;
+
+        try {
+            currentPeriodResponseObject = currentPeriodService.findById(currentPeriodId, request);
+        } catch (MongoException e) {
+            throw new DataException(e.getMessage(), e);
+        }
+
+        Long balanceSheetDebtorsCurrent =
+            currentPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets().getDebtors();
+
+        if (currentDebtorsTotalValue != balanceSheetDebtorsCurrent) {
+            addError(errors, currentBalanceSheetNotEqual, CURRENT_TOTAL_PATH);
+
+        }
+
+//            // get previous period object
+//            ResponseObject<PreviousPeriod> periodResponseObject;
+//
+//            try {
+//                periodResponseObject = previousPeriodService.findById(currentPeriodId, request);
+//            } catch (MongoException e) {
+//                throw new DataException(e.getMessage(), e);
+//            }
+//            Long balanceSheetDebtorsPrevious =
+//                periodResponseObject.getData().getBalanceSheet().getCurrentAssets().getDebtors();
+//
+//
+//            if (previousDebtorsValue != balanceSheetDebtorsPrevious) {
+//                addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
+//
+//            }
+        return errors;
+    }
 }
-
-

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -139,15 +139,13 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
             Long traderDebtors =
                 Optional.ofNullable(debtors.getCurrentPeriod().getTradeDebtors()).orElse(0L);
             Long prepayments =
-                Optional.ofNullable(debtors.getCurrentPeriod().getPrepaymentsAndAccruedIncome())
-                        .orElse(0L);
+                Optional.ofNullable(debtors.getCurrentPeriod().getPrepaymentsAndAccruedIncome()).orElse(0L);
             Long otherDebtors =
                 Optional.ofNullable(debtors.getCurrentPeriod().getOtherDebtors()).orElse(0L);
             Long moreThanOneYear =
                 Optional.ofNullable(debtors.getCurrentPeriod().getGreaterThanOneYear()).orElse(0L);
 
             Long total = debtors.getCurrentPeriod().getTotal();
-
             Long sum = traderDebtors + prepayments + otherDebtors + moreThanOneYear;
 
             validateAggregateTotal(total, sum, CURRENT_TOTAL_PATH, errors);
@@ -160,15 +158,13 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
             Long traderDebtors =
                 Optional.ofNullable(debtors.getPreviousPeriod().getTradeDebtors()).orElse(0L);
             Long prepayments =
-                Optional.ofNullable(debtors.getPreviousPeriod().getPrepaymentsAndAccruedIncome())
-                        .orElse(0L);
+                Optional.ofNullable(debtors.getPreviousPeriod().getPrepaymentsAndAccruedIncome()).orElse(0L);
             Long otherDebtors =
                 Optional.ofNullable(debtors.getPreviousPeriod().getOtherDebtors()).orElse(0L);
             Long moreThanOneYear =
                 Optional.ofNullable(debtors.getPreviousPeriod().getGreaterThanOneYear()).orElse(0L);
 
             Long total = debtors.getPreviousPeriod().getTotal();
-
             Long sum = traderDebtors + prepayments + otherDebtors + moreThanOneYear;
 
             validateAggregateTotal(total, sum, PREVIOUS_TOTAL_PATH, errors);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -51,17 +51,16 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     private PreviousPeriodService previousPeriodService;
 
     @Autowired
-    public DebtorsValidator(CompanyService companyService,
-                            CurrentPeriodService currentPeriodService,
-                            PreviousPeriodService previousPeriodService) {
+    public DebtorsValidator (CompanyService companyService, CurrentPeriodService currentPeriodService,
+            PreviousPeriodService previousPeriodService) {
         this.companyService = companyService;
         this.currentPeriodService = currentPeriodService;
         this.previousPeriodService = previousPeriodService;
     }
 
-    public Errors validateDebtors(@Valid Debtors debtors, Transaction transaction,
-                                  String companyAccountsId,
-                                  HttpServletRequest request) throws DataException {
+    public Errors validateDebtors (@Valid Debtors debtors, Transaction transaction,
+            String companyAccountsId,
+            HttpServletRequest request) throws DataException {
 
         Errors errors = new Errors();
 
@@ -90,37 +89,37 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         return errors;
     }
 
-    private void validatePreviousPeriodDebtors(Errors errors, Debtors debtors) {
+    private void validatePreviousPeriodDebtors (Errors errors, Debtors debtors) {
 
         validateRequiredPreviousPeriodTotalFieldNotNull(debtors, errors);
         validatePreviousPeriodTotalIsCorrect(debtors, errors);
     }
 
-    private void addInconsistentDataError(Errors errors, String errorPath) {
+    private void addInconsistentDataError (Errors errors, String errorPath) {
 
         addError(errors, inconsistentData, errorPath);
     }
 
-    private void validateCurrentPeriodDebtors(Errors errors, Debtors debtors) {
+    private void validateCurrentPeriodDebtors (Errors errors, Debtors debtors) {
 
         validateRequiredCurrentPeriodTotalFieldNotNull(debtors, errors);
         validateCurrentPeriodTotalIsCorrect(debtors, errors);
     }
 
-    private void validateRequiredCurrentPeriodTotalFieldNotNull(Debtors debtors, Errors errors) {
+    private void validateRequiredCurrentPeriodTotalFieldNotNull (Debtors debtors, Errors errors) {
 
         if ((debtors.getCurrentPeriod().getTradeDebtors() != null ||
                 debtors.getCurrentPeriod().getPrepaymentsAndAccruedIncome() != null ||
                 debtors.getCurrentPeriod().getOtherDebtors() != null ||
                 debtors.getCurrentPeriod().getGreaterThanOneYear() != null ||
-                !debtors.getCurrentPeriod().getDetails().isEmpty()) &&
+                ! debtors.getCurrentPeriod().getDetails().isEmpty()) &&
                 debtors.getCurrentPeriod().getTotal() == null) {
 
             addError(errors, invalidNote, CURRENT_TOTAL_PATH);
         }
     }
 
-    private void validateRequiredPreviousPeriodTotalFieldNotNull(Debtors debtors, Errors errors) {
+    private void validateRequiredPreviousPeriodTotalFieldNotNull (Debtors debtors, Errors errors) {
 
         if ((debtors.getPreviousPeriod().getTradeDebtors() != null ||
                 debtors.getPreviousPeriod().getPrepaymentsAndAccruedIncome() != null ||
@@ -132,7 +131,7 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         }
     }
 
-    private void validateCurrentPeriodTotalIsCorrect(Debtors debtors, Errors errors) {
+    private void validateCurrentPeriodTotalIsCorrect (Debtors debtors, Errors errors) {
 
         if (debtors.getCurrentPeriod().getTotal() != null) {
             Long traderDebtors =
@@ -152,7 +151,7 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         }
     }
 
-    private void validatePreviousPeriodTotalIsCorrect(Debtors debtors, Errors errors) {
+    private void validatePreviousPeriodTotalIsCorrect (Debtors debtors, Errors errors) {
 
         if (debtors.getPreviousPeriod().getTotal() != null) {
             Long traderDebtors =
@@ -172,7 +171,7 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         }
     }
 
-    private boolean isMultipleYearFiler(Transaction transaction) throws DataException {
+    private boolean isMultipleYearFiler (Transaction transaction) throws DataException {
 
         try {
             CompanyProfileApi companyProfile =
@@ -186,7 +185,7 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         }
     }
 
-    private void validateInconsistentPeriodFiling(Debtors debtors, Errors errors) {
+    private void validateInconsistentPeriodFiling (Debtors debtors, Errors errors) {
 
         if (debtors.getPreviousPeriod().getTradeDebtors() != null) {
             addInconsistentDataError(errors, PREVIOUS_TRADE_DEBTORS);
@@ -214,8 +213,9 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
      */
 
     @Override
-    public Errors crossValidate(Errors errors, HttpServletRequest request, String companyAccountsId,
-                                Debtors debtors) throws DataException {
+    public Errors crossValidate (Errors errors, HttpServletRequest request,
+            String companyAccountsId,
+            Debtors debtors) throws DataException {
 
         crossValidateCurrentPeriod(errors, request, debtors, companyAccountsId);
         crossValidatePreviousPeriod(errors, request, companyAccountsId, debtors);
@@ -223,9 +223,9 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         return errors;
     }
 
-    private void crossValidatePreviousPeriod(Errors errors, HttpServletRequest request,
-                                             String companyAccountsId,
-                                             Debtors debtors) throws DataException {
+    private void crossValidatePreviousPeriod (Errors errors, HttpServletRequest request,
+            String companyAccountsId,
+            Debtors debtors) throws DataException {
 
         ResponseObject<PreviousPeriod> previousPeriodResponseObject =
                 getPreviousPeriodResponseObject(request, companyAccountsId);
@@ -235,12 +235,12 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         checkIfPreviousBalanceAndNoteValuesAreEqual(errors, debtors, previousPeriodResponseObject);
     }
 
-    private void checkIfPreviousBalanceAndNoteValuesAreEqual(Errors errors, Debtors debtors,
-                                                             ResponseObject<PreviousPeriod> previousPeriodResponseObject) {
-        if (!isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject) &&
-                (!isDebtorsNotePreviousTotalNull(debtors))
+    private void checkIfPreviousBalanceAndNoteValuesAreEqual (Errors errors, Debtors debtors,
+            ResponseObject<PreviousPeriod> previousPeriodResponseObject) {
+        if (! isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject) &&
+                (! isDebtorsNotePreviousTotalNull(debtors))
 
-                && (!debtors.getPreviousPeriod().getTotal().equals(
+                && (! debtors.getPreviousPeriod().getTotal().equals(
                 previousPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
                         .getDebtors()))) {
 
@@ -248,25 +248,25 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         }
     }
 
-    private void checkIsPrevousBalanceNullAndNoteNot(Errors errors, Debtors debtors,
-                                                     ResponseObject<PreviousPeriod> previousPeriodResponseObject) {
+    private void checkIsPrevousBalanceNullAndNoteNot (Errors errors, Debtors debtors,
+            ResponseObject<PreviousPeriod> previousPeriodResponseObject) {
         if (isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject) &&
-                (!isDebtorsNotePreviousTotalNull(debtors))) {
+                (! isDebtorsNotePreviousTotalNull(debtors))) {
 
             addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
         }
     }
 
-    private void checkIfPreviousNoteIsNullAndBalanceNot(Errors errors, Debtors debtors,
-                                                        ResponseObject<PreviousPeriod> previousPeriodResponseObject) {
+    private void checkIfPreviousNoteIsNullAndBalanceNot (Errors errors, Debtors debtors,
+            ResponseObject<PreviousPeriod> previousPeriodResponseObject) {
         if (isDebtorsNotePreviousTotalNull(debtors) &&
-                (!isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject))) {
+                (! isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject))) {
 
             addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
         }
     }
 
-    private ResponseObject<PreviousPeriod> getPreviousPeriodResponseObject(
+    private ResponseObject<PreviousPeriod> getPreviousPeriodResponseObject (
             HttpServletRequest request, String companyAccountsId) throws DataException {
         String previousPeriodId = previousPeriodService.generateID(companyAccountsId);
 
@@ -282,9 +282,9 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         return previousPeriodResponseObject;
     }
 
-    private void crossValidateCurrentPeriod(Errors errors, HttpServletRequest request,
-                                            Debtors debtors,
-                                            String companyAccountsId) throws DataException {
+    private void crossValidateCurrentPeriod (Errors errors, HttpServletRequest request,
+            Debtors debtors,
+            String companyAccountsId) throws DataException {
 
         ResponseObject<CurrentPeriod> currentPeriodResponseObject =
                 getCurrentPeriodResponseObject(request, companyAccountsId);
@@ -294,10 +294,10 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         checkIfCurrentBalanceAndNoteValuesAreEqual(errors, debtors, currentPeriodResponseObject);
     }
 
-    private void checkIfCurrentBalanceAndNoteValuesAreEqual(Errors errors, Debtors debtors,
-                                                            ResponseObject<CurrentPeriod> currentPeriodResponseObject) {
-        if (!(isCurrentPeriodBalanceSheetDebtorsNull(currentPeriodResponseObject)) &&
-                (!isDebtorsNoteCurrentTotalNull(debtors))
+    private void checkIfCurrentBalanceAndNoteValuesAreEqual (Errors errors, Debtors debtors,
+            ResponseObject<CurrentPeriod> currentPeriodResponseObject) {
+        if (! (isCurrentPeriodBalanceSheetDebtorsNull(currentPeriodResponseObject)) &&
+                (! isDebtorsNoteCurrentTotalNull(debtors))
 
                 && (debtors.getCurrentPeriod().getTotal() !=
                 currentPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
@@ -307,17 +307,17 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         }
     }
 
-    private void checkIfCurrentBalanceSheetIsNullAndNoteNot(Errors errors, Debtors debtors,
-                                                            ResponseObject<CurrentPeriod> currentPeriodResponseObject) {
+    private void checkIfCurrentBalanceSheetIsNullAndNoteNot (Errors errors, Debtors debtors,
+            ResponseObject<CurrentPeriod> currentPeriodResponseObject) {
         if (isCurrentPeriodBalanceSheetDebtorsNull(currentPeriodResponseObject) &&
-                (!isDebtorsNoteCurrentTotalNull(debtors))) {
+                (! isDebtorsNoteCurrentTotalNull(debtors))) {
 
             addError(errors, currentBalanceSheetNotEqual, CURRENT_TOTAL_PATH);
         }
     }
 
-    private void checkIfCurrentNoteIsNullAndBalanceSheetNot(Errors errors, Debtors debtors,
-                                                            ResponseObject<CurrentPeriod> currentPeriodResponseObject) {
+    private void checkIfCurrentNoteIsNullAndBalanceSheetNot (Errors errors, Debtors debtors,
+            ResponseObject<CurrentPeriod> currentPeriodResponseObject) {
         if (isDebtorsNoteCurrentTotalNull(debtors) &&
                 currentPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
                         .getDebtors() != null) {
@@ -326,8 +326,8 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         }
     }
 
-    private ResponseObject<CurrentPeriod> getCurrentPeriodResponseObject(HttpServletRequest request,
-                                                                         String companyAccountsId) throws DataException {
+    private ResponseObject<CurrentPeriod> getCurrentPeriodResponseObject (HttpServletRequest request,
+            String companyAccountsId) throws DataException {
         String currentPeriodId = currentPeriodService.generateID(companyAccountsId);
 
         ResponseObject<CurrentPeriod> currentPeriodResponseObject;
@@ -342,11 +342,11 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         return currentPeriodResponseObject;
     }
 
-    private boolean isDebtorsNoteCurrentTotalNull(Debtors debtors) {
+    private boolean isDebtorsNoteCurrentTotalNull (Debtors debtors) {
         return debtors.getCurrentPeriod() == null || debtors.getCurrentPeriod().getTotal() == null;
     }
 
-    private boolean isCurrentPeriodBalanceSheetDebtorsNull(
+    private boolean isCurrentPeriodBalanceSheetDebtorsNull (
             ResponseObject<CurrentPeriod> currentPeriodResponseObject) {
 
         return currentPeriodResponseObject.getData() == null ||
@@ -356,7 +356,7 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
                         .getDebtors() == null;
     }
 
-    private boolean isPreviousPeriodBalanceSheetDebtorsNull(
+    private boolean isPreviousPeriodBalanceSheetDebtorsNull (
             ResponseObject<PreviousPeriod> previousPeriodResponseObject) {
 
         return previousPeriodResponseObject.getData() == null ||
@@ -366,7 +366,7 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
                         .getDebtors() == null;
     }
 
-    private boolean isDebtorsNotePreviousTotalNull(Debtors debtors) {
+    private boolean isDebtorsNotePreviousTotalNull (Debtors debtors) {
 
         return debtors.getPreviousPeriod() == null ||
                 debtors.getPreviousPeriod().getTotal() == null;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -41,10 +41,10 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     private static final String PREVIOUS_TOTAL_PATH = DEBTORS_PATH_PREVIOUS + ".total";
     private static final String PREVIOUS_TRADE_DEBTORS = DEBTORS_PATH_PREVIOUS + ".trade_debtors";
     private static final String PREVIOUS_PREPAYMENTS =
-        DEBTORS_PATH_PREVIOUS + ".prepayments_and_accrued_income";
+            DEBTORS_PATH_PREVIOUS + ".prepayments_and_accrued_income";
     private static final String PREVIOUS_OTHER_DEBTORS = DEBTORS_PATH_PREVIOUS + ".other_debtors";
     private static final String PREVIOUS_GREATER_THAN_ONE_YEAR =
-        DEBTORS_PATH_PREVIOUS + ".greater_than_one_year";
+            DEBTORS_PATH_PREVIOUS + ".greater_than_one_year";
 
     private CompanyService companyService;
     private CurrentPeriodService currentPeriodService;
@@ -110,11 +110,11 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     private void validateRequiredCurrentPeriodTotalFieldNotNull(Debtors debtors, Errors errors) {
 
         if ((debtors.getCurrentPeriod().getTradeDebtors() != null ||
-            debtors.getCurrentPeriod().getPrepaymentsAndAccruedIncome() != null ||
-            debtors.getCurrentPeriod().getOtherDebtors() != null ||
-            debtors.getCurrentPeriod().getGreaterThanOneYear() != null ||
-            !debtors.getCurrentPeriod().getDetails().isEmpty()) &&
-            debtors.getCurrentPeriod().getTotal() == null) {
+                debtors.getCurrentPeriod().getPrepaymentsAndAccruedIncome() != null ||
+                debtors.getCurrentPeriod().getOtherDebtors() != null ||
+                debtors.getCurrentPeriod().getGreaterThanOneYear() != null ||
+                !debtors.getCurrentPeriod().getDetails().isEmpty()) &&
+                debtors.getCurrentPeriod().getTotal() == null) {
 
             addError(errors, invalidNote, CURRENT_TOTAL_PATH);
         }
@@ -123,10 +123,10 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     private void validateRequiredPreviousPeriodTotalFieldNotNull(Debtors debtors, Errors errors) {
 
         if ((debtors.getPreviousPeriod().getTradeDebtors() != null ||
-            debtors.getPreviousPeriod().getPrepaymentsAndAccruedIncome() != null ||
-            debtors.getPreviousPeriod().getOtherDebtors() != null ||
-            debtors.getPreviousPeriod().getGreaterThanOneYear() != null) &&
-            debtors.getPreviousPeriod().getTotal() == null) {
+                debtors.getPreviousPeriod().getPrepaymentsAndAccruedIncome() != null ||
+                debtors.getPreviousPeriod().getOtherDebtors() != null ||
+                debtors.getPreviousPeriod().getGreaterThanOneYear() != null) &&
+                debtors.getPreviousPeriod().getTotal() == null) {
 
             addError(errors, invalidNote, PREVIOUS_TOTAL_PATH);
         }
@@ -136,14 +136,14 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
 
         if (debtors.getCurrentPeriod().getTotal() != null) {
             Long traderDebtors =
-                Optional.ofNullable(debtors.getCurrentPeriod().getTradeDebtors()).orElse(0L);
+                    Optional.ofNullable(debtors.getCurrentPeriod().getTradeDebtors()).orElse(0L);
             Long prepayments =
-                Optional.ofNullable(debtors.getCurrentPeriod().getPrepaymentsAndAccruedIncome())
-                        .orElse(0L);
+                    Optional.ofNullable(debtors.getCurrentPeriod().getPrepaymentsAndAccruedIncome())
+                            .orElse(0L);
             Long otherDebtors =
-                Optional.ofNullable(debtors.getCurrentPeriod().getOtherDebtors()).orElse(0L);
+                    Optional.ofNullable(debtors.getCurrentPeriod().getOtherDebtors()).orElse(0L);
             Long moreThanOneYear =
-                Optional.ofNullable(debtors.getCurrentPeriod().getGreaterThanOneYear()).orElse(0L);
+                    Optional.ofNullable(debtors.getCurrentPeriod().getGreaterThanOneYear()).orElse(0L);
 
             Long total = debtors.getCurrentPeriod().getTotal();
             Long sum = traderDebtors + prepayments + otherDebtors + moreThanOneYear;
@@ -156,14 +156,14 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
 
         if (debtors.getPreviousPeriod().getTotal() != null) {
             Long traderDebtors =
-                Optional.ofNullable(debtors.getPreviousPeriod().getTradeDebtors()).orElse(0L);
+                    Optional.ofNullable(debtors.getPreviousPeriod().getTradeDebtors()).orElse(0L);
             Long prepayments =
-                Optional.ofNullable(debtors.getPreviousPeriod().getPrepaymentsAndAccruedIncome())
-                        .orElse(0L);
+                    Optional.ofNullable(debtors.getPreviousPeriod().getPrepaymentsAndAccruedIncome())
+                            .orElse(0L);
             Long otherDebtors =
-                Optional.ofNullable(debtors.getPreviousPeriod().getOtherDebtors()).orElse(0L);
+                    Optional.ofNullable(debtors.getPreviousPeriod().getOtherDebtors()).orElse(0L);
             Long moreThanOneYear =
-                Optional.ofNullable(debtors.getPreviousPeriod().getGreaterThanOneYear()).orElse(0L);
+                    Optional.ofNullable(debtors.getPreviousPeriod().getGreaterThanOneYear()).orElse(0L);
 
             Long total = debtors.getPreviousPeriod().getTotal();
             Long sum = traderDebtors + prepayments + otherDebtors + moreThanOneYear;
@@ -176,10 +176,10 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
 
         try {
             CompanyProfileApi companyProfile =
-                companyService.getCompanyProfile(transaction.getCompanyNumber());
+                    companyService.getCompanyProfile(transaction.getCompanyNumber());
             return (companyProfile != null && companyProfile.getAccounts() != null &&
-                companyProfile.getAccounts().getLastAccounts() != null &&
-                companyProfile.getAccounts().getLastAccounts().getPeriodStartOn() != null);
+                    companyProfile.getAccounts().getLastAccounts() != null &&
+                    companyProfile.getAccounts().getLastAccounts().getPeriodStartOn() != null);
 
         } catch (ServiceException e) {
             throw new DataException(e.getMessage(), e);
@@ -224,47 +224,57 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     }
 
     private void crossValidatePreviousPeriod(Errors errors, HttpServletRequest request,
-                                             String CompanyAccountsId,
+                                             String companyAccountsId,
                                              Debtors debtors) throws DataException {
 
         ResponseObject<PreviousPeriod> previousPeriodResponseObject =
-            getPreviousPeriodResponseObject(request, CompanyAccountsId);
+                getPreviousPeriodResponseObject(request, companyAccountsId);
 
-        // if note is null and balance sheet value isn't add error
-        if (isDebtorsNotePreviousTotalNull(debtors) &&
-            (!isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject))) {
+        checkIfPreviousNoteIsNullAndBalanceNot(errors, debtors, previousPeriodResponseObject);
+        checkIsPrevousBalanceNullAndNoteNot(errors, debtors, previousPeriodResponseObject);
+        checkIfPreviousBalanceAndNoteValuesAreEqual(errors, debtors, previousPeriodResponseObject);
+    }
 
-            addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
-        }
-
-        // if balance sheet value is null and note value isn't add error
-        if (isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject) &&
-            (!isDebtorsNotePreviousTotalNull(debtors))) {
-
-            addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
-        }
-
-        // if neither are null and values do not match add error
+    private void checkIfPreviousBalanceAndNoteValuesAreEqual(Errors errors, Debtors debtors,
+                                                             ResponseObject<PreviousPeriod> previousPeriodResponseObject) {
         if (!isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject) &&
-            (!isDebtorsNotePreviousTotalNull(debtors))
+                (!isDebtorsNotePreviousTotalNull(debtors))
 
-            && (!debtors.getPreviousPeriod().getTotal().equals(
-            previousPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
-                                        .getDebtors()))) {
+                && (!debtors.getPreviousPeriod().getTotal().equals(
+                previousPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
+                        .getDebtors()))) {
+
+            addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
+        }
+    }
+
+    private void checkIsPrevousBalanceNullAndNoteNot(Errors errors, Debtors debtors,
+                                                     ResponseObject<PreviousPeriod> previousPeriodResponseObject) {
+        if (isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject) &&
+                (!isDebtorsNotePreviousTotalNull(debtors))) {
+
+            addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
+        }
+    }
+
+    private void checkIfPreviousNoteIsNullAndBalanceNot(Errors errors, Debtors debtors,
+                                                        ResponseObject<PreviousPeriod> previousPeriodResponseObject) {
+        if (isDebtorsNotePreviousTotalNull(debtors) &&
+                (!isPreviousPeriodBalanceSheetDebtorsNull(previousPeriodResponseObject))) {
 
             addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
         }
     }
 
     private ResponseObject<PreviousPeriod> getPreviousPeriodResponseObject(
-        HttpServletRequest request, String CompanyAccountsId) throws DataException {
-        String previousPeriodId = previousPeriodService.generateID(CompanyAccountsId);
+            HttpServletRequest request, String companyAccountsId) throws DataException {
+        String previousPeriodId = previousPeriodService.generateID(companyAccountsId);
 
         ResponseObject<PreviousPeriod> previousPeriodResponseObject;
 
         try {
             previousPeriodResponseObject =
-                previousPeriodService.findById(previousPeriodId, request);
+                    previousPeriodService.findById(previousPeriodId, request);
         } catch (MongoException e) {
 
             throw new DataException(e.getMessage(), e);
@@ -277,30 +287,40 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
                                             String companyAccountsId) throws DataException {
 
         ResponseObject<CurrentPeriod> currentPeriodResponseObject =
-            getCurrentPeriodResponseObject(request, companyAccountsId);
+                getCurrentPeriodResponseObject(request, companyAccountsId);
 
-        // if note is null and balance sheet isn't null add error
-       if (isDebtorsNoteCurrentTotalNull(debtors) &&
-            currentPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
-                                       .getDebtors() != null) {
+        checkIfCurrentNoteIsNullAndBalanceSheetNot(errors, debtors, currentPeriodResponseObject);
+        checkIfCurrentBalanceSheetIsNullAndNoteNot(errors, debtors, currentPeriodResponseObject);
+        checkIfCurrentBalanceAndNoteValuesAreEqual(errors, debtors, currentPeriodResponseObject);
+    }
 
-            addError(errors, currentBalanceSheetNotEqual, CURRENT_TOTAL_PATH);
-        }
-
-        // if balance sheet value is null and note value isn't add error
-        if (isCurrentPeriodBalanceSheetDebtorsNull(currentPeriodResponseObject) &&
-            (!isDebtorsNoteCurrentTotalNull(debtors))) {
-
-            addError(errors, currentBalanceSheetNotEqual, CURRENT_TOTAL_PATH);
-        }
-
-        // if neither are null and values don't match add error
+    private void checkIfCurrentBalanceAndNoteValuesAreEqual(Errors errors, Debtors debtors,
+                                                            ResponseObject<CurrentPeriod> currentPeriodResponseObject) {
         if (!(isCurrentPeriodBalanceSheetDebtorsNull(currentPeriodResponseObject)) &&
-            (!isDebtorsNoteCurrentTotalNull(debtors))
+                (!isDebtorsNoteCurrentTotalNull(debtors))
 
-            && (debtors.getCurrentPeriod().getTotal() !=
-            currentPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
-                                       .getDebtors())) {
+                && (debtors.getCurrentPeriod().getTotal() !=
+                currentPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
+                        .getDebtors())) {
+
+            addError(errors, currentBalanceSheetNotEqual, CURRENT_TOTAL_PATH);
+        }
+    }
+
+    private void checkIfCurrentBalanceSheetIsNullAndNoteNot(Errors errors, Debtors debtors,
+                                                            ResponseObject<CurrentPeriod> currentPeriodResponseObject) {
+        if (isCurrentPeriodBalanceSheetDebtorsNull(currentPeriodResponseObject) &&
+                (!isDebtorsNoteCurrentTotalNull(debtors))) {
+
+            addError(errors, currentBalanceSheetNotEqual, CURRENT_TOTAL_PATH);
+        }
+    }
+
+    private void checkIfCurrentNoteIsNullAndBalanceSheetNot(Errors errors, Debtors debtors,
+                                                            ResponseObject<CurrentPeriod> currentPeriodResponseObject) {
+        if (isDebtorsNoteCurrentTotalNull(debtors) &&
+                currentPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
+                        .getDebtors() != null) {
 
             addError(errors, currentBalanceSheetNotEqual, CURRENT_TOTAL_PATH);
         }
@@ -327,28 +347,28 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     }
 
     private boolean isCurrentPeriodBalanceSheetDebtorsNull(
-        ResponseObject<CurrentPeriod> currentPeriodResponseObject) {
+            ResponseObject<CurrentPeriod> currentPeriodResponseObject) {
 
         return currentPeriodResponseObject.getData() == null ||
-            currentPeriodResponseObject.getData().getBalanceSheet() == null ||
-            currentPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets() == null ||
-            currentPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
-                                       .getDebtors() == null;
+                currentPeriodResponseObject.getData().getBalanceSheet() == null ||
+                currentPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets() == null ||
+                currentPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
+                        .getDebtors() == null;
     }
 
     private boolean isPreviousPeriodBalanceSheetDebtorsNull(
-        ResponseObject<PreviousPeriod> previousPeriodResponseObject) {
+            ResponseObject<PreviousPeriod> previousPeriodResponseObject) {
 
         return previousPeriodResponseObject.getData() == null ||
-            previousPeriodResponseObject.getData().getBalanceSheet() == null ||
-            previousPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets() == null ||
-            previousPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
-                                        .getDebtors() == null;
+                previousPeriodResponseObject.getData().getBalanceSheet() == null ||
+                previousPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets() == null ||
+                previousPeriodResponseObject.getData().getBalanceSheet().getCurrentAssets()
+                        .getDebtors() == null;
     }
 
     private boolean isDebtorsNotePreviousTotalNull(Debtors debtors) {
 
         return debtors.getPreviousPeriod() == null ||
-            debtors.getPreviousPeriod().getTotal() == null;
+                debtors.getPreviousPeriod().getTotal() == null;
     }
 }

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -15,3 +15,5 @@ shareholders.mismatch=shareholder_funds_mismatch
 mandatory.element.missing=mandatory_element_missing
 invalid.note=invalid_note
 inconsistent.data=inconsistent_data
+current.balancesheet.not.equal=value_not_equal_to_current_period_on_balance_sheet
+previous.balancesheet.not.equal=value_not_equal_to_previous_period_on_balance_sheet

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsServiceTest.java
@@ -1,205 +1,206 @@
-//package uk.gov.companieshouse.api.accounts.service.impl;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertNotNull;
-//import static org.junit.jupiter.api.Assertions.assertNull;
-//import static org.junit.jupiter.api.Assertions.assertThrows;
-//import static org.mockito.Mockito.doReturn;
-//import static org.mockito.Mockito.when;
-//
-//import com.mongodb.MongoException;
-//import java.util.HashMap;
-//import java.util.Map;
-//import java.util.Optional;
-//import javax.servlet.http.HttpServletRequest;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.TestInstance;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.ArgumentMatchers;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.dao.DuplicateKeyException;
-//import uk.gov.companieshouse.api.accounts.exception.DataException;
-//import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
-//import uk.gov.companieshouse.api.accounts.model.entity.notes.debtors.DebtorsDataEntity;
-//import uk.gov.companieshouse.api.accounts.model.entity.notes.debtors.DebtorsEntity;
-//import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.Debtors;
-//import uk.gov.companieshouse.api.accounts.model.validation.Errors;
-//import uk.gov.companieshouse.api.accounts.repository.DebtorsRepository;
-//import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
-//import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
-//import uk.gov.companieshouse.api.accounts.transaction.Transaction;
-//import uk.gov.companieshouse.api.accounts.transformer.DebtorsTransformer;
-//import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
-//import uk.gov.companieshouse.api.accounts.validation.DebtorsValidator;
-//
-//@ExtendWith(MockitoExtension.class)
-//@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-//public class DebtorsServiceTest {
-//
-//    @Mock
-//    private DebtorsTransformer mockTransformer;
-//
-//    @Mock
-//    private Debtors mockDebtors;
-//
-//    @Mock
-//    private HttpServletRequest mockRequest;
-//
-//    @Mock
-//    private Transaction mockTransaction;
-//
-//    @Mock
-//    private DebtorsRepository mockRepository;
-//
-//    @Mock
-//    private DebtorsValidator debtorsValidator;
-//
-//    @Mock
-//    private SmallFullService mockSmallFullService;
-//
-//    @Mock
-//    private DuplicateKeyException mockDuplicateKeyException;
-//
-//    @Mock
-//    private MongoException mockMongoException;
-//
-//    @Mock
-//    private KeyIdGenerator mockKeyIdGenerator;
-//
-//    @Mock
-//    private Errors errors;
-//
-//    @InjectMocks
-//    private DebtorsService service;
-//
-//    private DebtorsEntity debtorsEntity;
-//
-//    @BeforeEach
-//    void setUp() {
-//
-//        DebtorsDataEntity dataEntity = new DebtorsDataEntity();
-//
-//        Map<String, String> links = new HashMap<>();
-//        links.put(BasicLinkType.SELF.getLink(), "self_link");
-//        dataEntity.setLinks(links);
-//
-//        debtorsEntity = new DebtorsEntity();
-//        debtorsEntity.setData(dataEntity);
-//    }
-//
-//    @Test
-//    @DisplayName("Tests the successful creation of a debtors resource")
-//    void canCreateDebtors() throws DataException {
-//
-//        errors = new Errors();
-//
-//        when(mockTransformer.transform(mockDebtors)).thenReturn(debtorsEntity);
-//        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction)).thenReturn(errors);
-//
-//
-//        ResponseObject<Debtors> result = service.create(mockDebtors, mockTransaction,
-//            "", mockRequest);
-//
-//        assertNotNull(result);
-//        assertEquals(mockDebtors, result.getData());
-//    }
-//
-//    @Test
-//    @DisplayName("Tests the duplicate key when creating a Debtors resource")
-//    void createDebtorsDuplicateKey() throws DataException {
-//
-//        doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
-//            .any(Debtors.class));
-//
-//        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction)).thenReturn(errors);
-//        when(mockRepository.insert(debtorsEntity)).thenThrow(mockDuplicateKeyException);
-//
-//        ResponseObject response = service.create(mockDebtors, mockTransaction, "", mockRequest);
-//
-//        assertNotNull(response);
-//        assertEquals(response.getStatus(), ResponseStatus.DUPLICATE_KEY_ERROR);
-//        assertNull(response.getData());
-//    }
-//
-//    @Test
-//    @DisplayName("Tests the mongo exception when creating Debtors")
-//    void createDebtorsMongoExceptionFailure() throws DataException {
-//
-//        doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
-//            .any(Debtors.class));
-//        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction)).thenReturn(errors);
-//        when(mockRepository.insert(debtorsEntity)).thenThrow(mockMongoException);
-//
-//        assertThrows(DataException.class,
-//            () -> service.create(mockDebtors, mockTransaction, "", mockRequest));
-//    }
-//
-//    @Test
-//    @DisplayName("Tests the successful update of an Debtors resource")
-//    void canUpdateADebtors() throws DataException {
-//
-//        when(mockTransformer.transform(mockDebtors)).thenReturn(debtorsEntity);
-//
-//        ResponseObject<Debtors> result = service.update(mockDebtors, mockTransaction,
-//            "", mockRequest);
-//
-//        assertNotNull(result);
-//        assertEquals(mockDebtors, result.getData());
-//    }
-//
-//    @Test
-//    @DisplayName("Tests the mongo exception when updating an Debtors")
-//    void updateDebtorsMongoExceptionFailure() {
-//
-//        doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
-//            .any(Debtors.class));
-//        when(mockRepository.save(debtorsEntity)).thenThrow(mockMongoException);
-//
-//        assertThrows(DataException.class,
-//            () -> service.update(mockDebtors, mockTransaction, "", mockRequest));
-//    }
-//
-//    @Test
-//    @DisplayName("Tests the successful find of an Debtors resource")
-//    void findDebtors() throws DataException {
-//
-//        when(mockRepository.findById(""))
-//            .thenReturn(Optional.ofNullable(debtorsEntity));
-//        when(mockTransformer.transform(debtorsEntity)).thenReturn(mockDebtors);
-//
-//        ResponseObject<Debtors> result = service.findById("", mockRequest);
-//
-//        assertNotNull(result);
-//        assertEquals(mockDebtors, result.getData());
-//    }
-//
-//    @Test
-//    @DisplayName("Tests Debtors response not found")
-//    void findDebtorsResponseNotFound() throws DataException {
-//        debtorsEntity = null;
-//        when(mockRepository.findById(""))
-//            .thenReturn(Optional.ofNullable(debtorsEntity));
-//
-//        ResponseObject<Debtors> result = service.findById("", mockRequest);
-//
-//        assertNotNull(result);
-//        assertEquals(responseStatusNotFound(), result.getStatus());
-//    }
-//
-//    @Test
-//    @DisplayName("Tests mongo exception thrown on find of an Debtors resource")
-//    void findDebtorsMongoException() {
-//        when(mockRepository.findById("")).thenThrow(mockMongoException);
-//
-//        assertThrows(DataException.class, () -> service.findById("", mockRequest));
-//    }
-//
-//    private ResponseStatus responseStatusNotFound() {
-//        ResponseObject responseObject = new ResponseObject<>(ResponseStatus.NOT_FOUND);
-//        return responseObject.getStatus();
-//    }
-//}
+package uk.gov.companieshouse.api.accounts.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.MongoException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
+import uk.gov.companieshouse.api.accounts.model.entity.notes.debtors.DebtorsDataEntity;
+import uk.gov.companieshouse.api.accounts.model.entity.notes.debtors.DebtorsEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.Debtors;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.repository.DebtorsRepository;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.accounts.transaction.Transaction;
+import uk.gov.companieshouse.api.accounts.transformer.DebtorsTransformer;
+import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
+import uk.gov.companieshouse.api.accounts.validation.DebtorsValidator;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DebtorsServiceTest {
+
+    @Mock
+    private DebtorsTransformer mockTransformer;
+
+    @Mock
+    private Debtors mockDebtors;
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    @Mock
+    private Transaction mockTransaction;
+
+    @Mock
+    private DebtorsRepository mockRepository;
+
+    @Mock
+    private DebtorsValidator debtorsValidator;
+
+    @Mock
+    private SmallFullService mockSmallFullService;
+
+    @Mock
+    private DuplicateKeyException mockDuplicateKeyException;
+
+    @Mock
+    private MongoException mockMongoException;
+
+    @Mock
+    private KeyIdGenerator mockKeyIdGenerator;
+
+    @Mock
+    private Errors errors;
+
+    @InjectMocks
+    private DebtorsService service;
+
+    private DebtorsEntity debtorsEntity;
+
+    @BeforeEach
+    void setUp() {
+
+        DebtorsDataEntity dataEntity = new DebtorsDataEntity();
+
+        Map<String, String> links = new HashMap<>();
+        links.put(BasicLinkType.SELF.getLink(), "self_link");
+        dataEntity.setLinks(links);
+
+        debtorsEntity = new DebtorsEntity();
+        debtorsEntity.setData(dataEntity);
+    }
+
+    @Test
+    @DisplayName("Tests the successful creation of a debtors resource")
+    void canCreateDebtors() throws DataException {
+
+        errors = new Errors();
+
+        when(mockTransformer.transform(mockDebtors)).thenReturn(debtorsEntity);
+        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "",mockRequest)).thenReturn(errors);
+
+
+        ResponseObject<Debtors> result = service.create(mockDebtors, mockTransaction,
+            "", mockRequest);
+
+        assertNotNull(result);
+        assertEquals(mockDebtors, result.getData());
+    }
+
+    @Test
+    @DisplayName("Tests the duplicate key when creating a Debtors resource")
+    void createDebtorsDuplicateKey() throws DataException {
+
+        doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
+            .any(Debtors.class));
+
+        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "",mockRequest)).thenReturn(errors);
+        when(mockRepository.insert(debtorsEntity)).thenThrow(mockDuplicateKeyException);
+
+        ResponseObject response = service.create(mockDebtors, mockTransaction, "",
+            mockRequest);
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), ResponseStatus.DUPLICATE_KEY_ERROR);
+        assertNull(response.getData());
+    }
+
+    @Test
+    @DisplayName("Tests the mongo exception when creating Debtors")
+    void createDebtorsMongoExceptionFailure() throws DataException {
+
+        doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
+            .any(Debtors.class));
+        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "",mockRequest)).thenReturn(errors);
+        when(mockRepository.insert(debtorsEntity)).thenThrow(mockMongoException);
+
+        assertThrows(DataException.class,
+            () -> service.create(mockDebtors, mockTransaction, "", mockRequest));
+    }
+
+    @Test
+    @DisplayName("Tests the successful update of an Debtors resource")
+    void canUpdateADebtors() throws DataException {
+
+        when(mockTransformer.transform(mockDebtors)).thenReturn(debtorsEntity);
+
+        ResponseObject<Debtors> result = service.update(mockDebtors, mockTransaction,
+            "", mockRequest);
+
+        assertNotNull(result);
+        assertEquals(mockDebtors, result.getData());
+    }
+
+    @Test
+    @DisplayName("Tests the mongo exception when updating an Debtors")
+    void updateDebtorsMongoExceptionFailure() {
+
+        doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
+            .any(Debtors.class));
+        when(mockRepository.save(debtorsEntity)).thenThrow(mockMongoException);
+
+        assertThrows(DataException.class,
+            () -> service.update(mockDebtors, mockTransaction, "", mockRequest));
+    }
+
+    @Test
+    @DisplayName("Tests the successful find of an Debtors resource")
+    void findDebtors() throws DataException {
+
+        when(mockRepository.findById(""))
+            .thenReturn(Optional.ofNullable(debtorsEntity));
+        when(mockTransformer.transform(debtorsEntity)).thenReturn(mockDebtors);
+
+        ResponseObject<Debtors> result = service.findById("", mockRequest);
+
+        assertNotNull(result);
+        assertEquals(mockDebtors, result.getData());
+    }
+
+    @Test
+    @DisplayName("Tests Debtors response not found")
+    void findDebtorsResponseNotFound() throws DataException {
+        debtorsEntity = null;
+        when(mockRepository.findById(""))
+            .thenReturn(Optional.ofNullable(debtorsEntity));
+
+        ResponseObject<Debtors> result = service.findById("", mockRequest);
+
+        assertNotNull(result);
+        assertEquals(responseStatusNotFound(), result.getStatus());
+    }
+
+    @Test
+    @DisplayName("Tests mongo exception thrown on find of an Debtors resource")
+    void findDebtorsMongoException() {
+        when(mockRepository.findById("")).thenThrow(mockMongoException);
+
+        assertThrows(DataException.class, () -> service.findById("", mockRequest));
+    }
+
+    private ResponseStatus responseStatusNotFound() {
+        ResponseObject responseObject = new ResponseObject<>(ResponseStatus.NOT_FOUND);
+        return responseObject.getStatus();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsServiceTest.java
@@ -1,205 +1,205 @@
-package uk.gov.companieshouse.api.accounts.service.impl;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
-
-import com.mongodb.MongoException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import javax.servlet.http.HttpServletRequest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DuplicateKeyException;
-import uk.gov.companieshouse.api.accounts.exception.DataException;
-import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
-import uk.gov.companieshouse.api.accounts.model.entity.notes.debtors.DebtorsDataEntity;
-import uk.gov.companieshouse.api.accounts.model.entity.notes.debtors.DebtorsEntity;
-import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.Debtors;
-import uk.gov.companieshouse.api.accounts.model.validation.Errors;
-import uk.gov.companieshouse.api.accounts.repository.DebtorsRepository;
-import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
-import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
-import uk.gov.companieshouse.api.accounts.transaction.Transaction;
-import uk.gov.companieshouse.api.accounts.transformer.DebtorsTransformer;
-import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
-import uk.gov.companieshouse.api.accounts.validation.DebtorsValidator;
-
-@ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class DebtorsServiceTest {
-
-    @Mock
-    private DebtorsTransformer mockTransformer;
-
-    @Mock
-    private Debtors mockDebtors;
-
-    @Mock
-    private HttpServletRequest mockRequest;
-
-    @Mock
-    private Transaction mockTransaction;
-
-    @Mock
-    private DebtorsRepository mockRepository;
-
-    @Mock
-    private DebtorsValidator debtorsValidator;
-
-    @Mock
-    private SmallFullService mockSmallFullService;
-
-    @Mock
-    private DuplicateKeyException mockDuplicateKeyException;
-
-    @Mock
-    private MongoException mockMongoException;
-
-    @Mock
-    private KeyIdGenerator mockKeyIdGenerator;
-
-    @Mock
-    private Errors errors;
-
-    @InjectMocks
-    private DebtorsService service;
-
-    private DebtorsEntity debtorsEntity;
-
-    @BeforeEach
-    void setUp() {
-
-        DebtorsDataEntity dataEntity = new DebtorsDataEntity();
-
-        Map<String, String> links = new HashMap<>();
-        links.put(BasicLinkType.SELF.getLink(), "self_link");
-        dataEntity.setLinks(links);
-
-        debtorsEntity = new DebtorsEntity();
-        debtorsEntity.setData(dataEntity);
-    }
-
-    @Test
-    @DisplayName("Tests the successful creation of a debtors resource")
-    void canCreateDebtors() throws DataException {
-
-        errors = new Errors();
-
-        when(mockTransformer.transform(mockDebtors)).thenReturn(debtorsEntity);
-        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction)).thenReturn(errors);
-
-
-        ResponseObject<Debtors> result = service.create(mockDebtors, mockTransaction,
-            "", mockRequest);
-
-        assertNotNull(result);
-        assertEquals(mockDebtors, result.getData());
-    }
-
-    @Test
-    @DisplayName("Tests the duplicate key when creating a Debtors resource")
-    void createDebtorsDuplicateKey() throws DataException {
-
-        doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
-            .any(Debtors.class));
-
-        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction)).thenReturn(errors);
-        when(mockRepository.insert(debtorsEntity)).thenThrow(mockDuplicateKeyException);
-
-        ResponseObject response = service.create(mockDebtors, mockTransaction, "", mockRequest);
-
-        assertNotNull(response);
-        assertEquals(response.getStatus(), ResponseStatus.DUPLICATE_KEY_ERROR);
-        assertNull(response.getData());
-    }
-
-    @Test
-    @DisplayName("Tests the mongo exception when creating Debtors")
-    void createDebtorsMongoExceptionFailure() throws DataException {
-
-        doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
-            .any(Debtors.class));
-        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction)).thenReturn(errors);
-        when(mockRepository.insert(debtorsEntity)).thenThrow(mockMongoException);
-
-        assertThrows(DataException.class,
-            () -> service.create(mockDebtors, mockTransaction, "", mockRequest));
-    }
-
-    @Test
-    @DisplayName("Tests the successful update of an Debtors resource")
-    void canUpdateADebtors() throws DataException {
-
-        when(mockTransformer.transform(mockDebtors)).thenReturn(debtorsEntity);
-
-        ResponseObject<Debtors> result = service.update(mockDebtors, mockTransaction,
-            "", mockRequest);
-
-        assertNotNull(result);
-        assertEquals(mockDebtors, result.getData());
-    }
-
-    @Test
-    @DisplayName("Tests the mongo exception when updating an Debtors")
-    void updateDebtorsMongoExceptionFailure() {
-
-        doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
-            .any(Debtors.class));
-        when(mockRepository.save(debtorsEntity)).thenThrow(mockMongoException);
-
-        assertThrows(DataException.class,
-            () -> service.update(mockDebtors, mockTransaction, "", mockRequest));
-    }
-
-    @Test
-    @DisplayName("Tests the successful find of an Debtors resource")
-    void findDebtors() throws DataException {
-
-        when(mockRepository.findById(""))
-            .thenReturn(Optional.ofNullable(debtorsEntity));
-        when(mockTransformer.transform(debtorsEntity)).thenReturn(mockDebtors);
-
-        ResponseObject<Debtors> result = service.findById("", mockRequest);
-
-        assertNotNull(result);
-        assertEquals(mockDebtors, result.getData());
-    }
-
-    @Test
-    @DisplayName("Tests Debtors response not found")
-    void findDebtorsResponseNotFound() throws DataException {
-        debtorsEntity = null;
-        when(mockRepository.findById(""))
-            .thenReturn(Optional.ofNullable(debtorsEntity));
-
-        ResponseObject<Debtors> result = service.findById("", mockRequest);
-
-        assertNotNull(result);
-        assertEquals(responseStatusNotFound(), result.getStatus());
-    }
-
-    @Test
-    @DisplayName("Tests mongo exception thrown on find of an Debtors resource")
-    void findDebtorsMongoException() {
-        when(mockRepository.findById("")).thenThrow(mockMongoException);
-
-        assertThrows(DataException.class, () -> service.findById("", mockRequest));
-    }
-
-    private ResponseStatus responseStatusNotFound() {
-        ResponseObject responseObject = new ResponseObject<>(ResponseStatus.NOT_FOUND);
-        return responseObject.getStatus();
-    }
-}
+//package uk.gov.companieshouse.api.accounts.service.impl;
+//
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.junit.jupiter.api.Assertions.assertNotNull;
+//import static org.junit.jupiter.api.Assertions.assertNull;
+//import static org.junit.jupiter.api.Assertions.assertThrows;
+//import static org.mockito.Mockito.doReturn;
+//import static org.mockito.Mockito.when;
+//
+//import com.mongodb.MongoException;
+//import java.util.HashMap;
+//import java.util.Map;
+//import java.util.Optional;
+//import javax.servlet.http.HttpServletRequest;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.TestInstance;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.ArgumentMatchers;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.springframework.dao.DuplicateKeyException;
+//import uk.gov.companieshouse.api.accounts.exception.DataException;
+//import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
+//import uk.gov.companieshouse.api.accounts.model.entity.notes.debtors.DebtorsDataEntity;
+//import uk.gov.companieshouse.api.accounts.model.entity.notes.debtors.DebtorsEntity;
+//import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.Debtors;
+//import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+//import uk.gov.companieshouse.api.accounts.repository.DebtorsRepository;
+//import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+//import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+//import uk.gov.companieshouse.api.accounts.transaction.Transaction;
+//import uk.gov.companieshouse.api.accounts.transformer.DebtorsTransformer;
+//import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
+//import uk.gov.companieshouse.api.accounts.validation.DebtorsValidator;
+//
+//@ExtendWith(MockitoExtension.class)
+//@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+//public class DebtorsServiceTest {
+//
+//    @Mock
+//    private DebtorsTransformer mockTransformer;
+//
+//    @Mock
+//    private Debtors mockDebtors;
+//
+//    @Mock
+//    private HttpServletRequest mockRequest;
+//
+//    @Mock
+//    private Transaction mockTransaction;
+//
+//    @Mock
+//    private DebtorsRepository mockRepository;
+//
+//    @Mock
+//    private DebtorsValidator debtorsValidator;
+//
+//    @Mock
+//    private SmallFullService mockSmallFullService;
+//
+//    @Mock
+//    private DuplicateKeyException mockDuplicateKeyException;
+//
+//    @Mock
+//    private MongoException mockMongoException;
+//
+//    @Mock
+//    private KeyIdGenerator mockKeyIdGenerator;
+//
+//    @Mock
+//    private Errors errors;
+//
+//    @InjectMocks
+//    private DebtorsService service;
+//
+//    private DebtorsEntity debtorsEntity;
+//
+//    @BeforeEach
+//    void setUp() {
+//
+//        DebtorsDataEntity dataEntity = new DebtorsDataEntity();
+//
+//        Map<String, String> links = new HashMap<>();
+//        links.put(BasicLinkType.SELF.getLink(), "self_link");
+//        dataEntity.setLinks(links);
+//
+//        debtorsEntity = new DebtorsEntity();
+//        debtorsEntity.setData(dataEntity);
+//    }
+//
+//    @Test
+//    @DisplayName("Tests the successful creation of a debtors resource")
+//    void canCreateDebtors() throws DataException {
+//
+//        errors = new Errors();
+//
+//        when(mockTransformer.transform(mockDebtors)).thenReturn(debtorsEntity);
+//        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction)).thenReturn(errors);
+//
+//
+//        ResponseObject<Debtors> result = service.create(mockDebtors, mockTransaction,
+//            "", mockRequest);
+//
+//        assertNotNull(result);
+//        assertEquals(mockDebtors, result.getData());
+//    }
+//
+//    @Test
+//    @DisplayName("Tests the duplicate key when creating a Debtors resource")
+//    void createDebtorsDuplicateKey() throws DataException {
+//
+//        doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
+//            .any(Debtors.class));
+//
+//        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction)).thenReturn(errors);
+//        when(mockRepository.insert(debtorsEntity)).thenThrow(mockDuplicateKeyException);
+//
+//        ResponseObject response = service.create(mockDebtors, mockTransaction, "", mockRequest);
+//
+//        assertNotNull(response);
+//        assertEquals(response.getStatus(), ResponseStatus.DUPLICATE_KEY_ERROR);
+//        assertNull(response.getData());
+//    }
+//
+//    @Test
+//    @DisplayName("Tests the mongo exception when creating Debtors")
+//    void createDebtorsMongoExceptionFailure() throws DataException {
+//
+//        doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
+//            .any(Debtors.class));
+//        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction)).thenReturn(errors);
+//        when(mockRepository.insert(debtorsEntity)).thenThrow(mockMongoException);
+//
+//        assertThrows(DataException.class,
+//            () -> service.create(mockDebtors, mockTransaction, "", mockRequest));
+//    }
+//
+//    @Test
+//    @DisplayName("Tests the successful update of an Debtors resource")
+//    void canUpdateADebtors() throws DataException {
+//
+//        when(mockTransformer.transform(mockDebtors)).thenReturn(debtorsEntity);
+//
+//        ResponseObject<Debtors> result = service.update(mockDebtors, mockTransaction,
+//            "", mockRequest);
+//
+//        assertNotNull(result);
+//        assertEquals(mockDebtors, result.getData());
+//    }
+//
+//    @Test
+//    @DisplayName("Tests the mongo exception when updating an Debtors")
+//    void updateDebtorsMongoExceptionFailure() {
+//
+//        doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
+//            .any(Debtors.class));
+//        when(mockRepository.save(debtorsEntity)).thenThrow(mockMongoException);
+//
+//        assertThrows(DataException.class,
+//            () -> service.update(mockDebtors, mockTransaction, "", mockRequest));
+//    }
+//
+//    @Test
+//    @DisplayName("Tests the successful find of an Debtors resource")
+//    void findDebtors() throws DataException {
+//
+//        when(mockRepository.findById(""))
+//            .thenReturn(Optional.ofNullable(debtorsEntity));
+//        when(mockTransformer.transform(debtorsEntity)).thenReturn(mockDebtors);
+//
+//        ResponseObject<Debtors> result = service.findById("", mockRequest);
+//
+//        assertNotNull(result);
+//        assertEquals(mockDebtors, result.getData());
+//    }
+//
+//    @Test
+//    @DisplayName("Tests Debtors response not found")
+//    void findDebtorsResponseNotFound() throws DataException {
+//        debtorsEntity = null;
+//        when(mockRepository.findById(""))
+//            .thenReturn(Optional.ofNullable(debtorsEntity));
+//
+//        ResponseObject<Debtors> result = service.findById("", mockRequest);
+//
+//        assertNotNull(result);
+//        assertEquals(responseStatusNotFound(), result.getStatus());
+//    }
+//
+//    @Test
+//    @DisplayName("Tests mongo exception thrown on find of an Debtors resource")
+//    void findDebtorsMongoException() {
+//        when(mockRepository.findById("")).thenThrow(mockMongoException);
+//
+//        assertThrows(DataException.class, () -> service.findById("", mockRequest));
+//    }
+//
+//    private ResponseStatus responseStatusNotFound() {
+//        ResponseObject responseObject = new ResponseObject<>(ResponseStatus.NOT_FOUND);
+//        return responseObject.getStatus();
+//    }
+//}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -1,279 +1,704 @@
-//
-//package uk.gov.companieshouse.api.accounts.validation;
-//
-//import static org.junit.jupiter.api.Assertions.assertFalse;
-//import static org.junit.jupiter.api.Assertions.assertThrows;
-//import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static org.mockito.Mockito.when;
-//
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.TestInstance;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.test.util.ReflectionTestUtils;
-//import uk.gov.companieshouse.api.accounts.exception.DataException;
-//import uk.gov.companieshouse.api.accounts.exception.ServiceException;
-//import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.CurrentPeriod;
-//import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.Debtors;
-//import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.PreviousPeriod;
-//import uk.gov.companieshouse.api.accounts.model.validation.Error;
-//import uk.gov.companieshouse.api.accounts.model.validation.Errors;
-//import uk.gov.companieshouse.api.accounts.service.CompanyService;
-//import uk.gov.companieshouse.api.accounts.transaction.Transaction;
-//import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
-//import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
-//import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
-//
-//@ExtendWith(MockitoExtension.class)
-//@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-//public class DebtorsValidatorTest {
-//
-//    private static final String DEBTORS_PATH = "$.debtors";
-//    private static final String DEBTORS_PATH_PREVIOUS = DEBTORS_PATH + ".previous_period";
-//    private static final String CURRENT_TOTAL_PATH = DEBTORS_PATH + ".current_period.total";
-//    private static final String PREVIOUS_TOTAL_PATH = DEBTORS_PATH_PREVIOUS + ".total";
-//    private static final String PREVIOUS_TRADE_DEBTORS = DEBTORS_PATH_PREVIOUS + ".trade_debtors";
-//    private static final String PREVIOUS_PREPAYMENTS = DEBTORS_PATH_PREVIOUS + ".prepayments_and_accrued_income";
-//    private static final String PREVIOUS_OTHER_DEBTORS = DEBTORS_PATH_PREVIOUS + ".other_debtors";
-//    private static final String PREVIOUS_GREATER_THAN_ONE_YEAR = DEBTORS_PATH_PREVIOUS + ".greater_than_one_year";
-//    private static final String COMPANY_NUMBER = "12345";
-//    private static final String INVALID_NOTE_VALUE = "invalid_note";
-//    private static final String INVALID_NOTE_NAME = "invalidNote";
-//    private static final String INCORRECT_TOTAL_NAME = "incorrectTotal";
-//    private static final String INCORRECT_TOTAL_VALUE = "incorrect_total";
-//    private static final String INCONSISTENT_DATA_NAME = "inconsistentData";
-//    private static final String INCONSISTENT_DATA_VALUE = "inconsistent_data";
-//
-//    private static final long INVALID_TOTAL = 200L;
-//
-//    private Debtors debtors;
-//    private Errors errors;
-//
-//    @Mock
-//    private CompanyService mockCompanyService;
-//
-//    @Mock
-//    private Transaction mockTransaction;
-//
-//    @Mock
-//    private ServiceException mockServiceException;
-//
-//    private DebtorsValidator validator;
-//
-//    @BeforeEach
-//    void setup() {
-//        debtors = new Debtors();
-//        errors = new Errors();
-//        validator = new DebtorsValidator(mockCompanyService);
-//    }
-//
-//    @Test
-//    @DisplayName("Tests the validation passes on valid single year debtors resource")
-//    void testSuccessfulSingleYearDebtorsNote() throws DataException {
-//
-//        addValidCurrentDebtors();
-//
-//        errors = validator.validateDebtors(debtors, mockTransaction);
-//
-//        assertFalse(errors.hasErrors());
-//
-//    }
-//
-//    @Test
-//    @DisplayName("Tests the validation passes on valid multiple year debtors resource")
-//    void testSuccessfulMultipleYearDebtorsNote() throws DataException, ServiceException {
-//
-//        addValidCurrentDebtors();
-//        addValidPreviousDebtors();
-//
-//        when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
-//            .thenReturn(createCompanyProfileMultipleYearFiler());
-//
-//        errors = validator.validateDebtors(debtors, mockTransaction);
-//
-//        assertFalse(errors.hasErrors());
-//
-//    }
-//
-//    @Test
-//    @DisplayName("Tests the validation fails on single year filer filing previous period")
-//    void tesInvalidMultipleYearDebtorsNote() throws DataException, ServiceException {
-//
-//        addValidCurrentDebtors();
-//        addValidPreviousDebtors();
-//
-//        when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
-//            .thenReturn(createCompanyProfileSingleYearFiler());
-//
-//        ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
-//
-//        errors = validator.validateDebtors(debtors, mockTransaction);
-//
-//        assertTrue(errors.hasErrors());
-//
-//        assertTrue(
-//            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TRADE_DEBTORS)));
-//
-//        assertTrue(
-//            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_PREPAYMENTS)));
-//
-//        assertTrue(errors
-//            .containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_GREATER_THAN_ONE_YEAR)));
-//
-//        assertTrue(
-//            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_OTHER_DEBTORS)));
-//
-//        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TOTAL_PATH)));
-//    }
-//
-//    @Test
-//    @DisplayName("Tests the validation fails on previous period incorrect total")
-//    void testIncorrectPreviousDebtorsTotal() throws DataException, ServiceException {
-//
-//        addValidCurrentDebtors();
-//
-//        PreviousPeriod previousDebtors = new PreviousPeriod();
-//        previousDebtors.setTradeDebtors(2L);
-//        previousDebtors.setTotal(INVALID_TOTAL);
-//
-//        debtors.setPreviousPeriod(previousDebtors);
-//
-//        ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME, INCORRECT_TOTAL_VALUE);
-//
-//        when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
-//            .thenReturn(createCompanyProfileMultipleYearFiler());
-//
-//        errors = validator.validateDebtors(debtors, mockTransaction);
-//
-//        assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE, PREVIOUS_TOTAL_PATH)));
-//    }
-//
-//    @Test
-//    @DisplayName("Tests the validation fails on previous period missing total")
-//    void testMissingPreviousDebtorsTotal() throws DataException, ServiceException {
-//
-//        addValidCurrentDebtors();
-//
-//        PreviousPeriod previousDebtors = new PreviousPeriod();
-//        previousDebtors.setTradeDebtors(2L);
-//
-//        debtors.setPreviousPeriod(previousDebtors);
-//
-//        when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
-//        when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
-//            .thenReturn(createCompanyProfileMultipleYearFiler());
-//
-//        ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
-//
-//        errors = validator.validateDebtors(debtors, mockTransaction);
-//
-//        assertTrue(errors.hasErrors());
-//
-//        assertTrue(errors.containsError(createError(INVALID_NOTE_VALUE, PREVIOUS_TOTAL_PATH)));
-//    }
-//
-//    @Test
-//    @DisplayName("Tests current period incorrect total throws error")
-//    void testIncorrectCurrentTotal() throws DataException {
-//
-//        CurrentPeriod currentDebtors = new CurrentPeriod();
-//        currentDebtors.setTradeDebtors(1L);
-//        currentDebtors.setPrepaymentsAndAccruedIncome(2L);
-//        currentDebtors.setGreaterThanOneYear(3L);
-//        currentDebtors.setOtherDebtors(4L);
-//        currentDebtors.setTotal(INVALID_TOTAL);
-//
-//        debtors.setCurrentPeriod(currentDebtors);
-//        ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME, INCORRECT_TOTAL_VALUE);
-//
-//        errors = validator.validateDebtors(debtors, mockTransaction);
-//
-//        assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE, CURRENT_TOTAL_PATH)));
-//    }
-//
-//    @Test
-//    @DisplayName("Tests current period missing total throws error")
-//    void testMissingCurrentTotal() throws DataException {
-//
-//        CurrentPeriod currentDebtors = new CurrentPeriod();
-//        currentDebtors.setTradeDebtors(1L);
-//
-//        debtors.setCurrentPeriod(currentDebtors);
-//        ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
-//
-//        errors = validator.validateDebtors(debtors, mockTransaction);
-//
-//        assertTrue(errors.hasErrors());
-//
-//        assertTrue(errors.containsError(createError(INVALID_NOTE_VALUE, CURRENT_TOTAL_PATH)));
-//    }
-//
-//    @Test
-//    @DisplayName("Tests data exception thrown when company profile api call fails")
-//    void testDataExceptionThrown() throws DataException, ServiceException {
-//
-//        addValidCurrentDebtors();
-//
-//        PreviousPeriod previousDebtors = new PreviousPeriod();
-//        previousDebtors.setTradeDebtors(2L);
-//        debtors.setPreviousPeriod(previousDebtors);
-//
-//        when(mockCompanyService.getCompanyProfile(null)).thenThrow(mockServiceException);
-//
-//        assertThrows(DataException.class,
-//            () -> validator.validateDebtors(debtors, mockTransaction));
-//    }
-//
-//    private void addValidCurrentDebtors() {
-//
-//        CurrentPeriod currentDebtors = new CurrentPeriod();
-//        currentDebtors.setTradeDebtors(1L);
-//        currentDebtors.setPrepaymentsAndAccruedIncome(2L);
-//        currentDebtors.setGreaterThanOneYear(3L);
-//        currentDebtors.setOtherDebtors(4L);
-//        currentDebtors.setTotal(10L);
-//        currentDebtors.setDetails("details");
-//
-//        debtors.setCurrentPeriod(currentDebtors);
-//    }
-//
-//    private CompanyProfileApi createCompanyProfileMultipleYearFiler() {
-//
-//        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
-//        CompanyAccountApi companyAccountApi = new CompanyAccountApi();
-//
-//        LastAccountsApi lastAccountsApi = new LastAccountsApi();
-//        lastAccountsApi.setType("lastaccounts");
-//
-//        companyAccountApi.setLastAccounts(lastAccountsApi);
-//        companyProfileApi.setAccounts(companyAccountApi);
-//
-//        return companyProfileApi;
-//    }
-//
-//    private CompanyProfileApi createCompanyProfileSingleYearFiler() {
-//
-//        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
-//        return companyProfileApi;
-//    }
-//
-//    private Error createError(String error, String path) {
-//        return new Error(error, path, LocationType.JSON_PATH.getValue(),
-//            ErrorType.VALIDATION.getType());
-//    }
-//
-//    private void addValidPreviousDebtors() {
-//        PreviousPeriod previousDebtors = new PreviousPeriod();
-//        previousDebtors.setTradeDebtors(2L);
-//        previousDebtors.setPrepaymentsAndAccruedIncome(4L);
-//        previousDebtors.setGreaterThanOneYear(6L);
-//        previousDebtors.setOtherDebtors(8L);
-//        previousDebtors.setTotal(20L);
-//
-//        debtors.setPreviousPeriod(previousDebtors);
-//    }
-//}
-//
+
+package uk.gov.companieshouse.api.accounts.validation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.MongoException;
+import java.time.LocalDate;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.exception.ServiceException;
+import uk.gov.companieshouse.api.accounts.model.rest.BalanceSheet;
+import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.CurrentPeriod;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.Debtors;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.PreviousPeriod;
+import uk.gov.companieshouse.api.accounts.model.validation.Error;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.service.CompanyService;
+import uk.gov.companieshouse.api.accounts.service.impl.CurrentPeriodService;
+import uk.gov.companieshouse.api.accounts.service.impl.PreviousPeriodService;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.accounts.transaction.Transaction;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
+import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DebtorsValidatorTest {
+
+    private static final String DEBTORS_PATH = "$.debtors";
+    private static final String DEBTORS_PATH_PREVIOUS = DEBTORS_PATH + ".previous_period";
+    private static final String CURRENT_TOTAL_PATH = DEBTORS_PATH + ".current_period.total";
+    private static final String PREVIOUS_TOTAL_PATH = DEBTORS_PATH_PREVIOUS + ".total";
+    private static final String PREVIOUS_TRADE_DEBTORS = DEBTORS_PATH_PREVIOUS + ".trade_debtors";
+    private static final String PREVIOUS_PREPAYMENTS = DEBTORS_PATH_PREVIOUS + ".prepayments_and_accrued_income";
+    private static final String PREVIOUS_OTHER_DEBTORS = DEBTORS_PATH_PREVIOUS + ".other_debtors";
+    private static final String PREVIOUS_GREATER_THAN_ONE_YEAR = DEBTORS_PATH_PREVIOUS + ".greater_than_one_year";
+    private static final String COMPANY_NUMBER = "12345";
+    private static final String INVALID_NOTE_VALUE = "invalid_note";
+    private static final String INVALID_NOTE_NAME = "invalidNote";
+    private static final String INCORRECT_TOTAL_NAME = "incorrectTotal";
+    private static final String INCORRECT_TOTAL_VALUE = "incorrect_total";
+    private static final String INCONSISTENT_DATA_NAME = "inconsistentData";
+    private static final String INCONSISTENT_DATA_VALUE = "inconsistent_data";
+
+    private static final long INVALID_TOTAL = 200L;
+
+    private Debtors debtors;
+    private Errors errors;
+
+    @Mock
+    private CompanyService mockCompanyService;
+
+    @Mock
+    private uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriod;
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    @Mock
+    private Transaction mockTransaction;
+
+    @Mock
+    private ServiceException mockServiceException;
+
+    @Mock
+    private MongoException mockMongoException;
+
+    @Mock
+    private CurrentPeriodService mockCurrentPeriodService;
+
+    @Mock
+    private PreviousPeriodService mockPreviousPeriodService;
+
+    @Mock
+    private ResponseObject mockResponseObject;
+
+    private DebtorsValidator validator;
+
+    private String companyAccountsId="123abc";
+
+    @BeforeEach
+    void setup() {
+        debtors = new Debtors();
+        errors = new Errors();
+        validator = new DebtorsValidator(mockCompanyService, mockCurrentPeriodService, mockPreviousPeriodService);
+    }
+
+    @Test
+    @DisplayName("Tests the validation passes on valid single year debtors resource")
+    void testSuccessfulSingleYearDebtorsNote() throws DataException {
+
+        addValidCurrentDebtors();
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+
+        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(companyAccountsId,
+            mockRequest);
+
+        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+
+        assertFalse(errors.hasErrors());
+
+    }
+
+    @Test
+    @DisplayName("Tests the validation passes on valid multiple year debtors resource")
+    void testSuccessfulMultipleYearDebtorsNote() throws DataException, ServiceException {
+
+        addValidCurrentDebtors();
+        addValidPreviousDebtors();
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+
+        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+            mockRequest);
+
+        when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
+            .thenReturn(createCompanyProfileMultipleYearFiler());
+
+        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
+            "value_not_equal_to_previous_period_on_balance_sheet");
+
+        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+
+        assertFalse(errors.hasErrors());
+
+    }
+
+    @Test
+    @DisplayName("Tests the validation fails on single year filer filing previous period")
+    void tesInvalidMultipleYearDebtorsNote() throws DataException, ServiceException {
+
+        addValidCurrentDebtors();
+        addValidPreviousDebtors();
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+
+        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+            mockRequest);
+//
+//        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> result = previousPeriodService.findById("", request);
+
+        when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
+            .thenReturn(createCompanyProfileSingleYearFiler());
+
+        ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
+        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
+            "value_not_equal_to_current_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
+            "value_not_equal_to_previous_period_on_balance_sheet");
+
+        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+
+        assertTrue(errors.hasErrors());
+        assertTrue(
+            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TRADE_DEBTORS)));
+        assertTrue(
+            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_PREPAYMENTS)));
+        assertTrue(errors
+            .containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_GREATER_THAN_ONE_YEAR)));
+        assertTrue(
+            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_OTHER_DEBTORS)));
+        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TOTAL_PATH)));
+    }
+
+    @Test
+    @DisplayName("Tests the validation fails on previous period incorrect total")
+    void testIncorrectPreviousDebtorsTotal() throws DataException, ServiceException {
+
+        addValidCurrentDebtors();
+
+        PreviousPeriod previousDebtors = new PreviousPeriod();
+        previousDebtors.setTradeDebtors(2L);
+        previousDebtors.setTotal(INVALID_TOTAL);
+
+        debtors.setPreviousPeriod(previousDebtors);
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+
+        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+            mockRequest);
+
+        when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
+            .thenReturn(createCompanyProfileMultipleYearFiler());
+
+        ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME, INCORRECT_TOTAL_VALUE);
+        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
+            "value_not_equal_to_current_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
+            "value_not_equal_to_previous_period_on_balance_sheet");
+
+        when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
+            .thenReturn(createCompanyProfileMultipleYearFiler());
+
+        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+
+        assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE, PREVIOUS_TOTAL_PATH)));
+    }
+
+    @Test
+    @DisplayName("Tests the validation fails on previous period missing total")
+    void testMissingPreviousDebtorsTotal() throws DataException, ServiceException {
+
+        addValidCurrentDebtors();
+
+        PreviousPeriod previousDebtors = new PreviousPeriod();
+        previousDebtors.setTradeDebtors(2L);
+        debtors.setPreviousPeriod(previousDebtors);
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+
+        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+            mockRequest);
+
+        when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
+            .thenReturn(createCompanyProfileMultipleYearFiler());
+
+        ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
+        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
+            "value_not_equal_to_current_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
+            "value_not_equal_to_previous_period_on_balance_sheet");
+
+        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+
+        assertTrue(errors.hasErrors());
+
+        assertTrue(errors.containsError(createError(INVALID_NOTE_VALUE, PREVIOUS_TOTAL_PATH)));
+    }
+
+    @Test
+    @DisplayName("Tests current period incorrect total throws error")
+    void testIncorrectCurrentTotal() throws DataException {
+
+        CurrentPeriod currentDebtors = new CurrentPeriod();
+        currentDebtors.setTradeDebtors(1L);
+        currentDebtors.setPrepaymentsAndAccruedIncome(2L);
+        currentDebtors.setGreaterThanOneYear(3L);
+        currentDebtors.setOtherDebtors(4L);
+        currentDebtors.setTotal(INVALID_TOTAL);
+
+        debtors.setCurrentPeriod(currentDebtors);
+        ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME, INCORRECT_TOTAL_VALUE);
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+
+        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(companyAccountsId,
+            mockRequest);
+
+        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
+            "value_not_equal_to_current_period_on_balance_sheet");
+
+        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+
+        assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE, CURRENT_TOTAL_PATH)));
+    }
+
+    @Test
+    @DisplayName("Tests current period missing total throws error")
+    void testMissingCurrentTotal() throws DataException {
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+
+        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+            mockRequest);
+
+        CurrentPeriod currentDebtors = new CurrentPeriod();
+        currentDebtors.setTradeDebtors(1L);
+
+        debtors.setCurrentPeriod(currentDebtors);
+        ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
+
+        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
+            "value_not_equal_to_current_period_on_balance_sheet");
+
+        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
+            "value_not_equal_to_previous_period_on_balance_sheet");
+
+        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+
+        assertTrue(errors.hasErrors());
+        assertTrue(errors.containsError(createError(INVALID_NOTE_VALUE, CURRENT_TOTAL_PATH)));
+    }
+
+    @Test
+    @DisplayName("Tests data exception thrown when company profile api call fails")
+    void testDataExceptionThrown() throws DataException, ServiceException {
+
+        addValidCurrentDebtors();
+        addValidPreviousDebtors();
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+
+        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+            mockRequest);
+
+        when(mockCompanyService.getCompanyProfile(null)).thenThrow(mockServiceException);
+
+        assertThrows(DataException.class,
+            () -> validator.validateDebtors(debtors, mockTransaction, companyAccountsId,
+                mockRequest));
+    }
+
+    @Test
+    @DisplayName("Tests data exception thrown when current period api call fails")
+    void testDataExceptionThrownWhenRetrievingCurrentPeriod() throws DataException,
+        ServiceException {
+
+        addValidCurrentDebtors();;
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        when(mockCurrentPeriodService.findById(companyAccountsId, mockRequest)).thenThrow(mockMongoException);
+
+        assertThrows(DataException.class,
+            () -> validator.validateDebtors(debtors, mockTransaction, companyAccountsId,
+                mockRequest));
+
+        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
+            "value_not_equal_to_current_period_on_balance_sheet");
+
+        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
+            "value_not_equal_to_previous_period_on_balance_sheet");
+    }
+
+    @Test
+    @DisplayName("Assert different balance sheet and note value throws error")
+    void testMismatchedDebtorsValues() throws DataException, ServiceException {
+
+        addValidCurrentDebtors();
+        addValidPreviousDebtors();
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateDifferentCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+
+        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateDifferentPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+            mockRequest);
+
+        when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
+            .thenReturn(createCompanyProfileMultipleYearFiler());
+
+
+        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
+            "value_not_equal_to_current_period_on_balance_sheet");
+
+        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
+            "value_not_equal_to_previous_period_on_balance_sheet");
+
+        ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
+
+        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+
+        assertTrue(errors.containsError(createError(
+            "value_not_equal_to_current_period_on_balance_sheet", CURRENT_TOTAL_PATH)));
+
+        assertTrue(errors.containsError(createError(
+            "value_not_equal_to_previous_period_on_balance_sheet", PREVIOUS_TOTAL_PATH)));
+
+    }
+
+    @Test
+    @DisplayName("Assert empty balance sheet and populated note value throws error")
+    void testEmptyBalanceSheetMismatchedDebtorsValues() throws DataException, ServiceException {
+
+        addValidCurrentDebtors();
+        addValidPreviousDebtors();
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateNullDebtorsBalanceSheetResponse()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+
+        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(companyAccountsId,
+            mockRequest);
+
+        when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
+            .thenReturn(createCompanyProfileMultipleYearFiler());
+
+
+        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
+            "value_not_equal_to_current_period_on_balance_sheet");
+
+        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
+            "value_not_equal_to_previous_period_on_balance_sheet");
+
+        ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
+
+        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+
+        assertTrue(errors.containsError(createError(
+            "value_not_equal_to_current_period_on_balance_sheet", CURRENT_TOTAL_PATH)));
+
+        assertTrue(errors.containsError(createError(
+            "value_not_equal_to_previous_period_on_balance_sheet", PREVIOUS_TOTAL_PATH)));
+
+    }
+
+    @Test
+    @DisplayName("Assert successful cross validation")
+    void testValidDebtorsCrossValidation() throws DataException, ServiceException {
+
+        addValidCurrentDebtors();
+        addValidPreviousDebtors();
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+
+        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+            mockRequest);
+
+        when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
+            .thenReturn(createCompanyProfileMultipleYearFiler());
+
+
+        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
+            "value_not_equal_to_current_period_on_balance_sheet");
+
+        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
+            "value_not_equal_to_previous_period_on_balance_sheet");
+
+        ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
+
+        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+
+        assertFalse(errors.containsError(createError(
+            "value_not_equal_to_current_period_on_balance_sheet", CURRENT_TOTAL_PATH)));
+
+        assertFalse(errors.containsError(createError(
+            "value_not_equal_to_previous_period_on_balance_sheet", PREVIOUS_TOTAL_PATH)));
+
+    }
+
+    @Test
+    @DisplayName("Assert empty note and populated balance sheet value throws error")
+    void testEmptyNoteMismatchedDebtorsValues() throws DataException, ServiceException {
+
+        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+
+        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+            mockRequest);
+
+        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
+            "value_not_equal_to_current_period_on_balance_sheet");
+
+        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
+            "value_not_equal_to_previous_period_on_balance_sheet");
+
+        ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
+
+        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+
+        assertTrue(errors.containsError(createError(
+            "value_not_equal_to_current_period_on_balance_sheet", CURRENT_TOTAL_PATH)));
+
+        assertTrue(errors.containsError(createError(
+            "value_not_equal_to_previous_period_on_balance_sheet", PREVIOUS_TOTAL_PATH)));
+
+    }
+
+    private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> generateValidCurrentPeriodResponseObject() {
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject =
+            new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod>(
+                ResponseStatus.FOUND);
+
+
+        uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriodTest =
+            new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
+        CurrentAssets currentAssets = new CurrentAssets();
+
+        currentAssets.setDebtors(10L);
+        BalanceSheet balanceSheet = new BalanceSheet();
+        balanceSheet.setCurrentAssets(currentAssets);
+        currentPeriodTest.setBalanceSheet(balanceSheet);
+
+        currentPeriodResponseObject.setData(currentPeriodTest);
+        return currentPeriodResponseObject;
+    }
+
+    private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> generateValidPreviousPeriodResponseObject() {
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject =
+            new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod>(
+                ResponseStatus.FOUND);
+
+        uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod previousPeriodTest =
+            new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
+        CurrentAssets currentAssets = new CurrentAssets();
+        currentAssets.setDebtors(20L);
+        BalanceSheet balanceSheet = new BalanceSheet();
+        balanceSheet.setCurrentAssets(currentAssets);
+        previousPeriodTest.setBalanceSheet(balanceSheet);
+
+        previousPeriodResponseObject.setData(previousPeriodTest);
+        return previousPeriodResponseObject;
+    }
+
+    private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> generateDifferentCurrentPeriodResponseObject() {
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject =
+            new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod>(
+                ResponseStatus.FOUND);
+
+
+        uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriodTest =
+            new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
+        CurrentAssets currentAssets = new CurrentAssets();
+
+        currentAssets.setDebtors(1L);
+        BalanceSheet balanceSheet = new BalanceSheet();
+        balanceSheet.setCurrentAssets(currentAssets);
+        currentPeriodTest.setBalanceSheet(balanceSheet);
+
+        currentPeriodResponseObject.setData(currentPeriodTest);
+        return currentPeriodResponseObject;
+    }
+
+    private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> generateNullDebtorsBalanceSheetResponse() {
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject =
+            new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod>(
+                ResponseStatus.FOUND);
+
+        uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriodTest =
+            new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
+        CurrentAssets currentAssets = new CurrentAssets();
+
+        BalanceSheet balanceSheet = new BalanceSheet();
+        currentPeriodTest.setBalanceSheet(balanceSheet);
+
+        currentPeriodResponseObject.setData(currentPeriodTest);
+        return currentPeriodResponseObject;
+    }
+
+    private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> generateNPreviousNullDebtorsBalanceSheetResponse() {
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject =
+            new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod>(
+                ResponseStatus.FOUND);
+
+        uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod previousPeriod =
+            new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
+        CurrentAssets currentAssets = new CurrentAssets();
+
+        BalanceSheet balanceSheet = new BalanceSheet();
+        previousPeriod.setBalanceSheet(balanceSheet);
+
+        previousPeriodResponseObject.setData(previousPeriod);
+        return previousPeriodResponseObject;
+    }
+
+    private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> generateDifferentPreviousPeriodResponseObject() {
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject =
+            new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod>(
+                ResponseStatus.FOUND);
+
+        uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod previousPeriodTest =
+            new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
+        CurrentAssets currentAssets = new CurrentAssets();
+        currentAssets.setDebtors(2L);
+        BalanceSheet balanceSheet = new BalanceSheet();
+        balanceSheet.setCurrentAssets(currentAssets);
+        previousPeriodTest.setBalanceSheet(balanceSheet);
+
+        previousPeriodResponseObject.setData(previousPeriodTest);
+        return previousPeriodResponseObject;
+    }
+
+
+    // test successfull cross validation
+    // test nll balance sheet and note value
+    // test balance sheet value and null note
+    // test mismatched values
+    private void addValidCurrentDebtors() {
+
+        CurrentPeriod currentDebtors = new CurrentPeriod();
+        currentDebtors.setTradeDebtors(1L);
+        currentDebtors.setPrepaymentsAndAccruedIncome(2L);
+        currentDebtors.setGreaterThanOneYear(3L);
+        currentDebtors.setOtherDebtors(4L);
+        currentDebtors.setTotal(10L);
+        currentDebtors.setDetails("details");
+
+        debtors.setCurrentPeriod(currentDebtors);
+    }
+
+    private CompanyProfileApi createCompanyProfileMultipleYearFiler() {
+
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        CompanyAccountApi companyAccountApi = new CompanyAccountApi();
+
+        LastAccountsApi lastAccountsApi = new LastAccountsApi();
+        lastAccountsApi.setType("lastaccounts");
+        lastAccountsApi.setPeriodStartOn(LocalDate.now());
+
+        companyAccountApi.setLastAccounts(lastAccountsApi);
+        companyProfileApi.setAccounts(companyAccountApi);
+
+        return companyProfileApi;
+    }
+
+
+
+    private CompanyProfileApi createCompanyProfileSingleYearFiler() {
+
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        return companyProfileApi;
+    }
+
+    private Error createError(String error, String path) {
+        return new Error(error, path, LocationType.JSON_PATH.getValue(),
+            ErrorType.VALIDATION.getType());
+    }
+
+    private void addValidPreviousDebtors() {
+        PreviousPeriod previousDebtors = new PreviousPeriod();
+        previousDebtors.setTradeDebtors(2L);
+        previousDebtors.setPrepaymentsAndAccruedIncome(4L);
+        previousDebtors.setGreaterThanOneYear(6L);
+        previousDebtors.setOtherDebtors(8L);
+        previousDebtors.setTotal(20L);
+
+        debtors.setPreviousPeriod(previousDebtors);
+    }
+
+    private uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod  createCurrentPeriodWithDifferentValue(){
+        uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriod = new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
+        BalanceSheet balanceSheet = new BalanceSheet();
+        CurrentAssets currentAssets = new CurrentAssets();
+        currentAssets.setDebtors(4L);
+        balanceSheet.setCurrentAssets(currentAssets);
+        currentPeriod.setBalanceSheet(balanceSheet);
+
+        return currentPeriod;
+    }
+
+    private uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod createValidCurrentPeriodWithDifferentValue(){
+        uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriod = new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
+        BalanceSheet balanceSheet = new BalanceSheet();
+        CurrentAssets currentAssets = new CurrentAssets();
+        currentAssets.setDebtors(1L);
+        balanceSheet.setCurrentAssets(currentAssets);
+        currentPeriod.setBalanceSheet(balanceSheet);
+
+        return currentPeriod;
+    }
+
+    private uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod createPreviousPeriodWithDifferentValue(){
+        uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod previousPeriod =
+            new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
+        BalanceSheet balanceSheet = new BalanceSheet();
+        CurrentAssets currentAssets = new CurrentAssets();
+        currentAssets.setDebtors(4L);
+        balanceSheet.setCurrentAssets(currentAssets);
+        previousPeriod.setBalanceSheet(balanceSheet);
+
+        return previousPeriod;
+    }
+
+    private uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod createValidPreviousPeriod(){
+        uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod previousPeriod =
+            new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
+        BalanceSheet balanceSheet = new BalanceSheet();
+        CurrentAssets currentAssets = new CurrentAssets();
+        currentAssets.setDebtors(1L);
+        balanceSheet.setCurrentAssets(currentAssets);
+        previousPeriod.setBalanceSheet(balanceSheet);
+
+        return previousPeriod;
+}
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -56,13 +56,13 @@ public class DebtorsValidatorTest {
     private static final String INCORRECT_TOTAL_VALUE = "incorrect_total";
     private static final String INCONSISTENT_DATA_NAME = "inconsistentData";
     private static final String INCONSISTENT_DATA_VALUE = "inconsistent_data";
-    private static final String COMPANY_ACCOUNTS_ID ="123abc";
+    private static final String COMPANY_ACCOUNTS_ID = "123abc";
     private static final String CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME = "currentBalanceSheetNotEqual";
     private static final String CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE =
-        "value_not_equal_to_current_period_on_balance_sheet";
+            "value_not_equal_to_current_period_on_balance_sheet";
     private static final String PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME = "previousBalanceSheetNotEqual";
     private static final String PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE =
-        "value_not_equal_to_previous_period_on_balance_sheet";
+            "value_not_equal_to_previous_period_on_balance_sheet";
     private static final long INVALID_TOTAL = 200L;
 
     private Debtors debtors;
@@ -111,17 +111,17 @@ public class DebtorsValidatorTest {
         addValidCurrentDebtors();
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
+                COMPANY_ACCOUNTS_ID, mockRequest);
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID,
-            mockRequest);
+                COMPANY_ACCOUNTS_ID,
+                mockRequest);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertFalse(errors.hasErrors());
 
@@ -135,23 +135,23 @@ public class DebtorsValidatorTest {
         addValidPreviousDebtors();
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
+                COMPANY_ACCOUNTS_ID, mockRequest);
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID,
-            mockRequest);
+                COMPANY_ACCOUNTS_ID,
+                mockRequest);
 
         when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
-            .thenReturn(createCompanyProfileMultipleYearFiler());
+                .thenReturn(createCompanyProfileMultipleYearFiler());
 
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertFalse(errors.hasErrors());
 
@@ -165,26 +165,26 @@ public class DebtorsValidatorTest {
         addValidPreviousDebtors();
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
+                COMPANY_ACCOUNTS_ID, mockRequest);
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID,
-            mockRequest);
+                COMPANY_ACCOUNTS_ID,
+                mockRequest);
 
         when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
-            .thenReturn(createCompanyProfileSingleYearFiler());
+                .thenReturn(createCompanyProfileSingleYearFiler());
 
         ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.hasErrors());
         assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TRADE_DEBTORS)));
@@ -207,30 +207,30 @@ public class DebtorsValidatorTest {
         debtors.setPreviousPeriod(previousDebtors);
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
+                COMPANY_ACCOUNTS_ID, mockRequest);
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID,
-            mockRequest);
+                COMPANY_ACCOUNTS_ID,
+                mockRequest);
 
         when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
-            .thenReturn(createCompanyProfileMultipleYearFiler());
+                .thenReturn(createCompanyProfileMultipleYearFiler());
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME, INCORRECT_TOTAL_VALUE);
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
-            .thenReturn(createCompanyProfileMultipleYearFiler());
+                .thenReturn(createCompanyProfileMultipleYearFiler());
 
-        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE, PREVIOUS_TOTAL_PATH)));
     }
@@ -246,26 +246,26 @@ public class DebtorsValidatorTest {
         debtors.setPreviousPeriod(previousDebtors);
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
+                COMPANY_ACCOUNTS_ID, mockRequest);
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID,
-            mockRequest);
+                COMPANY_ACCOUNTS_ID,
+                mockRequest);
 
         when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
-            .thenReturn(createCompanyProfileMultipleYearFiler());
+                .thenReturn(createCompanyProfileMultipleYearFiler());
 
         ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
-        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.hasErrors());
 
@@ -287,19 +287,19 @@ public class DebtorsValidatorTest {
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME, INCORRECT_TOTAL_VALUE);
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
+                COMPANY_ACCOUNTS_ID, mockRequest);
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID,
-            mockRequest);
+                COMPANY_ACCOUNTS_ID,
+                mockRequest);
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
-        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE, CURRENT_TOTAL_PATH)));
     }
@@ -312,23 +312,23 @@ public class DebtorsValidatorTest {
         currentDebtors.setTradeDebtors(1L);
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
+                COMPANY_ACCOUNTS_ID, mockRequest);
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID,
-            mockRequest);
+                COMPANY_ACCOUNTS_ID,
+                mockRequest);
 
         debtors.setCurrentPeriod(currentDebtors);
         ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.hasErrors());
         assertTrue(errors.containsError(createError(INVALID_NOTE_VALUE, CURRENT_TOTAL_PATH)));
@@ -342,42 +342,43 @@ public class DebtorsValidatorTest {
         addValidPreviousDebtors();
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
+                COMPANY_ACCOUNTS_ID, mockRequest);
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID,
-            mockRequest);
+                COMPANY_ACCOUNTS_ID,
+                mockRequest);
 
         when(mockCompanyService.getCompanyProfile(null)).thenThrow(mockServiceException);
 
         assertThrows(DataException.class,
-            () -> validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,
-                mockRequest));
+                () -> validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,
+                        mockRequest));
     }
 
     @Test
     @DisplayName("Tests data exception thrown when current period api call fails")
     void testDataExceptionThrownWhenRetrievingCurrentPeriod() throws DataException {
 
-        addValidCurrentDebtors();;
+        addValidCurrentDebtors();
+        ;
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         when(mockCurrentPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(mockMongoException);
 
         assertThrows(DataException.class,
-            () -> validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,
-                mockRequest));
+                () -> validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,
+                        mockRequest));
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
     }
 
     @Test
@@ -388,33 +389,33 @@ public class DebtorsValidatorTest {
         addValidPreviousDebtors();
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateDifferentCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
+                COMPANY_ACCOUNTS_ID, mockRequest);
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateDifferentPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID,
-            mockRequest);
+                COMPANY_ACCOUNTS_ID,
+                mockRequest);
 
         when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
-            .thenReturn(createCompanyProfileMultipleYearFiler());
+                .thenReturn(createCompanyProfileMultipleYearFiler());
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
-
-        assertTrue(errors.containsError(createError(
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE, CURRENT_TOTAL_PATH)));
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.containsError(createError(
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE, PREVIOUS_TOTAL_PATH)));
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE, CURRENT_TOTAL_PATH)));
+
+        assertTrue(errors.containsError(createError(
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE, PREVIOUS_TOTAL_PATH)));
 
     }
 
@@ -426,33 +427,33 @@ public class DebtorsValidatorTest {
         addValidPreviousDebtors();
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateNullDebtorsBalanceSheetResponse()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
+                COMPANY_ACCOUNTS_ID, mockRequest);
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID,
-            mockRequest);
+                COMPANY_ACCOUNTS_ID,
+                mockRequest);
 
         when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
-            .thenReturn(createCompanyProfileMultipleYearFiler());
+                .thenReturn(createCompanyProfileMultipleYearFiler());
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
-
-        assertTrue(errors.containsError(createError(
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE, CURRENT_TOTAL_PATH)));
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.containsError(createError(
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE, PREVIOUS_TOTAL_PATH)));
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE, CURRENT_TOTAL_PATH)));
+
+        assertTrue(errors.containsError(createError(
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE, PREVIOUS_TOTAL_PATH)));
 
     }
 
@@ -464,21 +465,21 @@ public class DebtorsValidatorTest {
         addValidPreviousDebtors();
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
+                COMPANY_ACCOUNTS_ID, mockRequest);
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID,
-            mockRequest);
+                COMPANY_ACCOUNTS_ID,
+                mockRequest);
 
         when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
-            .thenReturn(createCompanyProfileMultipleYearFiler());
+                .thenReturn(createCompanyProfileMultipleYearFiler());
 
-        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertFalse(errors.hasErrors());
     }
@@ -488,40 +489,40 @@ public class DebtorsValidatorTest {
     void testEmptyNoteMismatchedDebtorsValues() throws DataException, ServiceException {
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
+                COMPANY_ACCOUNTS_ID, mockRequest);
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID,
-            mockRequest);
+                COMPANY_ACCOUNTS_ID,
+                mockRequest);
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
-
-        assertTrue(errors.containsError(createError(
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE, CURRENT_TOTAL_PATH)));
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.containsError(createError(
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE, PREVIOUS_TOTAL_PATH)));
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE, CURRENT_TOTAL_PATH)));
+
+        assertTrue(errors.containsError(createError(
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE, PREVIOUS_TOTAL_PATH)));
 
     }
 
     private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> generateValidCurrentPeriodResponseObject() {
         ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject =
-            new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod>(
-                ResponseStatus.FOUND);
+                new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod>(
+                        ResponseStatus.FOUND);
 
 
         uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriodTest =
-            new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
+                new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
         CurrentAssets currentAssets = new CurrentAssets();
 
         currentAssets.setDebtors(10L);
@@ -535,11 +536,11 @@ public class DebtorsValidatorTest {
 
     private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> generateValidPreviousPeriodResponseObject() {
         ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject =
-            new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod>(
-                ResponseStatus.FOUND);
+                new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod>(
+                        ResponseStatus.FOUND);
 
         uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod previousPeriodTest =
-            new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
+                new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
         CurrentAssets currentAssets = new CurrentAssets();
         currentAssets.setDebtors(20L);
         BalanceSheet balanceSheet = new BalanceSheet();
@@ -552,12 +553,12 @@ public class DebtorsValidatorTest {
 
     private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> generateDifferentCurrentPeriodResponseObject() {
         ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject =
-            new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod>(
-                ResponseStatus.FOUND);
+                new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod>(
+                        ResponseStatus.FOUND);
 
 
         uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriodTest =
-            new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
+                new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
         CurrentAssets currentAssets = new CurrentAssets();
 
         currentAssets.setDebtors(1L);
@@ -571,11 +572,11 @@ public class DebtorsValidatorTest {
 
     private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> generateNullDebtorsBalanceSheetResponse() {
         ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject =
-            new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod>(
-                ResponseStatus.FOUND);
+                new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod>(
+                        ResponseStatus.FOUND);
 
         uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriodTest =
-            new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
+                new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
         CurrentAssets currentAssets = new CurrentAssets();
 
         BalanceSheet balanceSheet = new BalanceSheet();
@@ -587,11 +588,11 @@ public class DebtorsValidatorTest {
 
     private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> generateNPreviousNullDebtorsBalanceSheetResponse() {
         ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject =
-            new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod>(
-                ResponseStatus.FOUND);
+                new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod>(
+                        ResponseStatus.FOUND);
 
         uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod previousPeriod =
-            new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
+                new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
         CurrentAssets currentAssets = new CurrentAssets();
 
         BalanceSheet balanceSheet = new BalanceSheet();
@@ -603,11 +604,11 @@ public class DebtorsValidatorTest {
 
     private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> generateDifferentPreviousPeriodResponseObject() {
         ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject =
-            new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod>(
-                ResponseStatus.FOUND);
+                new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod>(
+                        ResponseStatus.FOUND);
 
         uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod previousPeriodTest =
-            new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
+                new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
         CurrentAssets currentAssets = new CurrentAssets();
         currentAssets.setDebtors(2L);
         BalanceSheet balanceSheet = new BalanceSheet();
@@ -654,7 +655,7 @@ public class DebtorsValidatorTest {
 
     private Error createError(String error, String path) {
         return new Error(error, path, LocationType.JSON_PATH.getValue(),
-            ErrorType.VALIDATION.getType());
+                ErrorType.VALIDATION.getType());
     }
 
     private void addValidPreviousDebtors() {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -319,7 +319,7 @@ public class DebtorsValidatorTest {
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
             COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
+        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(
             COMPANY_ACCOUNTS_ID,
             mockRequest);
 
@@ -328,9 +328,6 @@ public class DebtorsValidatorTest {
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
             CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
-
-        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
@@ -365,8 +362,7 @@ public class DebtorsValidatorTest {
 
     @Test
     @DisplayName("Tests data exception thrown when current period api call fails")
-    void testDataExceptionThrownWhenRetrievingCurrentPeriod() throws DataException,
-        ServiceException {
+    void testDataExceptionThrownWhenRetrievingCurrentPeriod() throws DataException {
 
         addValidCurrentDebtors();;
 
@@ -407,14 +403,11 @@ public class DebtorsValidatorTest {
         when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
             .thenReturn(createCompanyProfileMultipleYearFiler());
 
-
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
             CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
             PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
-
-        ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
 
         errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
@@ -448,14 +441,11 @@ public class DebtorsValidatorTest {
         when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
             .thenReturn(createCompanyProfileMultipleYearFiler());
 
-
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
             CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
             PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
-
-        ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
 
         errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
@@ -489,23 +479,9 @@ public class DebtorsValidatorTest {
         when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
             .thenReturn(createCompanyProfileMultipleYearFiler());
 
-
-        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
-
-        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
-
-        ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
-
         errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
-        assertFalse(errors.containsError(createError(
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE, CURRENT_TOTAL_PATH)));
-
-        assertFalse(errors.containsError(createError(
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE, PREVIOUS_TOTAL_PATH)));
-
+        assertFalse(errors.hasErrors());
     }
 
     @Test
@@ -528,8 +504,6 @@ public class DebtorsValidatorTest {
 
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
             PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
-
-        ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
 
         errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -288,15 +288,15 @@ public class DebtorsValidatorTest {
     @DisplayName("Tests current period missing total throws error")
     void testMissingCurrentTotal() throws DataException {
 
+        CurrentPeriod currentDebtors = new CurrentPeriod();
+        currentDebtors.setTradeDebtors(1L);
+
         when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
 
         when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
         doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
             mockRequest);
-
-        CurrentPeriod currentDebtors = new CurrentPeriod();
-        currentDebtors.setTradeDebtors(1L);
 
         debtors.setCurrentPeriod(currentDebtors);
         ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
@@ -599,11 +599,6 @@ public class DebtorsValidatorTest {
         return previousPeriodResponseObject;
     }
 
-
-    // test successfull cross validation
-    // test nll balance sheet and note value
-    // test balance sheet value and null note
-    // test mismatched values
     private void addValidCurrentDebtors() {
 
         CurrentPeriod currentDebtors = new CurrentPeriod();
@@ -632,8 +627,6 @@ public class DebtorsValidatorTest {
         return companyProfileApi;
     }
 
-
-
     private CompanyProfileApi createCompanyProfileSingleYearFiler() {
 
         CompanyProfileApi companyProfileApi = new CompanyProfileApi();
@@ -655,50 +648,4 @@ public class DebtorsValidatorTest {
 
         debtors.setPreviousPeriod(previousDebtors);
     }
-
-    private uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod  createCurrentPeriodWithDifferentValue(){
-        uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriod = new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
-        BalanceSheet balanceSheet = new BalanceSheet();
-        CurrentAssets currentAssets = new CurrentAssets();
-        currentAssets.setDebtors(4L);
-        balanceSheet.setCurrentAssets(currentAssets);
-        currentPeriod.setBalanceSheet(balanceSheet);
-
-        return currentPeriod;
-    }
-
-    private uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod createValidCurrentPeriodWithDifferentValue(){
-        uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriod = new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
-        BalanceSheet balanceSheet = new BalanceSheet();
-        CurrentAssets currentAssets = new CurrentAssets();
-        currentAssets.setDebtors(1L);
-        balanceSheet.setCurrentAssets(currentAssets);
-        currentPeriod.setBalanceSheet(balanceSheet);
-
-        return currentPeriod;
-    }
-
-    private uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod createPreviousPeriodWithDifferentValue(){
-        uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod previousPeriod =
-            new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
-        BalanceSheet balanceSheet = new BalanceSheet();
-        CurrentAssets currentAssets = new CurrentAssets();
-        currentAssets.setDebtors(4L);
-        balanceSheet.setCurrentAssets(currentAssets);
-        previousPeriod.setBalanceSheet(balanceSheet);
-
-        return previousPeriod;
-    }
-
-    private uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod createValidPreviousPeriod(){
-        uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod previousPeriod =
-            new uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod();
-        BalanceSheet balanceSheet = new BalanceSheet();
-        CurrentAssets currentAssets = new CurrentAssets();
-        currentAssets.setDebtors(1L);
-        balanceSheet.setCurrentAssets(currentAssets);
-        previousPeriod.setBalanceSheet(balanceSheet);
-
-        return previousPeriod;
-}
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -56,8 +56,15 @@ public class DebtorsValidatorTest {
     private static final String INCORRECT_TOTAL_VALUE = "incorrect_total";
     private static final String INCONSISTENT_DATA_NAME = "inconsistentData";
     private static final String INCONSISTENT_DATA_VALUE = "inconsistent_data";
+    private static final String COMPANY_ACCOUNTS_ID ="123abc";
 
     private static final long INVALID_TOTAL = 200L;
+    public static final String CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME = "currentBalanceSheetNotEqual";
+    public static final String CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE =
+        "value_not_equal_to_current_period_on_balance_sheet";
+    public static final String PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME = "previousBalanceSheetNotEqual";
+    public static final String PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE =
+        "value_not_equal_to_previous_period_on_balance_sheet";
 
     private Debtors debtors;
     private Errors errors;
@@ -91,8 +98,6 @@ public class DebtorsValidatorTest {
 
     private DebtorsValidator validator;
 
-    private String companyAccountsId="123abc";
-
     @BeforeEach
     void setup() {
         debtors = new Debtors();
@@ -106,14 +111,18 @@ public class DebtorsValidatorTest {
 
         addValidCurrentDebtors();
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
+            COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(companyAccountsId,
+        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(
+            COMPANY_ACCOUNTS_ID,
             mockRequest);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
         assertFalse(errors.hasErrors());
 
@@ -126,20 +135,24 @@ public class DebtorsValidatorTest {
         addValidCurrentDebtors();
         addValidPreviousDebtors();
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
+            COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
+            COMPANY_ACCOUNTS_ID,
             mockRequest);
 
         when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
             .thenReturn(createCompanyProfileMultipleYearFiler());
 
-        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
-            "value_not_equal_to_previous_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
         assertFalse(errors.hasErrors());
 
@@ -152,35 +165,33 @@ public class DebtorsValidatorTest {
         addValidCurrentDebtors();
         addValidPreviousDebtors();
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
+            COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
+            COMPANY_ACCOUNTS_ID,
             mockRequest);
-//
-//        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> result = previousPeriodService.findById("", request);
 
         when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
             .thenReturn(createCompanyProfileSingleYearFiler());
 
         ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
-        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
-            "value_not_equal_to_current_period_on_balance_sheet");
-        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
-            "value_not_equal_to_previous_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
         assertTrue(errors.hasErrors());
-        assertTrue(
-            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TRADE_DEBTORS)));
-        assertTrue(
-            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_PREPAYMENTS)));
-        assertTrue(errors
-            .containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_GREATER_THAN_ONE_YEAR)));
-        assertTrue(
-            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_OTHER_DEBTORS)));
+        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TRADE_DEBTORS)));
+        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_PREPAYMENTS)));
+        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_GREATER_THAN_ONE_YEAR)));
+        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_OTHER_DEBTORS)));
         assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TOTAL_PATH)));
     }
 
@@ -196,11 +207,15 @@ public class DebtorsValidatorTest {
 
         debtors.setPreviousPeriod(previousDebtors);
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
+            COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
+            COMPANY_ACCOUNTS_ID,
             mockRequest);
 
         when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
@@ -208,15 +223,15 @@ public class DebtorsValidatorTest {
             .thenReturn(createCompanyProfileMultipleYearFiler());
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME, INCORRECT_TOTAL_VALUE);
-        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
-            "value_not_equal_to_current_period_on_balance_sheet");
-        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
-            "value_not_equal_to_previous_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
             .thenReturn(createCompanyProfileMultipleYearFiler());
 
-        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE, PREVIOUS_TOTAL_PATH)));
     }
@@ -231,11 +246,15 @@ public class DebtorsValidatorTest {
         previousDebtors.setTradeDebtors(2L);
         debtors.setPreviousPeriod(previousDebtors);
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
+            COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
+            COMPANY_ACCOUNTS_ID,
             mockRequest);
 
         when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
@@ -243,12 +262,11 @@ public class DebtorsValidatorTest {
             .thenReturn(createCompanyProfileMultipleYearFiler());
 
         ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
-        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
-            "value_not_equal_to_current_period_on_balance_sheet");
-        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
-            "value_not_equal_to_previous_period_on_balance_sheet");
-
-        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
         assertTrue(errors.hasErrors());
 
@@ -269,17 +287,20 @@ public class DebtorsValidatorTest {
         debtors.setCurrentPeriod(currentDebtors);
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME, INCORRECT_TOTAL_VALUE);
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
+            COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(companyAccountsId,
+        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(
+            COMPANY_ACCOUNTS_ID,
             mockRequest);
 
-        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
-            "value_not_equal_to_current_period_on_balance_sheet");
-
-        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE, CURRENT_TOTAL_PATH)));
     }
@@ -291,23 +312,27 @@ public class DebtorsValidatorTest {
         CurrentPeriod currentDebtors = new CurrentPeriod();
         currentDebtors.setTradeDebtors(1L);
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
+            COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
+            COMPANY_ACCOUNTS_ID,
             mockRequest);
 
         debtors.setCurrentPeriod(currentDebtors);
         ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
 
-        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
-            "value_not_equal_to_current_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
-            "value_not_equal_to_previous_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
         assertTrue(errors.hasErrors());
         assertTrue(errors.containsError(createError(INVALID_NOTE_VALUE, CURRENT_TOTAL_PATH)));
@@ -320,17 +345,21 @@ public class DebtorsValidatorTest {
         addValidCurrentDebtors();
         addValidPreviousDebtors();
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
+            COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
+            COMPANY_ACCOUNTS_ID,
             mockRequest);
 
         when(mockCompanyService.getCompanyProfile(null)).thenThrow(mockServiceException);
 
         assertThrows(DataException.class,
-            () -> validator.validateDebtors(debtors, mockTransaction, companyAccountsId,
+            () -> validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,
                 mockRequest));
     }
 
@@ -341,18 +370,19 @@ public class DebtorsValidatorTest {
 
         addValidCurrentDebtors();;
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        when(mockCurrentPeriodService.findById(companyAccountsId, mockRequest)).thenThrow(mockMongoException);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        when(mockCurrentPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(mockMongoException);
 
         assertThrows(DataException.class,
-            () -> validator.validateDebtors(debtors, mockTransaction, companyAccountsId,
+            () -> validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,
                 mockRequest));
 
-        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
-            "value_not_equal_to_current_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
-            "value_not_equal_to_previous_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
     }
 
     @Test
@@ -362,11 +392,15 @@ public class DebtorsValidatorTest {
         addValidCurrentDebtors();
         addValidPreviousDebtors();
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateDifferentCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateDifferentCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
+            COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateDifferentPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateDifferentPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
+            COMPANY_ACCOUNTS_ID,
             mockRequest);
 
         when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
@@ -374,21 +408,21 @@ public class DebtorsValidatorTest {
             .thenReturn(createCompanyProfileMultipleYearFiler());
 
 
-        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
-            "value_not_equal_to_current_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
-            "value_not_equal_to_previous_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
         assertTrue(errors.containsError(createError(
-            "value_not_equal_to_current_period_on_balance_sheet", CURRENT_TOTAL_PATH)));
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE, CURRENT_TOTAL_PATH)));
 
         assertTrue(errors.containsError(createError(
-            "value_not_equal_to_previous_period_on_balance_sheet", PREVIOUS_TOTAL_PATH)));
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE, PREVIOUS_TOTAL_PATH)));
 
     }
 
@@ -399,11 +433,15 @@ public class DebtorsValidatorTest {
         addValidCurrentDebtors();
         addValidPreviousDebtors();
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateNullDebtorsBalanceSheetResponse()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateNullDebtorsBalanceSheetResponse()).when(mockCurrentPeriodService).findById(
+            COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(companyAccountsId,
+        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(
+            COMPANY_ACCOUNTS_ID,
             mockRequest);
 
         when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
@@ -411,21 +449,21 @@ public class DebtorsValidatorTest {
             .thenReturn(createCompanyProfileMultipleYearFiler());
 
 
-        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
-            "value_not_equal_to_current_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
-            "value_not_equal_to_previous_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
         assertTrue(errors.containsError(createError(
-            "value_not_equal_to_current_period_on_balance_sheet", CURRENT_TOTAL_PATH)));
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE, CURRENT_TOTAL_PATH)));
 
         assertTrue(errors.containsError(createError(
-            "value_not_equal_to_previous_period_on_balance_sheet", PREVIOUS_TOTAL_PATH)));
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE, PREVIOUS_TOTAL_PATH)));
 
     }
 
@@ -436,11 +474,15 @@ public class DebtorsValidatorTest {
         addValidCurrentDebtors();
         addValidPreviousDebtors();
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
+            COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
+            COMPANY_ACCOUNTS_ID,
             mockRequest);
 
         when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
@@ -448,21 +490,21 @@ public class DebtorsValidatorTest {
             .thenReturn(createCompanyProfileMultipleYearFiler());
 
 
-        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
-            "value_not_equal_to_current_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
-            "value_not_equal_to_previous_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
         assertFalse(errors.containsError(createError(
-            "value_not_equal_to_current_period_on_balance_sheet", CURRENT_TOTAL_PATH)));
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE, CURRENT_TOTAL_PATH)));
 
         assertFalse(errors.containsError(createError(
-            "value_not_equal_to_previous_period_on_balance_sheet", PREVIOUS_TOTAL_PATH)));
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE, PREVIOUS_TOTAL_PATH)));
 
     }
 
@@ -470,28 +512,32 @@ public class DebtorsValidatorTest {
     @DisplayName("Assert empty note and populated balance sheet value throws error")
     void testEmptyNoteMismatchedDebtorsValues() throws DataException, ServiceException {
 
-        when(mockCurrentPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(companyAccountsId, mockRequest);
+        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
+            COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(companyAccountsId)).thenReturn(companyAccountsId);
-        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(companyAccountsId,
+        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
+            COMPANY_ACCOUNTS_ID);
+        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
+            COMPANY_ACCOUNTS_ID,
             mockRequest);
 
-        ReflectionTestUtils.setField(validator, "currentBalanceSheetNotEqual",
-            "value_not_equal_to_current_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
-        ReflectionTestUtils.setField(validator, "previousBalanceSheetNotEqual",
-            "value_not_equal_to_previous_period_on_balance_sheet");
+        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
 
-        errors = validator.validateDebtors(debtors, mockTransaction, companyAccountsId,mockRequest);
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID,mockRequest);
 
         assertTrue(errors.containsError(createError(
-            "value_not_equal_to_current_period_on_balance_sheet", CURRENT_TOTAL_PATH)));
+            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE, CURRENT_TOTAL_PATH)));
 
         assertTrue(errors.containsError(createError(
-            "value_not_equal_to_previous_period_on_balance_sheet", PREVIOUS_TOTAL_PATH)));
+            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE, PREVIOUS_TOTAL_PATH)));
 
     }
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -57,14 +57,13 @@ public class DebtorsValidatorTest {
     private static final String INCONSISTENT_DATA_NAME = "inconsistentData";
     private static final String INCONSISTENT_DATA_VALUE = "inconsistent_data";
     private static final String COMPANY_ACCOUNTS_ID ="123abc";
-
-    private static final long INVALID_TOTAL = 200L;
-    public static final String CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME = "currentBalanceSheetNotEqual";
-    public static final String CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE =
+    private static final String CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME = "currentBalanceSheetNotEqual";
+    private static final String CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE =
         "value_not_equal_to_current_period_on_balance_sheet";
-    public static final String PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME = "previousBalanceSheetNotEqual";
-    public static final String PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE =
+    private static final String PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME = "previousBalanceSheetNotEqual";
+    private static final String PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE =
         "value_not_equal_to_previous_period_on_balance_sheet";
+    private static final long INVALID_TOTAL = 200L;
 
     private Debtors debtors;
     private Errors errors;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -1,278 +1,279 @@
-package uk.gov.companieshouse.api.accounts.validation;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
-
-import java.time.LocalDate;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-import uk.gov.companieshouse.api.accounts.exception.DataException;
-import uk.gov.companieshouse.api.accounts.exception.ServiceException;
-import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.CurrentPeriod;
-import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.Debtors;
-import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.PreviousPeriod;
-import uk.gov.companieshouse.api.accounts.model.validation.Error;
-import uk.gov.companieshouse.api.accounts.model.validation.Errors;
-import uk.gov.companieshouse.api.accounts.service.CompanyService;
-import uk.gov.companieshouse.api.accounts.transaction.Transaction;
-import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
-import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
-import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
-
-@ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class DebtorsValidatorTest {
-
-    private static final String DEBTORS_PATH = "$.debtors";
-    private static final String DEBTORS_PATH_PREVIOUS = DEBTORS_PATH + ".previous_period";
-    private static final String CURRENT_TOTAL_PATH = DEBTORS_PATH + ".current_period.total";
-    private static final String PREVIOUS_TOTAL_PATH = DEBTORS_PATH_PREVIOUS + ".total";
-    private static final String PREVIOUS_TRADE_DEBTORS = DEBTORS_PATH_PREVIOUS + ".trade_debtors";
-    private static final String PREVIOUS_PREPAYMENTS = DEBTORS_PATH_PREVIOUS + ".prepayments_and_accrued_income";
-    private static final String PREVIOUS_OTHER_DEBTORS = DEBTORS_PATH_PREVIOUS + ".other_debtors";
-    private static final String PREVIOUS_GREATER_THAN_ONE_YEAR = DEBTORS_PATH_PREVIOUS + ".greater_than_one_year";
-    private static final String COMPANY_NUMBER = "12345";
-    private static final String INVALID_NOTE_VALUE = "invalid_note";
-    private static final String INVALID_NOTE_NAME = "invalidNote";
-    private static final String INCORRECT_TOTAL_NAME = "incorrectTotal";
-    private static final String INCORRECT_TOTAL_VALUE = "incorrect_total";
-    private static final String INCONSISTENT_DATA_NAME = "inconsistentData";
-    private static final String INCONSISTENT_DATA_VALUE = "inconsistent_data";
-
-    private static final long INVALID_TOTAL = 200L;
-
-    private Debtors debtors;
-    private Errors errors;
-
-    @Mock
-    private CompanyService mockCompanyService;
-
-    @Mock
-    private Transaction mockTransaction;
-
-    @Mock
-    private ServiceException mockServiceException;
-
-    private DebtorsValidator validator;
-
-    @BeforeEach
-    void setup() {
-        debtors = new Debtors();
-        errors = new Errors();
-        validator = new DebtorsValidator(mockCompanyService);
-    }
-
-    @Test
-    @DisplayName("Tests the validation passes on valid single year debtors resource")
-    void testSuccessfulSingleYearDebtorsNote() throws DataException {
-
-        addValidCurrentDebtors();
-
-        errors = validator.validateDebtors(debtors, mockTransaction);
-
-        assertFalse(errors.hasErrors());
-
-    }
-
-    @Test
-    @DisplayName("Tests the validation passes on valid multiple year debtors resource")
-    void testSuccessfulMultipleYearDebtorsNote() throws DataException, ServiceException {
-
-        addValidCurrentDebtors();
-        addValidPreviousDebtors();
-
-        when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
-            .thenReturn(createCompanyProfileMultipleYearFiler());
-
-        errors = validator.validateDebtors(debtors, mockTransaction);
-
-        assertFalse(errors.hasErrors());
-
-    }
-
-    @Test
-    @DisplayName("Tests the validation fails on single year filer filing previous period")
-    void tesInvalidMultipleYearDebtorsNote() throws DataException, ServiceException {
-
-        addValidCurrentDebtors();
-        addValidPreviousDebtors();
-
-        when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
-            .thenReturn(createCompanyProfileSingleYearFiler());
-
-        ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
-
-        errors = validator.validateDebtors(debtors, mockTransaction);
-
-        assertTrue(errors.hasErrors());
-
-        assertTrue(
-            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TRADE_DEBTORS)));
-
-        assertTrue(
-            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_PREPAYMENTS)));
-
-        assertTrue(errors
-            .containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_GREATER_THAN_ONE_YEAR)));
-
-        assertTrue(
-            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_OTHER_DEBTORS)));
-
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TOTAL_PATH)));
-    }
-
-    @Test
-    @DisplayName("Tests the validation fails on previous period incorrect total")
-    void testIncorrectPreviousDebtorsTotal() throws DataException, ServiceException {
-
-        addValidCurrentDebtors();
-
-        PreviousPeriod previousDebtors = new PreviousPeriod();
-        previousDebtors.setTradeDebtors(2L);
-        previousDebtors.setTotal(INVALID_TOTAL);
-
-        debtors.setPreviousPeriod(previousDebtors);
-
-        ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME, INCORRECT_TOTAL_VALUE);
-
-        when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
-            .thenReturn(createCompanyProfileMultipleYearFiler());
-
-        errors = validator.validateDebtors(debtors, mockTransaction);
-
-        assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE, PREVIOUS_TOTAL_PATH)));
-    }
-
-    @Test
-    @DisplayName("Tests the validation fails on previous period missing total")
-    void testMissingPreviousDebtorsTotal() throws DataException, ServiceException {
-
-        addValidCurrentDebtors();
-
-        PreviousPeriod previousDebtors = new PreviousPeriod();
-        previousDebtors.setTradeDebtors(2L);
-
-        debtors.setPreviousPeriod(previousDebtors);
-
-        when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
-        when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
-            .thenReturn(createCompanyProfileMultipleYearFiler());
-
-        ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
-
-        errors = validator.validateDebtors(debtors, mockTransaction);
-
-        assertTrue(errors.hasErrors());
-
-        assertTrue(errors.containsError(createError(INVALID_NOTE_VALUE, PREVIOUS_TOTAL_PATH)));
-    }
-
-    @Test
-    @DisplayName("Tests current period incorrect total throws error")
-    void testIncorrectCurrentTotal() throws DataException {
-
-        CurrentPeriod currentDebtors = new CurrentPeriod();
-        currentDebtors.setTradeDebtors(1L);
-        currentDebtors.setPrepaymentsAndAccruedIncome(2L);
-        currentDebtors.setGreaterThanOneYear(3L);
-        currentDebtors.setOtherDebtors(4L);
-        currentDebtors.setTotal(INVALID_TOTAL);
-
-        debtors.setCurrentPeriod(currentDebtors);
-        ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME, INCORRECT_TOTAL_VALUE);
-
-        errors = validator.validateDebtors(debtors, mockTransaction);
-
-        assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE, CURRENT_TOTAL_PATH)));
-    }
-
-    @Test
-    @DisplayName("Tests current period missing total throws error")
-    void testMissingCurrentTotal() throws DataException {
-
-        CurrentPeriod currentDebtors = new CurrentPeriod();
-        currentDebtors.setTradeDebtors(1L);
-
-        debtors.setCurrentPeriod(currentDebtors);
-        ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
-
-        errors = validator.validateDebtors(debtors, mockTransaction);
-
-        assertTrue(errors.hasErrors());
-
-        assertTrue(errors.containsError(createError(INVALID_NOTE_VALUE, CURRENT_TOTAL_PATH)));
-    }
-
-    @Test
-    @DisplayName("Tests data exception thrown when company profile api call fails")
-    void testDataExceptionThrown() throws DataException, ServiceException {
-
-        addValidCurrentDebtors();
-
-        PreviousPeriod previousDebtors = new PreviousPeriod();
-        previousDebtors.setTradeDebtors(2L);
-        debtors.setPreviousPeriod(previousDebtors);
-
-        when(mockCompanyService.getCompanyProfile(null)).thenThrow(mockServiceException);
-
-        assertThrows(DataException.class,
-            () -> validator.validateDebtors(debtors, mockTransaction));
-    }
-
-    private void addValidCurrentDebtors() {
-
-        CurrentPeriod currentDebtors = new CurrentPeriod();
-        currentDebtors.setTradeDebtors(1L);
-        currentDebtors.setPrepaymentsAndAccruedIncome(2L);
-        currentDebtors.setGreaterThanOneYear(3L);
-        currentDebtors.setOtherDebtors(4L);
-        currentDebtors.setTotal(10L);
-        currentDebtors.setDetails("details");
-
-        debtors.setCurrentPeriod(currentDebtors);
-    }
-
-    private CompanyProfileApi createCompanyProfileMultipleYearFiler() {
-
-        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
-        CompanyAccountApi companyAccountApi = new CompanyAccountApi();
-
-        LastAccountsApi lastAccountsApi = new LastAccountsApi();
-        lastAccountsApi.setPeriodStartOn(LocalDate.now());
-
-        companyAccountApi.setLastAccounts(lastAccountsApi);
-        companyProfileApi.setAccounts(companyAccountApi);
-
-        return companyProfileApi;
-    }
-
-    private CompanyProfileApi createCompanyProfileSingleYearFiler() {
-
-        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
-        return companyProfileApi;
-    }
-
-    private Error createError(String error, String path) {
-        return new Error(error, path, LocationType.JSON_PATH.getValue(),
-            ErrorType.VALIDATION.getType());
-    }
-
-    private void addValidPreviousDebtors() {
-        PreviousPeriod previousDebtors = new PreviousPeriod();
-        previousDebtors.setTradeDebtors(2L);
-        previousDebtors.setPrepaymentsAndAccruedIncome(4L);
-        previousDebtors.setGreaterThanOneYear(6L);
-        previousDebtors.setOtherDebtors(8L);
-        previousDebtors.setTotal(20L);
-
-        debtors.setPreviousPeriod(previousDebtors);
-    }
-}
+//
+//package uk.gov.companieshouse.api.accounts.validation;
+//
+//import static org.junit.jupiter.api.Assertions.assertFalse;
+//import static org.junit.jupiter.api.Assertions.assertThrows;
+//import static org.junit.jupiter.api.Assertions.assertTrue;
+//import static org.mockito.Mockito.when;
+//
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.TestInstance;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.springframework.test.util.ReflectionTestUtils;
+//import uk.gov.companieshouse.api.accounts.exception.DataException;
+//import uk.gov.companieshouse.api.accounts.exception.ServiceException;
+//import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.CurrentPeriod;
+//import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.Debtors;
+//import uk.gov.companieshouse.api.accounts.model.rest.notes.Debtors.PreviousPeriod;
+//import uk.gov.companieshouse.api.accounts.model.validation.Error;
+//import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+//import uk.gov.companieshouse.api.accounts.service.CompanyService;
+//import uk.gov.companieshouse.api.accounts.transaction.Transaction;
+//import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+//import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
+//import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
+//
+//@ExtendWith(MockitoExtension.class)
+//@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+//public class DebtorsValidatorTest {
+//
+//    private static final String DEBTORS_PATH = "$.debtors";
+//    private static final String DEBTORS_PATH_PREVIOUS = DEBTORS_PATH + ".previous_period";
+//    private static final String CURRENT_TOTAL_PATH = DEBTORS_PATH + ".current_period.total";
+//    private static final String PREVIOUS_TOTAL_PATH = DEBTORS_PATH_PREVIOUS + ".total";
+//    private static final String PREVIOUS_TRADE_DEBTORS = DEBTORS_PATH_PREVIOUS + ".trade_debtors";
+//    private static final String PREVIOUS_PREPAYMENTS = DEBTORS_PATH_PREVIOUS + ".prepayments_and_accrued_income";
+//    private static final String PREVIOUS_OTHER_DEBTORS = DEBTORS_PATH_PREVIOUS + ".other_debtors";
+//    private static final String PREVIOUS_GREATER_THAN_ONE_YEAR = DEBTORS_PATH_PREVIOUS + ".greater_than_one_year";
+//    private static final String COMPANY_NUMBER = "12345";
+//    private static final String INVALID_NOTE_VALUE = "invalid_note";
+//    private static final String INVALID_NOTE_NAME = "invalidNote";
+//    private static final String INCORRECT_TOTAL_NAME = "incorrectTotal";
+//    private static final String INCORRECT_TOTAL_VALUE = "incorrect_total";
+//    private static final String INCONSISTENT_DATA_NAME = "inconsistentData";
+//    private static final String INCONSISTENT_DATA_VALUE = "inconsistent_data";
+//
+//    private static final long INVALID_TOTAL = 200L;
+//
+//    private Debtors debtors;
+//    private Errors errors;
+//
+//    @Mock
+//    private CompanyService mockCompanyService;
+//
+//    @Mock
+//    private Transaction mockTransaction;
+//
+//    @Mock
+//    private ServiceException mockServiceException;
+//
+//    private DebtorsValidator validator;
+//
+//    @BeforeEach
+//    void setup() {
+//        debtors = new Debtors();
+//        errors = new Errors();
+//        validator = new DebtorsValidator(mockCompanyService);
+//    }
+//
+//    @Test
+//    @DisplayName("Tests the validation passes on valid single year debtors resource")
+//    void testSuccessfulSingleYearDebtorsNote() throws DataException {
+//
+//        addValidCurrentDebtors();
+//
+//        errors = validator.validateDebtors(debtors, mockTransaction);
+//
+//        assertFalse(errors.hasErrors());
+//
+//    }
+//
+//    @Test
+//    @DisplayName("Tests the validation passes on valid multiple year debtors resource")
+//    void testSuccessfulMultipleYearDebtorsNote() throws DataException, ServiceException {
+//
+//        addValidCurrentDebtors();
+//        addValidPreviousDebtors();
+//
+//        when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
+//            .thenReturn(createCompanyProfileMultipleYearFiler());
+//
+//        errors = validator.validateDebtors(debtors, mockTransaction);
+//
+//        assertFalse(errors.hasErrors());
+//
+//    }
+//
+//    @Test
+//    @DisplayName("Tests the validation fails on single year filer filing previous period")
+//    void tesInvalidMultipleYearDebtorsNote() throws DataException, ServiceException {
+//
+//        addValidCurrentDebtors();
+//        addValidPreviousDebtors();
+//
+//        when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
+//            .thenReturn(createCompanyProfileSingleYearFiler());
+//
+//        ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
+//
+//        errors = validator.validateDebtors(debtors, mockTransaction);
+//
+//        assertTrue(errors.hasErrors());
+//
+//        assertTrue(
+//            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TRADE_DEBTORS)));
+//
+//        assertTrue(
+//            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_PREPAYMENTS)));
+//
+//        assertTrue(errors
+//            .containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_GREATER_THAN_ONE_YEAR)));
+//
+//        assertTrue(
+//            errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_OTHER_DEBTORS)));
+//
+//        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TOTAL_PATH)));
+//    }
+//
+//    @Test
+//    @DisplayName("Tests the validation fails on previous period incorrect total")
+//    void testIncorrectPreviousDebtorsTotal() throws DataException, ServiceException {
+//
+//        addValidCurrentDebtors();
+//
+//        PreviousPeriod previousDebtors = new PreviousPeriod();
+//        previousDebtors.setTradeDebtors(2L);
+//        previousDebtors.setTotal(INVALID_TOTAL);
+//
+//        debtors.setPreviousPeriod(previousDebtors);
+//
+//        ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME, INCORRECT_TOTAL_VALUE);
+//
+//        when(mockCompanyService.getCompanyProfile(mockTransaction.getCompanyNumber()))
+//            .thenReturn(createCompanyProfileMultipleYearFiler());
+//
+//        errors = validator.validateDebtors(debtors, mockTransaction);
+//
+//        assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE, PREVIOUS_TOTAL_PATH)));
+//    }
+//
+//    @Test
+//    @DisplayName("Tests the validation fails on previous period missing total")
+//    void testMissingPreviousDebtorsTotal() throws DataException, ServiceException {
+//
+//        addValidCurrentDebtors();
+//
+//        PreviousPeriod previousDebtors = new PreviousPeriod();
+//        previousDebtors.setTradeDebtors(2L);
+//
+//        debtors.setPreviousPeriod(previousDebtors);
+//
+//        when(mockTransaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+//        when(mockCompanyService.getCompanyProfile(COMPANY_NUMBER))
+//            .thenReturn(createCompanyProfileMultipleYearFiler());
+//
+//        ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
+//
+//        errors = validator.validateDebtors(debtors, mockTransaction);
+//
+//        assertTrue(errors.hasErrors());
+//
+//        assertTrue(errors.containsError(createError(INVALID_NOTE_VALUE, PREVIOUS_TOTAL_PATH)));
+//    }
+//
+//    @Test
+//    @DisplayName("Tests current period incorrect total throws error")
+//    void testIncorrectCurrentTotal() throws DataException {
+//
+//        CurrentPeriod currentDebtors = new CurrentPeriod();
+//        currentDebtors.setTradeDebtors(1L);
+//        currentDebtors.setPrepaymentsAndAccruedIncome(2L);
+//        currentDebtors.setGreaterThanOneYear(3L);
+//        currentDebtors.setOtherDebtors(4L);
+//        currentDebtors.setTotal(INVALID_TOTAL);
+//
+//        debtors.setCurrentPeriod(currentDebtors);
+//        ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME, INCORRECT_TOTAL_VALUE);
+//
+//        errors = validator.validateDebtors(debtors, mockTransaction);
+//
+//        assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE, CURRENT_TOTAL_PATH)));
+//    }
+//
+//    @Test
+//    @DisplayName("Tests current period missing total throws error")
+//    void testMissingCurrentTotal() throws DataException {
+//
+//        CurrentPeriod currentDebtors = new CurrentPeriod();
+//        currentDebtors.setTradeDebtors(1L);
+//
+//        debtors.setCurrentPeriod(currentDebtors);
+//        ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
+//
+//        errors = validator.validateDebtors(debtors, mockTransaction);
+//
+//        assertTrue(errors.hasErrors());
+//
+//        assertTrue(errors.containsError(createError(INVALID_NOTE_VALUE, CURRENT_TOTAL_PATH)));
+//    }
+//
+//    @Test
+//    @DisplayName("Tests data exception thrown when company profile api call fails")
+//    void testDataExceptionThrown() throws DataException, ServiceException {
+//
+//        addValidCurrentDebtors();
+//
+//        PreviousPeriod previousDebtors = new PreviousPeriod();
+//        previousDebtors.setTradeDebtors(2L);
+//        debtors.setPreviousPeriod(previousDebtors);
+//
+//        when(mockCompanyService.getCompanyProfile(null)).thenThrow(mockServiceException);
+//
+//        assertThrows(DataException.class,
+//            () -> validator.validateDebtors(debtors, mockTransaction));
+//    }
+//
+//    private void addValidCurrentDebtors() {
+//
+//        CurrentPeriod currentDebtors = new CurrentPeriod();
+//        currentDebtors.setTradeDebtors(1L);
+//        currentDebtors.setPrepaymentsAndAccruedIncome(2L);
+//        currentDebtors.setGreaterThanOneYear(3L);
+//        currentDebtors.setOtherDebtors(4L);
+//        currentDebtors.setTotal(10L);
+//        currentDebtors.setDetails("details");
+//
+//        debtors.setCurrentPeriod(currentDebtors);
+//    }
+//
+//    private CompanyProfileApi createCompanyProfileMultipleYearFiler() {
+//
+//        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+//        CompanyAccountApi companyAccountApi = new CompanyAccountApi();
+//
+//        LastAccountsApi lastAccountsApi = new LastAccountsApi();
+//        lastAccountsApi.setType("lastaccounts");
+//
+//        companyAccountApi.setLastAccounts(lastAccountsApi);
+//        companyProfileApi.setAccounts(companyAccountApi);
+//
+//        return companyProfileApi;
+//    }
+//
+//    private CompanyProfileApi createCompanyProfileSingleYearFiler() {
+//
+//        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+//        return companyProfileApi;
+//    }
+//
+//    private Error createError(String error, String path) {
+//        return new Error(error, path, LocationType.JSON_PATH.getValue(),
+//            ErrorType.VALIDATION.getType());
+//    }
+//
+//    private void addValidPreviousDebtors() {
+//        PreviousPeriod previousDebtors = new PreviousPeriod();
+//        previousDebtors.setTradeDebtors(2L);
+//        previousDebtors.setPrepaymentsAndAccruedIncome(4L);
+//        previousDebtors.setGreaterThanOneYear(6L);
+//        previousDebtors.setOtherDebtors(8L);
+//        previousDebtors.setTotal(20L);
+//
+//        debtors.setPreviousPeriod(previousDebtors);
+//    }
+//}
+//

--- a/start.sh
+++ b/start.sh
@@ -31,7 +31,7 @@ else
 
 fi
 
-#exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.api.ch.gov.uk.jar"
+exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.api.ch.gov.uk.jar"
 
 # debug settings
-exec java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=21095 -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.api.ch.gov.uk.jar"
+#exec java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=21095 -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.api.ch.gov.uk.jar"

--- a/start.sh
+++ b/start.sh
@@ -31,7 +31,7 @@ else
 
 fi
 
-exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.api.ch.gov.uk.jar"
+#exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.api.ch.gov.uk.jar"
 
 # debug settings
-# exec java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=21095 -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.api.ch.gov.uk.jar"
+exec java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=21095 -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.api.ch.gov.uk.jar"

--- a/start.sh
+++ b/start.sh
@@ -34,4 +34,4 @@ fi
 exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.api.ch.gov.uk.jar"
 
 # debug settings
-#exec java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=21095 -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.api.ch.gov.uk.jar"
+# exec java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=21095 -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.api.ch.gov.uk.jar"


### PR DESCRIPTION
Add CrossValidator interface with crossValidate() method to be implemented by any note requiring cross validation

Implement crossValidate method in debtorsValidator and validate current and previous periods

Add new error messages for cross validation errors

Add unit tests to cover new cross validation methods

Resolves SFA-606