### PR TITLE
Amending Tangible notes to fix existing issues

### DIFF
--- a/src/main/resources/filing/templates/small-full-accounts.html
+++ b/src/main/resources/filing/templates/small-full-accounts.html
@@ -2969,46 +2969,46 @@ ul.accounts-comps-ct {
                   </tr>
 
                   <tr class="figures">
-                      <td id ="tangible-net-book-value-at-period-start">At {{$period.current_period_end_on_formatted}}</td>
-                      <td id="tangible-net-book-value-at-period-start-land-and-building" class="strong grandtotal">
+                      <td id ="tangible-net-book-value-current-period">At {{$period.current_period_end_on_formatted}}</td>
+                      <td id="tangible-net-book-value-current-period-land-and-building" class="strong grandtotal">
                           <ix:nonFraction contextRef="LandAndBuildings_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.land_and_buildings}}</ix:nonFraction>
                       </td>
-                      <td id="tangible-net-book-value-at-period-start-land-and-building" class="strong grandtotal">
+                      <td id="tangible-net-book-value-current-period-land-and-building" class="strong grandtotal">
                           <ix:nonFraction contextRef="PlantMachinery_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.plant_and_machinery}}</ix:nonFraction>
                       </td>
-                      <td id="tangible-net-book-value-at-period-start-fixtures-and-fitting" class="strong grandtotal">
+                      <td id="tangible-net-book-value-current-period-fixtures-and-fitting" class="strong grandtotal">
                           <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.fixtures_and_fittings}}</ix:nonFraction>
                       </td>
-                      <td id="tangible-net-book-value-at-period-start-office-equipment" class="strong grandtotal">
+                      <td id="tangible-net-book-value-current-period-office-equipment" class="strong grandtotal">
                           <ix:nonFraction contextRef="OfficeEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.office_equipment}}</ix:nonFraction>
                       </td>
-                      <td id="tangible-net-book-value-at-period-start-office-equipment" class="strong grandtotal">
+                      <td id="tangible-net-book-value-current-period-office-equipment" class="strong grandtotal">
                           <ix:nonFraction contextRef="Vehicles_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.motor_vehicles}}</ix:nonFraction>
                       </td>
-                      <td id="tangible-net-book-value-at-period-start-total" class="strong grandtotal">
+                      <td id="tangible-net-book-value-current-period-total" class="strong grandtotal">
                           <ix:nonFraction contextRef="CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.total}}</ix:nonFraction>
                       </td>
                   </tr>
 
                   {{if $previousPeriod}}
                   <tr class="figures">
-                      <td id="tangible-net-book-value-at-period-end">At {{$period.previous_period_end_on_formatted}}</td>
-                      <td id="tangible-net-book-value-at-period-start-land-and-building" class="strong grandtotal">
+                      <td id="tangible-net-book-value-previous_period">At {{$period.previous_period_end_on_formatted}}</td>
+                      <td id="tangible-net-book-value-previous_period-land-and-building" class="strong grandtotal">
                           <ix:nonFraction contextRef="LandAndBuildings_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.land_and_buildings}}</ix:nonFraction>
                       </td>
-                      <td id="tangible-net-book-value-at-period-start-plant-and-machinery" class="strong grandtotal">
+                      <td id="tangible-net-book-value-previous_period-plant-and-machinery" class="strong grandtotal">
                           <ix:nonFraction contextRef="PlantMachinery_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.plant_and_machinery}}</ix:nonFraction>
                       </td>
-                      <td id="tangible-net-book-value-at-period-start-fixtures-and-fitting" class="strong grandtotal">
+                      <td id="tangible-net-book-value-previous_period-fixtures-and-fitting" class="strong grandtotal">
                           <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.fixtures_and_fittings}}</ix:nonFraction>
                       </td>
-                      <td id="tangible-net-book-value-at-period-start-office-equipment" class="strong grandtotal">
+                      <td id="tangible-net-book-value-previous_period-office-equipment" class="strong grandtotal">
                           <ix:nonFraction contextRef="OfficeEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.office_equipment}}</ix:nonFraction>
                       </td>
-                      <td id="tangible-net-book-value-at-period-start-motor-vehicles" class="strong grandtotal">
+                      <td id="tangible-net-book-value-previous_period-motor-vehicles" class="strong grandtotal">
                           <ix:nonFraction contextRef="Vehicles_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.motor_vehicles}}</ix:nonFraction>
                       </td>
-                      <td id="tangible-net-book-value-at-period-end-total" class="strong grandtotal">
+                      <td id="tangible-net-book-value-previous_period-total" class="strong grandtotal">
                           <ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.total}}</ix:nonFraction>
                       </td>
                   </tr>

--- a/src/main/resources/filing/templates/small-full-accounts.html
+++ b/src/main/resources/filing/templates/small-full-accounts.html
@@ -2684,7 +2684,7 @@ ul.accounts-comps-ct {
 
                   <tr class="figures">
                       <td id="tangible-cost-additions">Additions</td>
-                      <td id="tangible-cost-additions-land-and-building"class="strong figure">
+                      <td id="tangible-cost-additions-land-and-building" class="strong figure">
                           {{if isNotEmpty $cost.additions.land_and_buildings}}
                           <ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:TotalAdditionsIncludingFromBusinessCombinationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.additions.land_and_buildings}}

--- a/src/main/resources/filing/templates/small-full-accounts.html
+++ b/src/main/resources/filing/templates/small-full-accounts.html
@@ -2642,6 +2642,7 @@ ul.accounts-comps-ct {
                       <td class="text--center">&#163;</td>
                   </tr>
 
+                  {{if $previousPeriod}}
                   <tr class="figures">
                       <td id="tangible-cost-at-period-start">At {{$period.current_period_start_on_formatted}}</td>
                       <td id="tangible-cost-at-period-start-land-and-building" class="strong figure">
@@ -2663,6 +2664,7 @@ ul.accounts-comps-ct {
                           <ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.total}}</ix:nonFraction>
                       </td>
                   </tr>
