### PR TITLE
Ensure correct errors being returned for first year filer

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -29,10 +29,20 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
             ".previous_period";
     private static final String CREDITORS_WITHIN_CURRENT_PERIOD_TOTAL_PATH =
             CREDITORS_WITHIN_CURRENT_PERIOD_PATH + ".total";
+    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_ACCRUALS_PATH =
+            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".accruals_and_deferred_income";
+    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_BANK_LOANS_PATH =
+            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".bank_loans_and_overdrafts";
+    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_FINANCE_PATH =
+            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".finance_leases_and_hire_purchase_contracts";
+    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_OTHER_CREDITORS_PATH =
+            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".other_creditors";
+    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_TAXATION_PATH =
+            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".taxation_and_social_security";
+    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_TRADE_CREDITORS_PATH =
+            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".trade_creditors";
     private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH =
             CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".total";
-    private static final String CREDITORS_WITHIN_CURRENT_PERIOD_DETAILS_PATH =
-            CREDITORS_WITHIN_CURRENT_PERIOD_PATH + ".details";
 
     private CompanyService companyService;
     private CurrentPeriodService currentPeriodService;
@@ -84,8 +94,38 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
 
     private void validateInconsistentFiling(@Valid PreviousPeriod creditorsPreviousPeriod,
             Errors errors) {
-        if (creditorsPreviousPeriod.getTotal() != null) {
 
+        if (creditorsPreviousPeriod.getAccrualsAndDeferredIncome() != null) {
+            addInconsistentDataError(errors,
+                    CREDITORS_WITHIN_PREVIOUS_PERIOD_ACCRUALS_PATH);
+        }
+
+        if (creditorsPreviousPeriod.getBankLoansAndOverdrafts() != null) {
+            addInconsistentDataError(errors,
+                    CREDITORS_WITHIN_PREVIOUS_PERIOD_BANK_LOANS_PATH);
+        }
+
+        if (creditorsPreviousPeriod.getFinanceLeasesAndHirePurchaseContracts() != null) {
+            addInconsistentDataError(errors,
+                    CREDITORS_WITHIN_PREVIOUS_PERIOD_FINANCE_PATH);
+        }
+
+        if (creditorsPreviousPeriod.getOtherCreditors() != null) {
+            addInconsistentDataError(errors,
+                    CREDITORS_WITHIN_PREVIOUS_PERIOD_OTHER_CREDITORS_PATH);
+        }
+
+        if (creditorsPreviousPeriod.getTaxationAndSocialSecurity() != null) {
+            addInconsistentDataError(errors,
+                    CREDITORS_WITHIN_PREVIOUS_PERIOD_TAXATION_PATH);
+        }
+
+        if (creditorsPreviousPeriod.getTradeCreditors() != null) {
+            addInconsistentDataError(errors,
+                    CREDITORS_WITHIN_PREVIOUS_PERIOD_TRADE_CREDITORS_PATH);
+        }
+
+        if (creditorsPreviousPeriod.getTotal() != null) {
             addInconsistentDataError(errors,
                     CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH);
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -29,18 +29,6 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
             ".previous_period";
     private static final String CREDITORS_WITHIN_CURRENT_PERIOD_TOTAL_PATH =
             CREDITORS_WITHIN_CURRENT_PERIOD_PATH + ".total";
-    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_ACCRUALS_PATH =
-            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".accruals_and_deferred_income";
-    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_BANK_LOANS_PATH =
-            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".bank_loans_and_overdrafts";
-    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_FINANCE_PATH =
-            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".finance_leases_and_hire_purchase_contracts";
-    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_OTHER_CREDITORS_PATH =
-            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".other_creditors";
-    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_TAXATION_PATH =
-            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".taxation_and_social_security";
-    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_TRADE_CREDITORS_PATH =
-            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".trade_creditors";
     private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH =
             CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".total";
 
@@ -61,10 +49,10 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
             HttpServletRequest request) throws DataException {
 
         Errors errors = new Errors();
-        
-        crossValidate(errors, request, companyAccountsId, creditorsWithinOneYear);
 
         if (creditorsWithinOneYear.getCurrentPeriod() != null) {
+
+            crossValidateCurrentPeriod(errors, request, creditorsWithinOneYear, companyAccountsId);
 
             CurrentPeriod creditorsCurrentPeriod = creditorsWithinOneYear.getCurrentPeriod();
 
@@ -73,62 +61,20 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
 
         if (creditorsWithinOneYear.getPreviousPeriod() != null) {
 
-            PreviousPeriod creditorsPreviousPeriod = creditorsWithinOneYear.getPreviousPeriod();
-
             try {
 
                 if (companyService.isMultipleYearFiler(transaction)) {
-
-                    validatePreviousPeriod(creditorsPreviousPeriod, errors);
-
+                    validatePreviousPeriod(creditorsWithinOneYear.getPreviousPeriod(), errors);
+                    crossValidatePreviousPeriod(errors, request, creditorsWithinOneYear, companyAccountsId);
                 } else {
-
-                    validateInconsistentFiling(creditorsPreviousPeriod, errors);
+                    addInconsistentDataError(errors, CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH);
                 }
+
             } catch (ServiceException e) {
                 throw new DataException(e.getMessage(), e);
             }
         }
         return errors;
-    }
-
-    private void validateInconsistentFiling(@Valid PreviousPeriod creditorsPreviousPeriod,
-            Errors errors) {
-
-        if (creditorsPreviousPeriod.getAccrualsAndDeferredIncome() != null) {
-            addInconsistentDataError(errors,
-                    CREDITORS_WITHIN_PREVIOUS_PERIOD_ACCRUALS_PATH);
-        }
-
-        if (creditorsPreviousPeriod.getBankLoansAndOverdrafts() != null) {
-            addInconsistentDataError(errors,
-                    CREDITORS_WITHIN_PREVIOUS_PERIOD_BANK_LOANS_PATH);
-        }
-
-        if (creditorsPreviousPeriod.getFinanceLeasesAndHirePurchaseContracts() != null) {
-            addInconsistentDataError(errors,
-                    CREDITORS_WITHIN_PREVIOUS_PERIOD_FINANCE_PATH);
-        }
-
-        if (creditorsPreviousPeriod.getOtherCreditors() != null) {
-            addInconsistentDataError(errors,
-                    CREDITORS_WITHIN_PREVIOUS_PERIOD_OTHER_CREDITORS_PATH);
-        }
-
-        if (creditorsPreviousPeriod.getTaxationAndSocialSecurity() != null) {
-            addInconsistentDataError(errors,
-                    CREDITORS_WITHIN_PREVIOUS_PERIOD_TAXATION_PATH);
-        }
-
-        if (creditorsPreviousPeriod.getTradeCreditors() != null) {
-            addInconsistentDataError(errors,
-                    CREDITORS_WITHIN_PREVIOUS_PERIOD_TRADE_CREDITORS_PATH);
-        }
-
-        if (creditorsPreviousPeriod.getTotal() != null) {
-            addInconsistentDataError(errors,
-                    CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH);
-        }
     }
 
     private void validatePreviousPeriod(@Valid PreviousPeriod creditorsPreviousPeriod,

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidatorTests.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidatorTests.java
@@ -43,18 +43,6 @@ public class CreditorsWithinOneYearValidatorTests {
             ".previous_period";
     private static final String CREDITORS_WITHIN_CURRENT_PERIOD_TOTAL_PATH =
             CREDITORS_WITHIN_CURRENT_PERIOD_PATH + ".total";
-    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_ACCRUALS_PATH =
-            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".accruals_and_deferred_income";
-    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_BANK_LOANS_PATH =
-            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".bank_loans_and_overdrafts";
-    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_FINANCE_PATH =
-            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".finance_leases_and_hire_purchase_contracts";
-    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_OTHER_CREDITORS_PATH =
-            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".other_creditors";
-    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_TAXATION_PATH =
-            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".taxation_and_social_security";
-    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_TRADE_CREDITORS_PATH =
-            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".trade_creditors";
     private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH =
             CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".total";
     
@@ -262,41 +250,24 @@ public class CreditorsWithinOneYearValidatorTests {
         createPreviousPeriodCreditors();
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
-  
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
-            COMPANY_ACCOUNTS_ID, mockRequest);
-        
+                COMPANY_ACCOUNTS_ID, mockRequest);
+
         when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(false);
 
         ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         errors = validator.validateCreditorsWithinOneYear(creditorsWithinOneYear, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.hasErrors());
-        assertEquals(7, errors.getErrorCount());
+        assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
-                CREDITORS_WITHIN_PREVIOUS_PERIOD_ACCRUALS_PATH)));
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
-                CREDITORS_WITHIN_PREVIOUS_PERIOD_BANK_LOANS_PATH)));
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
-                CREDITORS_WITHIN_PREVIOUS_PERIOD_FINANCE_PATH)));
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
-                CREDITORS_WITHIN_PREVIOUS_PERIOD_OTHER_CREDITORS_PATH)));
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
-                CREDITORS_WITHIN_PREVIOUS_PERIOD_TAXATION_PATH)));
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
-                CREDITORS_WITHIN_PREVIOUS_PERIOD_TRADE_CREDITORS_PATH)));
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
-                CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH)));
+                CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH)));
     }
 
     @Test
