### PR TITLE
Return a new map from the statement service instead of the original

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
@@ -264,7 +264,7 @@ public class StatementService implements ResourceService<Statement> {
      * @return
      */
     private Map<String, String> getLegalStatementsFromProperties() {
-        return statementsServiceProperties.getStatements();
+        return statementsServiceProperties.getCloneOfStatements();
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementsServiceProperties.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementsServiceProperties.java
@@ -16,4 +16,8 @@ public class StatementsServiceProperties {
     public Map<String, String> getCloneOfStatements() {
         return new HashMap<>(statements);
     }
+
+    public void setStatements(Map<String, String> statements) {
+        this.statements = statements;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementsServiceProperties.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementsServiceProperties.java
@@ -13,11 +13,7 @@ public class StatementsServiceProperties {
 
     private Map<String, String> statements;
 
-    public Map<String, String> getStatements() {
+    public Map<String, String> getCloneOfStatements() {
         return new HashMap<>(statements);
-    }
-
-    public void setStatements(Map<String, String> statements) {
-        this.statements = statements;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementsServiceProperties.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementsServiceProperties.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.api.accounts.service.impl;
 
+import java.util.HashMap;
 import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.PropertySource;
@@ -13,7 +14,7 @@ public class StatementsServiceProperties {
     private Map<String, String> statements;
 
     public Map<String, String> getStatements() {
-        return statements;
+        return new HashMap<>(statements);
     }
 
     public void setStatements(Map<String, String> statements) {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StatementServiceTest.java
@@ -9,15 +9,11 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import com.mongodb.MongoException;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -103,7 +99,7 @@ public class StatementServiceTest {
     void shouldCreateStatement() throws DataException {
         when(requestMock.getAttribute(anyString())).thenReturn(companyAccountMock);
         when(companyAccountMock.getPeriodEndOn()).thenReturn(LocalDate.of(2018, Month.NOVEMBER, 1));
-        when(statementsServicePropertiesMock.getStatements()).thenReturn(legalStatements);
+        when(statementsServicePropertiesMock.getCloneOfStatements()).thenReturn(legalStatements);
         when(statementTransformerMock.transform(statementMock)).thenReturn(statementEntity);
 
         ResponseObject<Statement> result =


### PR DESCRIPTION
Prevented a bug where this class from exposing the internal representation of the enclosed properties Map.

Resolves a bug on: SFA-829