+                  {{end}}
 
                   <tr class="figures">
                       <td id="tangible-cost-additions">Additions</td>
@@ -2820,6 +2822,7 @@ ul.accounts-comps-ct {
                       <td class="text--center"></td>
                   </tr>
 
+                  {{if $previousPeriod}}
                   <tr class="figures">
                       <td id="tangible-depreciation-at-period-start">At {{$period.current_period_start_on_formatted}}</td>
                       <td id="tangible-depreciation-at-period-start-land-and-building" class="strong figure">
@@ -2841,6 +2844,7 @@ ul.accounts-comps-ct {
                           <ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.total}}</ix:nonFraction>
                       </td>
                   </tr>
+                  {{end}}
 
                   <tr class="figures">
                       <td id="tangible-depreciation-charge">Charge for year</td>
@@ -2986,6 +2990,7 @@ ul.accounts-comps-ct {
                       </td>
                   </tr>
 
+                  {{if $previousPeriod}}
                   <tr class="figures">
                       <td id="tangible-net-book-value-at-period-end">At {{$period.previous_period_end_on_formatted}}</td>
                       <td id="tangible-net-book-value-at-period-start-land-and-building" class="strong grandtotal">
@@ -3007,6 +3012,7 @@ ul.accounts-comps-ct {
                           <ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.total}}</ix:nonFraction>
                       </td>
                   </tr>
+                  {{end}}
                   </tbody>
               </table>
 

--- a/src/main/resources/filing/templates/small-full-accounts.html
+++ b/src/main/resources/filing/templates/small-full-accounts.html
@@ -1973,7 +1973,7 @@ ul.accounts-comps-ct {
                   </tr>
                   <tr class = "figures">
                     <td id = "tangible-assets-label">Tangible assets:</td>
-                    {{if .small_full_accounts.additional_notes.tangible_assets}}
+                    {{if .small_full_accounts.balance_sheet_notes.tangible_assets}}
                         <td class="figure noteIndex" id="uk-busPropertyPlantEquipmentCY_ENDNoteIndexes">{{getValue "tangible-notes-id" }}</td>
                     {{else}}
                         <td class="figure noteIndex" id="uk-busPropertyPlantEquipmentCY_ENDNoteIndexes">&#160;</td>

--- a/src/main/resources/filing/templates/small-full-accounts.html
+++ b/src/main/resources/filing/templates/small-full-accounts.html
@@ -2643,55 +2643,55 @@ ul.accounts-comps-ct {
                   </tr>
 
                   <tr class="figures">
-                      <td>At {{$period.current_period_start_on_formatted}}</td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-at-period-start">At {{$period.current_period_start_on_formatted}}</td>
+                      <td id="tangible-cost-at-period-start-land-and-building" class="strong figure">
                           {{emitIfNegative $cost.at_period_start.land_and_buildings "(" }}<ix:nonFraction contextRef="LandAndBuildings_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.land_and_buildings}}</ix:nonFraction>{{emitIfNegative $cost.at_period_start.land_and_buildings ")" }}
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-at-period-start-plant-and-machinery" class="strong figure">
                           {{emitIfNegative $cost.at_period_start.plant_and_machinery "(" }}<ix:nonFraction contextRef="PlantMachinery_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.plant_and_machinery}}</ix:nonFraction>{{emitIfNegative $cost.at_period_start.plant_and_machinery ")" }}
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-at-period-start-fixtures-and-fitting" class="strong figure">
                           {{emitIfNegative $cost.at_period_start.fixtures_and_fittings "(" }}<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.fixtures_and_fittings}}</ix:nonFraction>{{emitIfNegative $cost.at_period_start.fixtures_and_fittings ")" }}
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-at-period-start-office-equipment" class="strong figure">
                           {{emitIfNegative $cost.at_period_start.office_equipment "(" }}<ix:nonFraction contextRef="OfficeEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.office_equipment}}</ix:nonFraction>{{emitIfNegative $cost.at_period_start.office_equipment ")" }}
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-at-period-start-motor-vehicles" class="strong figure">
                           {{emitIfNegative $cost.at_period_start.motor_vehicles "(" }}<ix:nonFraction contextRef="Vehicles_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.motor_vehicles}}</ix:nonFraction>{{emitIfNegative $cost.at_period_start.motor_vehicles ")" }}
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-at-period-start-total" class="strong figure">
                           {{emitIfNegative $cost.at_period_start.total "(" }}<ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.total}}</ix:nonFraction>{{emitIfNegative $cost.at_period_start.total ")" }}
                       </td>
                   </tr>
 
                   <tr class="figures">
-                      <td>Additions</td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-additions">Additions</td>
+                      <td id="tangible-cost-additions-land-and-building"class="strong figure">
                           <ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:TotalAdditionsIncludingFromBusinessCombinationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.additions.land_and_buildings}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-additions-plant-and-machinery" class="strong figure">
                           <ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:TotalAdditionsIncludingFromBusinessCombinationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.additions.plant_and_machinery}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-additions-fixtures-and-fitting" class="strong figure">
                           <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:TotalAdditionsIncludingFromBusinessCombinationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.additions.fixtures_and_fittings}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-additions-office-equipment" class="strong figure">
                           <ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:TotalAdditionsIncludingFromBusinessCombinationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.additions.office_equipment}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-additions-motor-vehicles" class="strong figure">
                           <ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:TotalAdditionsIncludingFromBusinessCombinationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.additions.motor_vehicles}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-additions-total" class="strong figure">
                           <ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:TotalAdditionsIncludingFromBusinessCombinationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.additions.total}}
                           </ix:nonFraction>
