### PR TITLE
Add Tangible Assets Database Model Transformer

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/transformer/TangibleAssetsTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transformer/TangibleAssetsTransformer.java
@@ -7,7 +7,10 @@ import uk.gov.companieshouse.api.accounts.model.entity.notes.tangible.Depreciati
 import uk.gov.companieshouse.api.accounts.model.entity.notes.tangible.TangibleAssetsDataEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.notes.tangible.TangibleAssetsEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.notes.tangible.TangibleAssetsResourceEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.tangible.Cost;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.tangible.Depreciation;
 import uk.gov.companieshouse.api.accounts.model.rest.notes.tangible.TangibleAssets;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.tangible.TangibleAssetsResource;
 
 @Component
 public class TangibleAssetsTransformer implements GenericTransformer<TangibleAssets, TangibleAssetsEntity> {
@@ -158,6 +161,144 @@ public class TangibleAssetsTransformer implements GenericTransformer<TangibleAss
 
     @Override
     public TangibleAssets transform(TangibleAssetsEntity entity) {
-        return null;
+
+        TangibleAssets tangibleAssets = new TangibleAssets();
+        TangibleAssetsDataEntity dataEntity = entity.getData();
+
+        BeanUtils.copyProperties(dataEntity, tangibleAssets);
+
+        if (dataEntity.getFixturesAndFittings() != null) {
+
+            TangibleAssetsResource fixturesAndFittings = new TangibleAssetsResource();
+            BeanUtils.copyProperties(dataEntity.getFixturesAndFittings(), fixturesAndFittings);
+
+            if (dataEntity.getFixturesAndFittings().getCost() != null) {
+
+                Cost cost = new Cost();
+                BeanUtils.copyProperties(dataEntity.getFixturesAndFittings().getCost(), cost);
+                fixturesAndFittings.setCost(cost);
+            }
+
+            if (dataEntity.getFixturesAndFittings().getDepreciation() != null) {
+
+                Depreciation depreciation = new Depreciation();
+                BeanUtils.copyProperties(dataEntity.getFixturesAndFittings().getDepreciation(), depreciation);
+                fixturesAndFittings.setDepreciation(depreciation);
+            }
+
+            tangibleAssets.setFixturesAndFittings(fixturesAndFittings);
+        }
+
+        if (dataEntity.getLandAndBuildings() != null) {
+
+            TangibleAssetsResource landAndBuildings = new TangibleAssetsResource();
+            BeanUtils.copyProperties(dataEntity.getLandAndBuildings(), landAndBuildings);
+
+            if (dataEntity.getLandAndBuildings().getCost() != null) {
+
+                Cost cost = new Cost();
+                BeanUtils.copyProperties(dataEntity.getLandAndBuildings().getCost(), cost);
+                landAndBuildings.setCost(cost);
+            }
+
+            if (dataEntity.getLandAndBuildings().getDepreciation() != null) {
+
+                Depreciation depreciation = new Depreciation();
+                BeanUtils.copyProperties(dataEntity.getLandAndBuildings().getDepreciation(), depreciation);
+                landAndBuildings.setDepreciation(depreciation);
+            }
+
+            tangibleAssets.setLandAndBuildings(landAndBuildings);
+        }
+
+        if (dataEntity.getMotorVehicles() != null) {
+
+            TangibleAssetsResource motorVehicles = new TangibleAssetsResource();
+            BeanUtils.copyProperties(dataEntity.getMotorVehicles(), motorVehicles);
+
+            if (dataEntity.getMotorVehicles().getCost() != null) {
+
+                Cost cost = new Cost();
+                BeanUtils.copyProperties(dataEntity.getMotorVehicles().getCost(), cost);
+                motorVehicles.setCost(cost);
+            }
+
+            if (dataEntity.getMotorVehicles().getDepreciation() != null) {
+
+                Depreciation depreciation = new Depreciation();
+                BeanUtils.copyProperties(dataEntity.getMotorVehicles().getDepreciation(), depreciation);
+                motorVehicles.setDepreciation(depreciation);
+            }
+
+            tangibleAssets.setMotorVehicles(motorVehicles);
+        }
+
+        if (dataEntity.getOfficeEquipment() != null) {
+
+            TangibleAssetsResource officeEquipment = new TangibleAssetsResource();
+            BeanUtils.copyProperties(dataEntity.getOfficeEquipment(), officeEquipment);
+
+            if (dataEntity.getOfficeEquipment().getCost() != null) {
+
+                Cost cost = new Cost();
+                BeanUtils.copyProperties(dataEntity.getOfficeEquipment().getCost(), cost);
+                officeEquipment.setCost(cost);
+            }
+
+            if (dataEntity.getOfficeEquipment().getDepreciation() != null) {
+
+                Depreciation depreciation = new Depreciation();
+                BeanUtils.copyProperties(dataEntity.getOfficeEquipment().getDepreciation(), depreciation);
+                officeEquipment.setDepreciation(depreciation);
+            }
+
+            tangibleAssets.setOfficeEquipment(officeEquipment);
+        }
+
+        if (dataEntity.getPlantAndMachinery() != null) {
+
+            TangibleAssetsResource plantAndMachinery = new TangibleAssetsResource();
+            BeanUtils.copyProperties(dataEntity.getPlantAndMachinery(), plantAndMachinery);
+
+            if (dataEntity.getPlantAndMachinery().getCost() != null) {
+
+                Cost cost = new Cost();
+                BeanUtils.copyProperties(dataEntity.getPlantAndMachinery().getCost(), cost);
+                plantAndMachinery.setCost(cost);
+            }
+
+            if (dataEntity.getPlantAndMachinery().getDepreciation() != null) {
+
+                Depreciation depreciation = new Depreciation();
+                BeanUtils.copyProperties(dataEntity.getPlantAndMachinery().getDepreciation(), depreciation);
+                plantAndMachinery.setDepreciation(depreciation);
+            }
+
+            tangibleAssets.setPlantAndMachinery(plantAndMachinery);
+        }
+
+        if (dataEntity.getTotal() != null) {
+
+            TangibleAssetsResource total = new TangibleAssetsResource();
+            BeanUtils.copyProperties(dataEntity.getTotal(), total);
+
+            if (dataEntity.getTotal().getCost() != null) {
+
+                Cost cost = new Cost();
+                BeanUtils.copyProperties(dataEntity.getTotal().getCost(), cost);
+                total.setCost(cost);
+            }
+
+            if (dataEntity.getTotal().getDepreciation() != null) {
+
+                Depreciation depreciation = new Depreciation();
+                BeanUtils.copyProperties(dataEntity.getTotal().getDepreciation(), depreciation);
+                total.setDepreciation(depreciation);
+            }
+
+            tangibleAssets.setTotal(total);
+        }
+
+        return tangibleAssets;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/TangibleAssetsTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/TangibleAssetsTransformerTest.java
@@ -707,6 +707,738 @@ public class TangibleAssetsTransformerTest {
         assertNetBookValueFieldsMapped(tangibleAssetsEntity.getData().getTotal());
     }
 
+    @Test
+    @DisplayName("Test fixtures and fittings fields map from the database object when the nested cost object is not null")
+    void TestFixturesAndFittingsMapFromDatabaseObjectCostNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setFixturesAndFittings(
+                createTangibleAssetsResourceEntity(false, true));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getFixturesAndFittings());
+        assertNotNull(tangibleAssets.getFixturesAndFittings().getCost());
+
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getFixturesAndFittings());
+        assertCostFieldsMapped(tangibleAssets.getFixturesAndFittings().getCost());
+
+        assertNull(tangibleAssets.getFixturesAndFittings().getDepreciation());
+    }
+
+    @Test
+    @DisplayName("Test fixtures and fittings fields map from the database object when the nested depreciation object is not null")
+    void TestFixturesAndFittingsMapFromDatabaseObjectDepreciationNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setFixturesAndFittings(
+                createTangibleAssetsResourceEntity(true, false));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getFixturesAndFittings());
+        assertNotNull(tangibleAssets.getFixturesAndFittings().getDepreciation());
+
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getFixturesAndFittings());
+        assertDepreciationFieldsMapped(tangibleAssets.getFixturesAndFittings().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings().getCost());
+    }
+
+    @Test
+    @DisplayName("Test fixtures and fittings fields map from the database object when the nested cost and depreciation objects are not null")
+    void TestFixturesAndFittingsMapFromDatabaseObjectCostAndDepreciationNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setFixturesAndFittings(
+                createTangibleAssetsResourceEntity(false, false));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getFixturesAndFittings());
+        assertNotNull(tangibleAssets.getFixturesAndFittings().getCost());
+        assertNotNull(tangibleAssets.getFixturesAndFittings().getDepreciation());
+
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getFixturesAndFittings());
+        assertCostFieldsMapped(tangibleAssets.getFixturesAndFittings().getCost());
+        assertDepreciationFieldsMapped(tangibleAssets.getFixturesAndFittings().getDepreciation());
+    }
+
+    @Test
+    @DisplayName("Test fixtures and fittings fields map from the database object when the nested cost and depreciation objects are null")
+    void TestFixturesAndFittingsMapFromDatabaseObjectCostAndDepreciationNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setFixturesAndFittings(
+                createTangibleAssetsResourceEntity(true, true));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getFixturesAndFittings().getCost());
+        assertNull(tangibleAssets.getFixturesAndFittings().getDepreciation());
+
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getFixturesAndFittings());
+    }
+
+    @Test
+    @DisplayName("Test land and buildings fields map from the database object when the nested cost object is not null")
+    void TestLandAndBuildingsMapFromDatabaseObjectCostNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setLandAndBuildings(
+                createTangibleAssetsResourceEntity(false, true));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getLandAndBuildings());
+        assertNotNull(tangibleAssets.getLandAndBuildings().getCost());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getLandAndBuildings());
+        assertCostFieldsMapped(tangibleAssets.getLandAndBuildings().getCost());
+
+        assertNull(tangibleAssets.getLandAndBuildings().getDepreciation());
+    }
+
+    @Test
+    @DisplayName("Test land and buildings fields map from the database object when the nested depreciation object is not null")
+    void TestLandAndBuildingsMapFromDatabaseObjectDepreciationNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setLandAndBuildings(
+                createTangibleAssetsResourceEntity(true, false));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getLandAndBuildings());
+        assertNotNull(tangibleAssets.getLandAndBuildings().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getLandAndBuildings());
+        assertDepreciationFieldsMapped(tangibleAssets.getLandAndBuildings().getDepreciation());
+
+        assertNull(tangibleAssets.getLandAndBuildings().getCost());
+    }
+
+    @Test
+    @DisplayName("Test land and buildings fields map from the database object when the nested cost and depreciation objects are not null")
+    void TestLandAndBuildingsMapFromDatabaseObjectCostAndDepreciationNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setLandAndBuildings(
+                createTangibleAssetsResourceEntity(false, false));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getLandAndBuildings());
+        assertNotNull(tangibleAssets.getLandAndBuildings().getCost());
+        assertNotNull(tangibleAssets.getLandAndBuildings().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getLandAndBuildings());
+        assertCostFieldsMapped(tangibleAssets.getLandAndBuildings().getCost());
+        assertDepreciationFieldsMapped(tangibleAssets.getLandAndBuildings().getDepreciation());
+    }
+
+    @Test
+    @DisplayName("Test land and buildings fields map from the database object when the nested cost and depreciation objects are null")
+    void TestLandAndBuildingsMapFromDatabaseObjectCostAndDepreciationNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setLandAndBuildings(
+                createTangibleAssetsResourceEntity(true, true));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getLandAndBuildings().getCost());
+        assertNull(tangibleAssets.getLandAndBuildings().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getLandAndBuildings());
+    }
+
+    @Test
+    @DisplayName("Test motor vehicles fields map from the database object when the nested cost object is not null")
+    void TestMotorVehiclesMapFromDatabaseObjectCostNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setMotorVehicles(
+                createTangibleAssetsResourceEntity(false, true));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getMotorVehicles());
+        assertNotNull(tangibleAssets.getMotorVehicles().getCost());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getMotorVehicles());
+        assertCostFieldsMapped(tangibleAssets.getMotorVehicles().getCost());
+
+        assertNull(tangibleAssets.getMotorVehicles().getDepreciation());
+    }
+
+    @Test
+    @DisplayName("Test motor vehicles fields map from the database object when the nested depreciation object is not null")
+    void TestMotorVehiclesMapFromDatabaseObjectDepreciationNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setMotorVehicles(
+                createTangibleAssetsResourceEntity(true, false));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getMotorVehicles());
+        assertNotNull(tangibleAssets.getMotorVehicles().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getMotorVehicles());
+        assertDepreciationFieldsMapped(tangibleAssets.getMotorVehicles().getDepreciation());
+
+        assertNull(tangibleAssets.getMotorVehicles().getCost());
+    }
+
+    @Test
+    @DisplayName("Test motor vehicles fields map from the database object when the nested cost and depreciation objects are not null")
+    void TestMotorVehiclesMapFromDatabaseObjectCostAndDepreciationNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setMotorVehicles(
+                createTangibleAssetsResourceEntity(false, false));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getMotorVehicles());
+        assertNotNull(tangibleAssets.getMotorVehicles().getCost());
+        assertNotNull(tangibleAssets.getMotorVehicles().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getMotorVehicles());
+        assertCostFieldsMapped(tangibleAssets.getMotorVehicles().getCost());
+        assertDepreciationFieldsMapped(tangibleAssets.getMotorVehicles().getDepreciation());
+    }
+
+    @Test
+    @DisplayName("Test motor vehicles fields map from the database object when the nested cost and depreciation objects are null")
+    void TestMotorVehiclesMapFromDatabaseObjectCostAndDepreciationNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setMotorVehicles(
+                createTangibleAssetsResourceEntity(true, true));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getMotorVehicles().getCost());
+        assertNull(tangibleAssets.getMotorVehicles().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getMotorVehicles());
+    }
+
+    @Test
+    @DisplayName("Test office equipment fields map from the database object when the nested cost object is not null")
+    void TestOfficeEquipmentMapFromDatabaseObjectCostNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setOfficeEquipment(
+                createTangibleAssetsResourceEntity(false, true));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getOfficeEquipment());
+        assertNotNull(tangibleAssets.getOfficeEquipment().getCost());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getOfficeEquipment());
+        assertCostFieldsMapped(tangibleAssets.getOfficeEquipment().getCost());
+
+        assertNull(tangibleAssets.getOfficeEquipment().getDepreciation());
+    }
+
+    @Test
+    @DisplayName("Test office equipment fields map from the database object when the nested depreciation object is not null")
+    void TestOfficeEquipmentMapFromDatabaseObjectDepreciationNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setOfficeEquipment(
+                createTangibleAssetsResourceEntity(true, false));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getOfficeEquipment());
+        assertNotNull(tangibleAssets.getOfficeEquipment().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getOfficeEquipment());
+        assertDepreciationFieldsMapped(tangibleAssets.getOfficeEquipment().getDepreciation());
+
+        assertNull(tangibleAssets.getOfficeEquipment().getCost());
+    }
+
+    @Test
+    @DisplayName("Test office equipment fields map from the database object when the nested cost and depreciation objects are not null")
+    void TestOfficeEquipmentMapFromDatabaseObjectCostAndDepreciationNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setOfficeEquipment(
+                createTangibleAssetsResourceEntity(false, false));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getOfficeEquipment());
+        assertNotNull(tangibleAssets.getOfficeEquipment().getCost());
+        assertNotNull(tangibleAssets.getOfficeEquipment().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getOfficeEquipment());
+        assertCostFieldsMapped(tangibleAssets.getOfficeEquipment().getCost());
+        assertDepreciationFieldsMapped(tangibleAssets.getOfficeEquipment().getDepreciation());
+    }
+
+    @Test
+    @DisplayName("Test office equipment fields map from the database object when the nested cost and depreciation objects are null")
+    void TestOfficeEquipmentMapFromDatabaseObjectCostAndDepreciationNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setOfficeEquipment(
+                createTangibleAssetsResourceEntity(true, true));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getOfficeEquipment().getCost());
+        assertNull(tangibleAssets.getOfficeEquipment().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getOfficeEquipment());
+    }
+
+    @Test
+    @DisplayName("Test plant and machinery fields map from the database object when the nested cost object is not null")
+    void TestPlantAndMachineryMapFromDatabaseObjectCostNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setPlantAndMachinery(
+                createTangibleAssetsResourceEntity(false, true));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getPlantAndMachinery());
+        assertNotNull(tangibleAssets.getPlantAndMachinery().getCost());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getPlantAndMachinery());
+        assertCostFieldsMapped(tangibleAssets.getPlantAndMachinery().getCost());
+
+        assertNull(tangibleAssets.getPlantAndMachinery().getDepreciation());
+    }
+
+    @Test
+    @DisplayName("Test plant and machinery fields map from the database object when the nested depreciation object is not null")
+    void TestPlantAndMachineryMapFromDatabaseObjectDepreciationNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setPlantAndMachinery(
+                createTangibleAssetsResourceEntity(true, false));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getPlantAndMachinery());
+        assertNotNull(tangibleAssets.getPlantAndMachinery().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getPlantAndMachinery());
+        assertDepreciationFieldsMapped(tangibleAssets.getPlantAndMachinery().getDepreciation());
+
+        assertNull(tangibleAssets.getPlantAndMachinery().getCost());
+    }
+
+    @Test
+    @DisplayName("Test plant and machinery fields map from the database object when the nested cost and depreciation objects are not null")
+    void TestPlantAndMachineryMapFromDatabaseObjectCostAndDepreciationNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setPlantAndMachinery(
+                createTangibleAssetsResourceEntity(false, false));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getPlantAndMachinery());
+        assertNotNull(tangibleAssets.getPlantAndMachinery().getCost());
+        assertNotNull(tangibleAssets.getPlantAndMachinery().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getPlantAndMachinery());
+        assertCostFieldsMapped(tangibleAssets.getPlantAndMachinery().getCost());
+        assertDepreciationFieldsMapped(tangibleAssets.getPlantAndMachinery().getDepreciation());
+    }
+
+    @Test
+    @DisplayName("Test plant and machinery fields map from the database object when the nested cost and depreciation objects are null")
+    void TestPlantAndMachineryMapFromDatabaseObjectCostAndDepreciationNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setPlantAndMachinery(
+                createTangibleAssetsResourceEntity(true, true));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getPlantAndMachinery());
+        assertNull(tangibleAssets.getPlantAndMachinery().getCost());
+        assertNull(tangibleAssets.getPlantAndMachinery().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getTotal());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getPlantAndMachinery());
+    }
+
+    @Test
+    @DisplayName("Test total fields map from the database object when the nested cost object is not null")
+    void TestTotalMapFromDatabaseObjectCostNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setTotal(
+                createTangibleAssetsResourceEntity(false, true));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getTotal());
+        assertNotNull(tangibleAssets.getTotal().getCost());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getTotal());
+        assertCostFieldsMapped(tangibleAssets.getTotal().getCost());
+
+        assertNull(tangibleAssets.getTotal().getDepreciation());
+    }
+
+    @Test
+    @DisplayName("Test total fields map from the database object when the nested depreciation object is not null")
+    void TestTotalMapFromDatabaseObjectDepreciationNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setTotal(
+                createTangibleAssetsResourceEntity(true, false));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getTotal());
+        assertNotNull(tangibleAssets.getTotal().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getTotal());
+        assertDepreciationFieldsMapped(tangibleAssets.getTotal().getDepreciation());
+
+        assertNull(tangibleAssets.getTotal().getCost());
+    }
+
+    @Test
+    @DisplayName("Test total fields map from the database object when the nested cost and depreciation objects are not null")
+    void TestTotalMapFromDatabaseObjectCostAndDepreciationNotNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setTotal(
+                createTangibleAssetsResourceEntity(false, false));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getTotal());
+        assertNotNull(tangibleAssets.getTotal().getCost());
+        assertNotNull(tangibleAssets.getTotal().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getTotal());
+        assertCostFieldsMapped(tangibleAssets.getTotal().getCost());
+        assertDepreciationFieldsMapped(tangibleAssets.getTotal().getDepreciation());
+    }
+
+    @Test
+    @DisplayName("Test total fields map from the database object when the nested cost and depreciation objects are null")
+    void TestTotalMapFromDatabaseObjectCostAndDepreciationNull() {
+
+        TangibleAssetsDataEntity tangibleAssetsDataEntity = createTangibleAssetsDataEntity();
+        tangibleAssetsDataEntity.setTotal(
+                createTangibleAssetsResourceEntity(true, true));
+
+        TangibleAssetsEntity tangibleAssetsEntity = new TangibleAssetsEntity();
+        tangibleAssetsEntity.setData(tangibleAssetsDataEntity);
+
+        TangibleAssets tangibleAssets = transformer.transform(tangibleAssetsEntity);
+
+        assertNotNull(tangibleAssets);
+        assertNotNull(tangibleAssets.getTotal());
+        assertNull(tangibleAssets.getTotal().getCost());
+        assertNull(tangibleAssets.getTotal().getDepreciation());
+
+        assertNull(tangibleAssets.getFixturesAndFittings());
+        assertNull(tangibleAssets.getLandAndBuildings());
+        assertNull(tangibleAssets.getMotorVehicles());
+        assertNull(tangibleAssets.getOfficeEquipment());
+        assertNull(tangibleAssets.getPlantAndMachinery());
+
+        assertRestObjectFieldsMapped(tangibleAssets);
+        assertAdditionalInformationMapped(tangibleAssets);
+        assertNetBookValueFieldsMapped(tangibleAssets.getTotal());
+    }
+    
     private TangibleAssets createTangibleAssets() {
 
         TangibleAssets tangibleAssets = new TangibleAssets();
@@ -760,6 +1492,59 @@ public class TangibleAssetsTransformerTest {
         return depreciation;
     }
 
+    private TangibleAssetsDataEntity createTangibleAssetsDataEntity() {
+
+        TangibleAssetsDataEntity dataEntity = new TangibleAssetsDataEntity();
+        dataEntity.setAdditionalInformation(ADDITIONAL_INFORMATION);
+        dataEntity.setEtag(ETAG);
+        dataEntity.setKind(KIND);
+        dataEntity.setLinks(LINKS);
+        return dataEntity;
+    }
+
+    private TangibleAssetsResourceEntity createTangibleAssetsResourceEntity(boolean costNull,
+                                                                            boolean depreciationNull) {
+
+        TangibleAssetsResourceEntity tangibleAssetsResourceEntity = new TangibleAssetsResourceEntity();
+        tangibleAssetsResourceEntity
+                .setNetBookValueAtEndOfCurrentPeriod(NET_BOOK_VALUE_AT_END_OF_CURRENT_PERIOD);
+        tangibleAssetsResourceEntity
+                .setNetBookValueAtEndOfPreviousPeriod(NET_BOOK_VALUE_AT_END_OF_PREVIOUS_PERIOD);
+
+        if (!costNull) {
+            tangibleAssetsResourceEntity.setCost(createCostEntity());
+        }
+
+        if (!depreciationNull) {
+            tangibleAssetsResourceEntity.setDepreciation(createDepreciationEntity());
+        }
+
+        return tangibleAssetsResourceEntity;
+    }
+
+    private CostEntity createCostEntity() {
+
+        CostEntity cost = new CostEntity();
+        cost.setAdditions(COST_ADDITIONS);
+        cost.setAtPeriodEnd(COST_AT_PERIOD_END);
+        cost.setAtPeriodStart(COST_AT_PERIOD_START);
+        cost.setDisposals(COST_DISPOSALS);
+        cost.setRevaluations(COST_REVALUATIONS);
+        cost.setTransfers(COST_TRANSFERS);
+        return cost;
+    }
+
+    private DepreciationEntity createDepreciationEntity() {
+
+        DepreciationEntity depreciation = new DepreciationEntity();
+        depreciation.setAtPeriodEnd(DEPRECIATION_AT_PERIOD_END);
+        depreciation.setAtPeriodStart(DEPRECIATION_AT_PERIOD_START);
+        depreciation.setChargeForYear(DEPRECIATION_CHARGE_FOR_YEAR);
+        depreciation.setOnDisposals(DEPRECIATION_ON_DISPOSALS);
+        depreciation.setOtherAdjustments(DEPRECIATION_OTHER_ADJUSTMENTS);
+        return depreciation;
+    }
+
     private void assertRestObjectFieldsMapped(TangibleAssetsEntity tangibleAssets) {
         assertEquals(ETAG, tangibleAssets.getData().getEtag());
         assertEquals(KIND, tangibleAssets.getData().getKind());
@@ -787,6 +1572,40 @@ public class TangibleAssetsTransformerTest {
     }
 
     private void assertDepreciationFieldsMapped(DepreciationEntity depreciation) {
+        assertEquals(DEPRECIATION_AT_PERIOD_END, depreciation.getAtPeriodEnd());
+        assertEquals(DEPRECIATION_AT_PERIOD_START, depreciation.getAtPeriodStart());
+        assertEquals(DEPRECIATION_CHARGE_FOR_YEAR, depreciation.getChargeForYear());
+        assertEquals(DEPRECIATION_ON_DISPOSALS, depreciation.getOnDisposals());
+        assertEquals(DEPRECIATION_OTHER_ADJUSTMENTS, depreciation.getOtherAdjustments());
+    }
+
+    private void assertRestObjectFieldsMapped(TangibleAssets tangibleAssets) {
+        assertEquals(ETAG, tangibleAssets.getEtag());
+        assertEquals(KIND, tangibleAssets.getKind());
+        assertEquals(LINKS, tangibleAssets.getLinks());
+    }
+
+    private void assertAdditionalInformationMapped(TangibleAssets tangibleAssets) {
+        assertEquals(ADDITIONAL_INFORMATION, tangibleAssets.getAdditionalInformation());
+    }
+
+    private void assertNetBookValueFieldsMapped(TangibleAssetsResource tangibleAssetsResource) {
+        assertEquals(NET_BOOK_VALUE_AT_END_OF_CURRENT_PERIOD,
+                tangibleAssetsResource.getNetBookValueAtEndOfCurrentPeriod());
+        assertEquals(NET_BOOK_VALUE_AT_END_OF_CURRENT_PERIOD,
+                tangibleAssetsResource.getNetBookValueAtEndOfCurrentPeriod());
+    }
+
+    private void assertCostFieldsMapped(Cost cost) {
+        assertEquals(COST_ADDITIONS, cost.getAdditions());
+        assertEquals(COST_AT_PERIOD_END, cost.getAtPeriodEnd());
+        assertEquals(COST_AT_PERIOD_START, cost.getAtPeriodStart());
+        assertEquals(COST_DISPOSALS, cost.getDisposals());
+        assertEquals(COST_REVALUATIONS, cost.getRevaluations());
+        assertEquals(COST_TRANSFERS, cost.getTransfers());
+    }
+
+    private void assertDepreciationFieldsMapped(Depreciation depreciation) {
         assertEquals(DEPRECIATION_AT_PERIOD_END, depreciation.getAtPeriodEnd());
         assertEquals(DEPRECIATION_AT_PERIOD_START, depreciation.getAtPeriodStart());
         assertEquals(DEPRECIATION_CHARGE_FOR_YEAR, depreciation.getChargeForYear());


### PR DESCRIPTION
Add transformer to map database object data to a rest object for tangible assets, with supporting unit tests.

Required for SFA-935