### PR TITLE
Ensure correct errors being returned for first year filer (stocks)

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/StocksValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/StocksValidator.java
@@ -27,8 +27,6 @@ public class StocksValidator extends BaseValidator implements CrossValidator<Sto
     private static final String PREVIOUS_PERIOD_PATH = STOCKS_PATH + ".previous_period";
     private static final String CURRENT_PERIOD_TOTAL_PATH = CURRENT_PERIOD_PATH + ".total";
     private static final String PREVIOUS_PERIOD_TOTAL_PATH = PREVIOUS_PERIOD_PATH + ".total";
-    private static final String PREVIOUS_PERIOD_PAYMENTS_ON_ACCOUNT_PATH = PREVIOUS_PERIOD_PATH + ".payments_on_account";
-    private static final String PREVIOUS_PERIOD_STOCKS_PATH = PREVIOUS_PERIOD_PATH + ".stocks";
 
     private CompanyService companyService;
     private CurrentPeriodService currentPeriodService;
@@ -60,7 +58,7 @@ public class StocksValidator extends BaseValidator implements CrossValidator<Sto
                     validatePreviousPeriod(stocks, errors);
                     crossValidatePreviousPeriod(errors, request, stocks, companyAccountsId);
                 } else {
-                    validateInconsistentFiling(stocks, errors);
+                    addInconsistentDataError(errors, PREVIOUS_PERIOD_PATH);
                 }
 
             } catch (ServiceException e) {
@@ -78,21 +76,6 @@ public class StocksValidator extends BaseValidator implements CrossValidator<Sto
     private void validatePreviousPeriod(Stocks stocks, Errors errors) {
         validatePreviousPeriodTotalPresent(stocks, errors);
         validatePreviousPeriodTotalCorrect(stocks, errors);
-    }
-
-    private void validateInconsistentFiling(Stocks stocks, Errors errors) {
-
-        if (stocks.getPreviousPeriod().getPaymentsOnAccount() != null) {
-            addInconsistentDataError(errors, PREVIOUS_PERIOD_PAYMENTS_ON_ACCOUNT_PATH);
-        }
-
-        if (stocks.getPreviousPeriod().getStocks() != null) {
-            addInconsistentDataError(errors, PREVIOUS_PERIOD_STOCKS_PATH);
-        }
-
-        if (stocks.getPreviousPeriod().getTotal() != null) {
-            addInconsistentDataError(errors, PREVIOUS_PERIOD_TOTAL_PATH);
-        }
     }
 
     private void validateCurrentPeriodTotalPresent(Stocks stocks, Errors errors) {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/StocksValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/StocksValidatorTest.java
@@ -68,8 +68,6 @@ public class StocksValidatorTest {
     private static final String PREVIOUS_PERIOD_PATH = STOCKS_PATH + ".previous_period";
     private static final String CURRENT_PERIOD_TOTAL_PATH = CURRENT_PERIOD_PATH + ".total";
     private static final String PREVIOUS_PERIOD_TOTAL_PATH = PREVIOUS_PERIOD_PATH + ".total";
-    private static final String PREVIOUS_PERIOD_PAYMENTS_ON_ACCOUNT_PATH = PREVIOUS_PERIOD_PATH + ".payments_on_account";
-    private static final String PREVIOUS_PERIOD_STOCKS_PATH = PREVIOUS_PERIOD_PATH + ".stocks";
 
     private Stocks stocks;
     private Errors errors;
@@ -302,13 +300,9 @@ public class StocksValidatorTest {
         errors = validator.validateStocks(stocks, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.hasErrors());
-        assertEquals(3, errors.getErrorCount());
+        assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
-                PREVIOUS_PERIOD_PAYMENTS_ON_ACCOUNT_PATH)));
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
-                PREVIOUS_PERIOD_STOCKS_PATH)));
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE,
-                PREVIOUS_PERIOD_TOTAL_PATH)));
+                PREVIOUS_PERIOD_PATH)));
     }
 
     @Test


### PR DESCRIPTION
These changes ensure that only a single `inconsistent_data` error is returned for the `previous_period` field when it has been supplied in a request for a first year filer.