@@ -2699,55 +2699,55 @@ ul.accounts-comps-ct {
                   </tr>
 
                   <tr class="figures">
-                      <td>Disposals</td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-disposals">Disposals</td>
+                      <td id="tangible-cost-disposals-land-and-building" class="strong figure">
                           <span class="debit">(<ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.land_and_buildings}}</ix:nonFraction>)</span>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-disposals-plant-and-machinery" class="strong figure">
                           <span class="debit">(<ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.plant_and_machinery}}</ix:nonFraction>)</span>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-disposals-fixtures-and-fitting" class="strong figure">
                           <span class="debit">(<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.fixtures_and_fittings}}</ix:nonFraction>)</span>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-disposals-office-equipment" class="strong figure">
                           <span class="debit">(<ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.office_equipment}}</ix:nonFraction>)</span>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-disposals-motor-vehicles" class="strong figure">
                           <span class="debit">(<ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.motor_vehicles}}</ix:nonFraction>)</span>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-disposals-total" class="strong figure">
                           <span class="debit">(<ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.total}}</ix:nonFraction>)</span>
                       </td>
                   </tr>
 
                   <tr class="figures">
-                      <td>Revaluations</td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-revaluations">Revaluations</td>
+                      <td id="tangible-cost-revaluations-land-and-building" class="strong figure">
                           <ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:TotalIncreaseDecreaseFromRevaluationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.revaluations.land_and_buildings}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-revaluations-plant-and-machinery" class="strong figure">
                           <ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:TotalIncreaseDecreaseFromRevaluationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.revaluations.plant_and_machinery}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-revaluations-fixtures-and-fitting" class="strong figure">
                           <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:TotalIncreaseDecreaseFromRevaluationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.revaluations.fixtures_and_fittings}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-revaluations-office-equipment" class="strong figure">
                           <ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:TotalIncreaseDecreaseFromRevaluationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.revaluations.office_equipment}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-revaluations-motor-vehicles" class="strong figure">
                           <ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:TotalIncreaseDecreaseFromRevaluationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.revaluations.motor_vehicles}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-revaluations-total" class="strong figure">
                           <ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:TotalIncreaseDecreaseFromRevaluationsPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.revaluations.total}}
                           </ix:nonFraction>
@@ -2755,33 +2755,33 @@ ul.accounts-comps-ct {
                   </tr>
 
                   <tr class="figures">
-                      <td>Transfers</td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-transfers" >Transfers</td>
+                      <td id="tangible-cost-transfers-land-and-building" class="strong figure">
                           <ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:IncreaseDecreaseDueToTransfersBetweenClassesPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.transfers.land_and_buildings}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-transfers-plant-and-machinery" class="strong figure">
                           <ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:IncreaseDecreaseDueToTransfersBetweenClassesPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.transfers.plant_and_machinery}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-transfers-fixtures-and-fitting" class="strong figure">
                           <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:IncreaseDecreaseDueToTransfersBetweenClassesPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.transfers.fixtures_and_fittings}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-transfers-office-equipment" class="strong figure">
                           <ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:IncreaseDecreaseDueToTransfersBetweenClassesPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.transfers.office_equipment}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-transfers-motor-vehicles" class="strong figure">
                           <ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:IncreaseDecreaseDueToTransfersBetweenClassesPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.transfers.motor_vehicles}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-cost-transfers-total" class="strong figure">
                           <ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:IncreaseDecreaseDueToTransfersBetweenClassesPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $cost.transfers.total}}
                           </ix:nonFraction>
@@ -2789,23 +2789,23 @@ ul.accounts-comps-ct {
                   </tr>
 
                   <tr class="figures">
-                      <td>At {{$period.current_period_end_on_formatted}}</td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-cost-at-period-end">At {{$period.current_period_end_on_formatted}}</td>
+                      <td id="tangible-cost-at-period-end-land-and-building" class="strong grandtotal">
                           {{emitIfNegative $cost.at_period_end.land_and_buildings "(" }}<ix:nonFraction contextRef="LandAndBuildings_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.land_and_buildings}}</ix:nonFraction>{{emitIfNegative $cost.at_period_end.land_and_buildings ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-cost-at-period-end-plant-and-machinery" class="strong grandtotal">
                           {{emitIfNegative $cost.at_period_end.plant_and_machinery "(" }}<ix:nonFraction contextRef="PlantMachinery_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.plant_and_machinery}}</ix:nonFraction>{{emitIfNegative $cost.at_period_end.plant_and_machinery ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-cost-at-period-end-fixtures-and-fitting" class="strong grandtotal">
                           {{emitIfNegative $cost.at_period_end.fixtures_and_fittings "(" }}<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.fixtures_and_fittings}}</ix:nonFraction>{{emitIfNegative $cost.at_period_end.fixtures_and_fittings ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-cost-at-period-end-office-equipment" class="strong grandtotal">
                           {{emitIfNegative $cost.at_period_end.office_equipment "(" }}<ix:nonFraction contextRef="OfficeEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.office_equipment}}</ix:nonFraction>{{emitIfNegative $cost.at_period_end.office_equipment ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-cost-at-period-end-motor-vehicles" class="strong grandtotal">
                           {{emitIfNegative $cost.at_period_end.motor_vehicles "(" }}<ix:nonFraction contextRef="Vehicles_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.motor_vehicles}}</ix:nonFraction>{{emitIfNegative $cost.at_period_end.motor_vehicles ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-cost-at-period-end-total" class="strong grandtotal">
                           {{emitIfNegative $cost.at_period_end.total "(" }}<ix:nonFraction contextRef="CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.total}}</ix:nonFraction>{{emitIfNegative $cost.at_period_end.total ")" }}
                       </td>
                   </tr>
@@ -2821,55 +2821,55 @@ ul.accounts-comps-ct {
                   </tr>
 
                   <tr class="figures">
-                      <td>At {{$period.current_period_start_on_formatted}}</td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-at-period-start">At {{$period.current_period_start_on_formatted}}</td>
+                      <td id="tangible-depreciation-at-period-start-land-and-building" class="strong figure">
                           {{emitIfNegative $depreciation.at_period_start.land_and_buildings "(" }}<ix:nonFraction contextRef="LandAndBuildings_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.land_and_buildings}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_start.land_and_buildings ")" }}
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-at-period-start-plant-and-machinery" class="strong figure">
                           {{emitIfNegative $depreciation.at_period_start.plant_and_machinery "(" }}<ix:nonFraction contextRef="PlantMachinery_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.plant_and_machinery}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_start.plant_and_machinery ")" }}
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-at-period-start-fixtures-and-fitting" class="strong figure">
                           {{emitIfNegative $depreciation.at_period_start.fixtures_and_fittings "(" }}<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.fixtures_and_fittings}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_start.fixtures_and_fittings ")" }}
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-at-period-start-office-equipment" class="strong figure">
                           {{emitIfNegative $depreciation.at_period_start.office_equipment "(" }}<ix:nonFraction contextRef="OfficeEquipment_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.office_equipment}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_start.office_equipment ")" }}
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-at-period-start-motor-vehicles" class="strong figure">
                           {{emitIfNegative $depreciation.at_period_start.motor_vehicles "(" }}<ix:nonFraction contextRef="Vehicles_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.motor_vehicles}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_start.motor_vehicles ")" }}
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-at-period-start-total" class="strong figure">
                           {{emitIfNegative $depreciation.at_period_start.total "(" }}<ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.total}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_start.total ")" }}
                       </td>
                   </tr>
 
                   <tr class="figures">