@@ -306,6 +277,9 @@ public class CreditorsWithinOneYearValidatorTests {
 
         CurrentPeriod currentPeriod = new CurrentPeriod();
         creditorsWithinOneYear.setCurrentPeriod(currentPeriod);
+
+        PreviousPeriod previousPeriod = new PreviousPeriod();
+        creditorsWithinOneYear.setPreviousPeriod(previousPeriod);
         
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
             COMPANY_ACCOUNTS_ID);
@@ -322,6 +296,8 @@ public class CreditorsWithinOneYearValidatorTests {
             CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
             PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
+
+        when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(true);
 
         errors = validator.validateCreditorsWithinOneYear(creditorsWithinOneYear, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
@@ -390,6 +366,8 @@ public class CreditorsWithinOneYearValidatorTests {
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
             COMPANY_ACCOUNTS_ID);
         when(mockPreviousPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new MongoException(""));
+
+        when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(true);
 
         assertThrows(DataException.class,
                 () -> validator.validateCreditorsWithinOneYear(creditorsWithinOneYear,

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidatorTests.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidatorTests.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,10 +43,20 @@ public class CreditorsWithinOneYearValidatorTests {
             ".previous_period";
     private static final String CREDITORS_WITHIN_CURRENT_PERIOD_TOTAL_PATH =
             CREDITORS_WITHIN_CURRENT_PERIOD_PATH + ".total";
+    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_ACCRUALS_PATH =
+            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".accruals_and_deferred_income";
+    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_BANK_LOANS_PATH =
+            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".bank_loans_and_overdrafts";
+    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_FINANCE_PATH =
+            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".finance_leases_and_hire_purchase_contracts";
+    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_OTHER_CREDITORS_PATH =
+            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".other_creditors";
+    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_TAXATION_PATH =
+            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".taxation_and_social_security";
+    private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_TRADE_CREDITORS_PATH =
+            CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".trade_creditors";
     private static final String CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH =
             CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH + ".total";
-    private static final String CREDITORS_WITHIN_CURRENT_PERIOD_DETAILS_PATH =
-            CREDITORS_WITHIN_CURRENT_PERIOD_PATH + ".details";
     
     private static final String CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME = "currentBalanceSheetNotEqual";
     private static final String CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE =
@@ -271,6 +282,19 @@ public class CreditorsWithinOneYearValidatorTests {
         errors = validator.validateCreditorsWithinOneYear(creditorsWithinOneYear, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.hasErrors());
+        assertEquals(7, errors.getErrorCount());
+        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
+                CREDITORS_WITHIN_PREVIOUS_PERIOD_ACCRUALS_PATH)));
+        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
+                CREDITORS_WITHIN_PREVIOUS_PERIOD_BANK_LOANS_PATH)));
+        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
+                CREDITORS_WITHIN_PREVIOUS_PERIOD_FINANCE_PATH)));
+        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
+                CREDITORS_WITHIN_PREVIOUS_PERIOD_OTHER_CREDITORS_PATH)));
+        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
+                CREDITORS_WITHIN_PREVIOUS_PERIOD_TAXATION_PATH)));
+        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
+                CREDITORS_WITHIN_PREVIOUS_PERIOD_TRADE_CREDITORS_PATH)));
         assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
                 CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH)));
     }


### PR DESCRIPTION
These changes ensure that only a single `inconsistent_data` error is returned for the `previous_period` field when it has been supplied in a request for a first year filer.

**Resolves:** SFA-1105