-                      <td>Charge for year</td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-charge">Charge for year</td>
+                      <td id="tangible-depreciation-charge-land-and-building" class="strong figure">
                           <ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:IncreaseFromDepreciationChargeForYearPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $depreciation.charge_for_year.land_and_buildings}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-charge-plant-and-machinery" class="strong figure">
                           <ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:IncreaseFromDepreciationChargeForYearPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $depreciation.charge_for_year.plant_and_machinery}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-charge-fixtures-and-fitting" class="strong figure">
                           <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:IncreaseFromDepreciationChargeForYearPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $depreciation.charge_for_year.fixtures_and_fittings}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-charge-office-equipment" class="strong figure">
                           <ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:IncreaseFromDepreciationChargeForYearPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $depreciation.charge_for_year.office_equipment}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-charge-motor-vehicles" class="strong figure">
                           <ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:IncreaseFromDepreciationChargeForYearPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $depreciation.charge_for_year.motor_vehicles}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-charge-total" class="strong figure">
                           <ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:IncreaseFromDepreciationChargeForYearPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $depreciation.charge_for_year.total}}
                           </ix:nonFraction>
@@ -2877,55 +2877,55 @@ ul.accounts-comps-ct {
                   </tr>
 
                   <tr class="figures">
-                      <td>On disposals</td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-on-disposals">On disposals</td>
+                      <td id="tangible-depreciation-on-disposals-land-and-building" class="strong figure">
                           <span class="debit">(<ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.land_and_buildings}}</ix:nonFraction>)</span>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-on-disposals-plant-and-machinery" class="strong figure">
                           <span class="debit">(<ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.plant_and_machinery}}</ix:nonFraction>)</span>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-on-disposals-fixtures-and-fitting" class="strong figure">
                           <span class="debit">(<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.fixtures_and_fittings}}</ix:nonFraction>)</span>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-on-disposals-office-equipment" class="strong figure">
                           <span class="debit">(<ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.office_equipment}}</ix:nonFraction>)</span>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-on-disposals-motor-vehicles" class="strong figure">
                           <span class="debit">(<ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.motor_vehicles}}</ix:nonFraction>)</span>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-on-disposals-total" class="strong figure">
                           <span class="debit">(<ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.total}}</ix:nonFraction>)</span>
                       </td>
                   </tr>
 
                   <tr class="figures">
-                      <td>Other adjustments</td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-other-adjustments">Other adjustments</td>
+                      <td id="tangible-depreciation-other-adjustments-land-and-building" class="strong figure">
                           <ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:OtherIncreaseDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $depreciation.other_adjustments.land_and_buildings}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-other-adjustments-plant-and-machinery" class="strong figure">
                           <ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:OtherIncreaseDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $depreciation.other_adjustments.plant_and_machinery}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-other-adjustments-fixtures-and-fitting" class="strong figure">
                           <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:OtherIncreaseDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $depreciation.other_adjustments.fixtures_and_fittings}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-other-adjustments-office-equipment" class="strong figure">
                           <ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:OtherIncreaseDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $depreciation.other_adjustments.office_equipment}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-other-adjustments-motor-vehicles" class="strong figure">
                           <ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:OtherIncreaseDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $depreciation.other_adjustments.motor_vehicles}}
                           </ix:nonFraction>
                       </td>
-                      <td class="strong figure">
+                      <td id="tangible-depreciation-other-adjustments-total" class="strong figure">
                           <ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:OtherIncreaseDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">
                               {{getMagnitudeFormatted $depreciation.other_adjustments.total}}
                           </ix:nonFraction>
@@ -2933,23 +2933,23 @@ ul.accounts-comps-ct {
                   </tr>
 
                   <tr class="figures">
-                      <td>At {{$period.current_period_end_on_formatted}}</td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-depreciation-at-period-end">At {{$period.current_period_end_on_formatted}}</td>
+                      <td id="tangible-depreciation-at-period-end-land-and-building" class="strong grandtotal">
                           {{emitIfNegative $depreciation.at_period_end.land_and_buildings "(" }}<ix:nonFraction contextRef="LandAndBuildings_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.land_and_buildings}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_end.land_and_buildings ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-depreciation-at-period-end-plant-and-machinery" class="strong grandtotal">
                           {{emitIfNegative $depreciation.at_period_end.plant_and_machinery "(" }}<ix:nonFraction contextRef="PlantMachinery_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.plant_and_machinery}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_end.plant_and_machinery ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-depreciation-at-period-end-fixtures-and-fitting" class="strong grandtotal">
                           {{emitIfNegative $depreciation.at_period_end.fixtures_and_fittings "(" }}<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.fixtures_and_fittings}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_end.fixtures_and_fittings ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-depreciation-at-period-end-office-equipment" class="strong grandtotal">
                           {{emitIfNegative $depreciation.at_period_end.office_equipment "(" }}<ix:nonFraction contextRef="OfficeEquipment_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.office_equipment}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_end.office_equipment ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-depreciation-at-period-end-motor-vehicles" class="strong grandtotal">
                           {{emitIfNegative $depreciation.at_period_end.motor_vehicles "(" }}<ix:nonFraction contextRef="Vehicles_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.motor_vehicles}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_end.motor_vehicles ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-depreciation-at-period-end-total" class="strong grandtotal">
                           {{emitIfNegative $depreciation.at_period_end.total "(" }}<ix:nonFraction contextRef="CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.total}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_end.total ")" }}
                       </td>
                   </tr>
@@ -2965,45 +2965,45 @@ ul.accounts-comps-ct {
                   </tr>
 
                   <tr class="figures">
-                      <td>At {{$period.current_period_end_on_formatted}}</td>
-                      <td class="strong grandtotal">
+                      <td id ="tangible-net-book-value-at-period-start">At {{$period.current_period_end_on_formatted}}</td>
+                      <td id="tangiblenet-book-value-at-period-start-land-and-building" class="strong grandtotal">
                           {{emitIfNegative $netBookValue.current_period.land_and_buildings "(" }}<ix:nonFraction contextRef="LandAndBuildings_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.land_and_buildings}}</ix:nonFraction>{{emitIfNegative $netBookValue.current_period.land_and_buildings ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-net-book-value-at-period-start-land-and-building" class="strong grandtotal">
                           {{emitIfNegative $netBookValue.current_period.plant_and_machinery "(" }}<ix:nonFraction contextRef="PlantMachinery_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.plant_and_machinery}}</ix:nonFraction>{{emitIfNegative $netBookValue.current_period.plant_and_machinery ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-net-book-value-at-period-start-fixtures-and-fitting" class="strong grandtotal">
                           {{emitIfNegative $netBookValue.current_period.fixtures_and_fittings "(" }}<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.fixtures_and_fittings}}</ix:nonFraction>{{emitIfNegative $netBookValue.current_period.fixtures_and_fittings ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-net-book-value-at-period-start-office-equipment" class="strong grandtotal">
                           {{emitIfNegative $netBookValue.current_period.office_equipment "(" }}<ix:nonFraction contextRef="OfficeEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.office_equipment}}</ix:nonFraction>{{emitIfNegative $netBookValue.current_period.office_equipment ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-net-book-value-at-period-start-office-equipment" class="strong grandtotal">
                           {{emitIfNegative $netBookValue.current_period.motor_vehicles "(" }}<ix:nonFraction contextRef="Vehicles_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.motor_vehicles}}</ix:nonFraction>{{emitIfNegative $netBookValue.current_period.motor_vehicles ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-net-book-value-at-period-start-total" class="strong grandtotal">
                           {{emitIfNegative $netBookValue.current_period.total "(" }}<ix:nonFraction contextRef="CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.total}}</ix:nonFraction>{{emitIfNegative $netBookValue.current_period.total ")" }}
                       </td>
                   </tr>
 
                   <tr class="figures">
-                      <td>At {{$period.previous_period_end_on_formatted}}</td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-net-book-value-at-period-end">At {{$period.previous_period_end_on_formatted}}</td>
+                      <td id="tangible-net-book-value-at-period-start-land-and-building" class="strong grandtotal">
                           {{emitIfNegative $netBookValue.previous_period.land_and_buildings "(" }}<ix:nonFraction contextRef="LandAndBuildings_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.land_and_buildings}}</ix:nonFraction>{{emitIfNegative $netBookValue.previous_period.land_and_buildings ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-net-book-value-at-period-start-plant-and-machinery" class="strong grandtotal">
                           {{emitIfNegative $netBookValue.previous_period.plant_and_machinery "(" }}<ix:nonFraction contextRef="PlantMachinery_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.plant_and_machinery}}</ix:nonFraction>{{emitIfNegative $netBookValue.previous_period.plant_and_machinery ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-net-book-value-at-period-start-fixtures-and-fitting" class="strong grandtotal">
                           {{emitIfNegative $netBookValue.previous_period.fixtures_and_fittings "(" }}<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.fixtures_and_fittings}}</ix:nonFraction>{{emitIfNegative $netBookValue.previous_period.fixtures_and_fittings ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-net-book-value-at-period-start-office-equipment" class="strong grandtotal">
                           {{emitIfNegative $netBookValue.previous_period.office_equipment "(" }}<ix:nonFraction contextRef="OfficeEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.office_equipment}}</ix:nonFraction>{{emitIfNegative $netBookValue.previous_period.office_equipment ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-net-book-value-at-period-start-motor-vehicles" class="strong grandtotal">
                           {{emitIfNegative $netBookValue.previous_period.motor_vehicles "(" }}<ix:nonFraction contextRef="Vehicles_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.motor_vehicles}}</ix:nonFraction>{{emitIfNegative $netBookValue.previous_period.motor_vehicles ")" }}
                       </td>
-                      <td class="strong grandtotal">
+                      <td id="tangible-net-book-value-at-period-end-total" class="strong grandtotal">
                           {{emitIfNegative $netBookValue.previous_period.total "(" }}<ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.total}}</ix:nonFraction>{{emitIfNegative $netBookValue.previous_period.total ")" }}
                       </td>
                   </tr>

--- a/src/main/resources/filing/templates/small-full-accounts.html
+++ b/src/main/resources/filing/templates/small-full-accounts.html
@@ -2645,22 +2645,22 @@ ul.accounts-comps-ct {
                   <tr class="figures">
                       <td id="tangible-cost-at-period-start">At {{$period.current_period_start_on_formatted}}</td>
                       <td id="tangible-cost-at-period-start-land-and-building" class="strong figure">
-                          {{emitIfNegative $cost.at_period_start.land_and_buildings "(" }}<ix:nonFraction contextRef="LandAndBuildings_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.land_and_buildings}}</ix:nonFraction>{{emitIfNegative $cost.at_period_start.land_and_buildings ")" }}
+                          <ix:nonFraction contextRef="LandAndBuildings_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.land_and_buildings}}</ix:nonFraction>
                       </td>
                       <td id="tangible-cost-at-period-start-plant-and-machinery" class="strong figure">
-                          {{emitIfNegative $cost.at_period_start.plant_and_machinery "(" }}<ix:nonFraction contextRef="PlantMachinery_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.plant_and_machinery}}</ix:nonFraction>{{emitIfNegative $cost.at_period_start.plant_and_machinery ")" }}
+                          <ix:nonFraction contextRef="PlantMachinery_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.plant_and_machinery}}</ix:nonFraction>
                       </td>
                       <td id="tangible-cost-at-period-start-fixtures-and-fitting" class="strong figure">
-                          {{emitIfNegative $cost.at_period_start.fixtures_and_fittings "(" }}<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.fixtures_and_fittings}}</ix:nonFraction>{{emitIfNegative $cost.at_period_start.fixtures_and_fittings ")" }}
+                          <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.fixtures_and_fittings}}</ix:nonFraction>
                       </td>
                       <td id="tangible-cost-at-period-start-office-equipment" class="strong figure">
-                          {{emitIfNegative $cost.at_period_start.office_equipment "(" }}<ix:nonFraction contextRef="OfficeEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.office_equipment}}</ix:nonFraction>{{emitIfNegative $cost.at_period_start.office_equipment ")" }}
+                          <ix:nonFraction contextRef="OfficeEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.office_equipment}}</ix:nonFraction>
                       </td>
                       <td id="tangible-cost-at-period-start-motor-vehicles" class="strong figure">
-                          {{emitIfNegative $cost.at_period_start.motor_vehicles "(" }}<ix:nonFraction contextRef="Vehicles_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.motor_vehicles}}</ix:nonFraction>{{emitIfNegative $cost.at_period_start.motor_vehicles ")" }}
+                          <ix:nonFraction contextRef="Vehicles_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.motor_vehicles}}</ix:nonFraction>
                       </td>
                       <td id="tangible-cost-at-period-start-total" class="strong figure">
-                          {{emitIfNegative $cost.at_period_start.total "(" }}<ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.total}}</ix:nonFraction>{{emitIfNegative $cost.at_period_start.total ")" }}
+                          <ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_start.total}}</ix:nonFraction>
                       </td>
                   </tr>
 
@@ -2791,22 +2791,22 @@ ul.accounts-comps-ct {
                   <tr class="figures">
                       <td id="tangible-cost-at-period-end">At {{$period.current_period_end_on_formatted}}</td>
                       <td id="tangible-cost-at-period-end-land-and-building" class="strong grandtotal">
-                          {{emitIfNegative $cost.at_period_end.land_and_buildings "(" }}<ix:nonFraction contextRef="LandAndBuildings_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.land_and_buildings}}</ix:nonFraction>{{emitIfNegative $cost.at_period_end.land_and_buildings ")" }}
+                          <ix:nonFraction contextRef="LandAndBuildings_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.land_and_buildings}}</ix:nonFraction>
                       </td>
                       <td id="tangible-cost-at-period-end-plant-and-machinery" class="strong grandtotal">
-                          {{emitIfNegative $cost.at_period_end.plant_and_machinery "(" }}<ix:nonFraction contextRef="PlantMachinery_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.plant_and_machinery}}</ix:nonFraction>{{emitIfNegative $cost.at_period_end.plant_and_machinery ")" }}
+                          <ix:nonFraction contextRef="PlantMachinery_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.plant_and_machinery}}</ix:nonFraction>
                       </td>
                       <td id="tangible-cost-at-period-end-fixtures-and-fitting" class="strong grandtotal">
-                          {{emitIfNegative $cost.at_period_end.fixtures_and_fittings "(" }}<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.fixtures_and_fittings}}</ix:nonFraction>{{emitIfNegative $cost.at_period_end.fixtures_and_fittings ")" }}
+                          <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.fixtures_and_fittings}}</ix:nonFraction>
                       </td>
                       <td id="tangible-cost-at-period-end-office-equipment" class="strong grandtotal">
-                          {{emitIfNegative $cost.at_period_end.office_equipment "(" }}<ix:nonFraction contextRef="OfficeEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.office_equipment}}</ix:nonFraction>{{emitIfNegative $cost.at_period_end.office_equipment ")" }}
+                          <ix:nonFraction contextRef="OfficeEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.office_equipment}}</ix:nonFraction>
                       </td>
                       <td id="tangible-cost-at-period-end-motor-vehicles" class="strong grandtotal">
-                          {{emitIfNegative $cost.at_period_end.motor_vehicles "(" }}<ix:nonFraction contextRef="Vehicles_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.motor_vehicles}}</ix:nonFraction>{{emitIfNegative $cost.at_period_end.motor_vehicles ")" }}
+                          <ix:nonFraction contextRef="Vehicles_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.motor_vehicles}}</ix:nonFraction>
                       </td>
                       <td id="tangible-cost-at-period-end-total" class="strong grandtotal">
-                          {{emitIfNegative $cost.at_period_end.total "(" }}<ix:nonFraction contextRef="CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.total}}</ix:nonFraction>{{emitIfNegative $cost.at_period_end.total ")" }}
+                          <ix:nonFraction contextRef="CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipmentGrossCost" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.at_period_end.total}}</ix:nonFraction>
                       </td>
                   </tr>
 
@@ -2823,22 +2823,22 @@ ul.accounts-comps-ct {
                   <tr class="figures">
                       <td id="tangible-depreciation-at-period-start">At {{$period.current_period_start_on_formatted}}</td>
                       <td id="tangible-depreciation-at-period-start-land-and-building" class="strong figure">
-                          {{emitIfNegative $depreciation.at_period_start.land_and_buildings "(" }}<ix:nonFraction contextRef="LandAndBuildings_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.land_and_buildings}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_start.land_and_buildings ")" }}
+                          <ix:nonFraction contextRef="LandAndBuildings_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.land_and_buildings}}</ix:nonFraction>
                       </td>
                       <td id="tangible-depreciation-at-period-start-plant-and-machinery" class="strong figure">
-                          {{emitIfNegative $depreciation.at_period_start.plant_and_machinery "(" }}<ix:nonFraction contextRef="PlantMachinery_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.plant_and_machinery}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_start.plant_and_machinery ")" }}
+                          <ix:nonFraction contextRef="PlantMachinery_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.plant_and_machinery}}</ix:nonFraction>
                       </td>
                       <td id="tangible-depreciation-at-period-start-fixtures-and-fitting" class="strong figure">
-                          {{emitIfNegative $depreciation.at_period_start.fixtures_and_fittings "(" }}<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.fixtures_and_fittings}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_start.fixtures_and_fittings ")" }}
+                          <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.fixtures_and_fittings}}</ix:nonFraction>
                       </td>
                       <td id="tangible-depreciation-at-period-start-office-equipment" class="strong figure">
-                          {{emitIfNegative $depreciation.at_period_start.office_equipment "(" }}<ix:nonFraction contextRef="OfficeEquipment_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.office_equipment}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_start.office_equipment ")" }}
+                          <ix:nonFraction contextRef="OfficeEquipment_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.office_equipment}}</ix:nonFraction>
                       </td>
                       <td id="tangible-depreciation-at-period-start-motor-vehicles" class="strong figure">
-                          {{emitIfNegative $depreciation.at_period_start.motor_vehicles "(" }}<ix:nonFraction contextRef="Vehicles_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.motor_vehicles}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_start.motor_vehicles ")" }}
+                          <ix:nonFraction contextRef="Vehicles_PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.motor_vehicles}}</ix:nonFraction>
                       </td>
                       <td id="tangible-depreciation-at-period-start-total" class="strong figure">
-                          {{emitIfNegative $depreciation.at_period_start.total "(" }}<ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.total}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_start.total ")" }}
+                          <ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_start.total}}</ix:nonFraction>
                       </td>
                   </tr>
 
@@ -2935,22 +2935,22 @@ ul.accounts-comps-ct {
                   <tr class="figures">
                       <td id="tangible-depreciation-at-period-end">At {{$period.current_period_end_on_formatted}}</td>
                       <td id="tangible-depreciation-at-period-end-land-and-building" class="strong grandtotal">
-                          {{emitIfNegative $depreciation.at_period_end.land_and_buildings "(" }}<ix:nonFraction contextRef="LandAndBuildings_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.land_and_buildings}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_end.land_and_buildings ")" }}
+                          <ix:nonFraction contextRef="LandAndBuildings_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.land_and_buildings}}</ix:nonFraction>
                       </td>
                       <td id="tangible-depreciation-at-period-end-plant-and-machinery" class="strong grandtotal">
-                          {{emitIfNegative $depreciation.at_period_end.plant_and_machinery "(" }}<ix:nonFraction contextRef="PlantMachinery_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.plant_and_machinery}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_end.plant_and_machinery ")" }}
+                          <ix:nonFraction contextRef="PlantMachinery_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.plant_and_machinery}}</ix:nonFraction>
                       </td>
                       <td id="tangible-depreciation-at-period-end-fixtures-and-fitting" class="strong grandtotal">
-                          {{emitIfNegative $depreciation.at_period_end.fixtures_and_fittings "(" }}<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.fixtures_and_fittings}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_end.fixtures_and_fittings ")" }}
+                          <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.fixtures_and_fittings}}</ix:nonFraction>
                       </td>
                       <td id="tangible-depreciation-at-period-end-office-equipment" class="strong grandtotal">
-                          {{emitIfNegative $depreciation.at_period_end.office_equipment "(" }}<ix:nonFraction contextRef="OfficeEquipment_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.office_equipment}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_end.office_equipment ")" }}
+                          <ix:nonFraction contextRef="OfficeEquipment_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.office_equipment}}</ix:nonFraction>
                       </td>
                       <td id="tangible-depreciation-at-period-end-motor-vehicles" class="strong grandtotal">
-                          {{emitIfNegative $depreciation.at_period_end.motor_vehicles "(" }}<ix:nonFraction contextRef="Vehicles_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.motor_vehicles}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_end.motor_vehicles ")" }}
+                          <ix:nonFraction contextRef="Vehicles_CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.motor_vehicles}}</ix:nonFraction>
                       </td>
                       <td id="tangible-depreciation-at-period-end-total" class="strong grandtotal">
-                          {{emitIfNegative $depreciation.at_period_end.total "(" }}<ix:nonFraction contextRef="CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.total}}</ix:nonFraction>{{emitIfNegative $depreciation.at_period_end.total ")" }}
+                          <ix:nonFraction contextRef="CY_END" decimals="0" unitRef="GBP" name="core:AccumulatedDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.at_period_end.total}}</ix:nonFraction>
                       </td>
                   </tr>
 
@@ -2966,45 +2966,45 @@ ul.accounts-comps-ct {
 
                   <tr class="figures">
                       <td id ="tangible-net-book-value-at-period-start">At {{$period.current_period_end_on_formatted}}</td>
-                      <td id="tangiblenet-book-value-at-period-start-land-and-building" class="strong grandtotal">
-                          {{emitIfNegative $netBookValue.current_period.land_and_buildings "(" }}<ix:nonFraction contextRef="LandAndBuildings_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.land_and_buildings}}</ix:nonFraction>{{emitIfNegative $netBookValue.current_period.land_and_buildings ")" }}
+                      <td id="tangible-net-book-value-at-period-start-land-and-building" class="strong grandtotal">
+                          <ix:nonFraction contextRef="LandAndBuildings_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.land_and_buildings}}</ix:nonFraction>
                       </td>
                       <td id="tangible-net-book-value-at-period-start-land-and-building" class="strong grandtotal">
-                          {{emitIfNegative $netBookValue.current_period.plant_and_machinery "(" }}<ix:nonFraction contextRef="PlantMachinery_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.plant_and_machinery}}</ix:nonFraction>{{emitIfNegative $netBookValue.current_period.plant_and_machinery ")" }}
+                          <ix:nonFraction contextRef="PlantMachinery_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.plant_and_machinery}}</ix:nonFraction>
                       </td>
                       <td id="tangible-net-book-value-at-period-start-fixtures-and-fitting" class="strong grandtotal">
-                          {{emitIfNegative $netBookValue.current_period.fixtures_and_fittings "(" }}<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.fixtures_and_fittings}}</ix:nonFraction>{{emitIfNegative $netBookValue.current_period.fixtures_and_fittings ")" }}
+                          <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.fixtures_and_fittings}}</ix:nonFraction>
                       </td>
                       <td id="tangible-net-book-value-at-period-start-office-equipment" class="strong grandtotal">
-                          {{emitIfNegative $netBookValue.current_period.office_equipment "(" }}<ix:nonFraction contextRef="OfficeEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.office_equipment}}</ix:nonFraction>{{emitIfNegative $netBookValue.current_period.office_equipment ")" }}
+                          <ix:nonFraction contextRef="OfficeEquipment_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.office_equipment}}</ix:nonFraction>
                       </td>
                       <td id="tangible-net-book-value-at-period-start-office-equipment" class="strong grandtotal">
-                          {{emitIfNegative $netBookValue.current_period.motor_vehicles "(" }}<ix:nonFraction contextRef="Vehicles_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.motor_vehicles}}</ix:nonFraction>{{emitIfNegative $netBookValue.current_period.motor_vehicles ")" }}
+                          <ix:nonFraction contextRef="Vehicles_CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.motor_vehicles}}</ix:nonFraction>
                       </td>
                       <td id="tangible-net-book-value-at-period-start-total" class="strong grandtotal">
-                          {{emitIfNegative $netBookValue.current_period.total "(" }}<ix:nonFraction contextRef="CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.total}}</ix:nonFraction>{{emitIfNegative $netBookValue.current_period.total ")" }}
+                          <ix:nonFraction contextRef="CY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.current_period.total}}</ix:nonFraction>
                       </td>
                   </tr>
 
                   <tr class="figures">
                       <td id="tangible-net-book-value-at-period-end">At {{$period.previous_period_end_on_formatted}}</td>
                       <td id="tangible-net-book-value-at-period-start-land-and-building" class="strong grandtotal">
-                          {{emitIfNegative $netBookValue.previous_period.land_and_buildings "(" }}<ix:nonFraction contextRef="LandAndBuildings_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.land_and_buildings}}</ix:nonFraction>{{emitIfNegative $netBookValue.previous_period.land_and_buildings ")" }}
+                          <ix:nonFraction contextRef="LandAndBuildings_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.land_and_buildings}}</ix:nonFraction>
                       </td>
                       <td id="tangible-net-book-value-at-period-start-plant-and-machinery" class="strong grandtotal">
-                          {{emitIfNegative $netBookValue.previous_period.plant_and_machinery "(" }}<ix:nonFraction contextRef="PlantMachinery_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.plant_and_machinery}}</ix:nonFraction>{{emitIfNegative $netBookValue.previous_period.plant_and_machinery ")" }}
+                          <ix:nonFraction contextRef="PlantMachinery_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.plant_and_machinery}}</ix:nonFraction>
                       </td>
                       <td id="tangible-net-book-value-at-period-start-fixtures-and-fitting" class="strong grandtotal">
-                          {{emitIfNegative $netBookValue.previous_period.fixtures_and_fittings "(" }}<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.fixtures_and_fittings}}</ix:nonFraction>{{emitIfNegative $netBookValue.previous_period.fixtures_and_fittings ")" }}
+                          <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.fixtures_and_fittings}}</ix:nonFraction>
                       </td>
                       <td id="tangible-net-book-value-at-period-start-office-equipment" class="strong grandtotal">
-                          {{emitIfNegative $netBookValue.previous_period.office_equipment "(" }}<ix:nonFraction contextRef="OfficeEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.office_equipment}}</ix:nonFraction>{{emitIfNegative $netBookValue.previous_period.office_equipment ")" }}
+                          <ix:nonFraction contextRef="OfficeEquipment_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.office_equipment}}</ix:nonFraction>
                       </td>
                       <td id="tangible-net-book-value-at-period-start-motor-vehicles" class="strong grandtotal">
-                          {{emitIfNegative $netBookValue.previous_period.motor_vehicles "(" }}<ix:nonFraction contextRef="Vehicles_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.motor_vehicles}}</ix:nonFraction>{{emitIfNegative $netBookValue.previous_period.motor_vehicles ")" }}
+                          <ix:nonFraction contextRef="Vehicles_PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.motor_vehicles}}</ix:nonFraction>
                       </td>
                       <td id="tangible-net-book-value-at-period-end-total" class="strong grandtotal">
-                          {{emitIfNegative $netBookValue.previous_period.total "(" }}<ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.total}}</ix:nonFraction>{{emitIfNegative $netBookValue.previous_period.total ")" }}
+                          <ix:nonFraction contextRef="PY_END" decimals="0" unitRef="GBP" name="core:PropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $netBookValue.previous_period.total}}</ix:nonFraction>
                       </td>
                   </tr>
                   </tbody>


### PR DESCRIPTION
Code changes were needed to meet the following criteria: 

-  **Negative values (minues figure)**
The following fields can NOT be a minus figure:
    `at_period_start`/`at_period_end` rows for **_Cost/Depreciation_**
    `current_period`/`previous_period rows for **_Net Book Value_**

- **Adding id's missing**
ID's need to be added to the iXBRL for sub-categories

- **Hiding Previous year information when it is a 1st year filer**

Resolves: 
SFA-356