### PR TITLE
Ensure correct errors being returned for first year filer (debtors)

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -25,12 +25,6 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     private static final String DEBTORS_PATH_PREVIOUS = DEBTORS_PATH + ".previous_period";
     private static final String CURRENT_TOTAL_PATH = DEBTORS_PATH + ".current_period.total";
     private static final String PREVIOUS_TOTAL_PATH = DEBTORS_PATH_PREVIOUS + ".total";
-    private static final String PREVIOUS_TRADE_DEBTORS = DEBTORS_PATH_PREVIOUS + ".trade_debtors";
-    private static final String PREVIOUS_PREPAYMENTS =
-            DEBTORS_PATH_PREVIOUS + ".prepayments_and_accrued_income";
-    private static final String PREVIOUS_OTHER_DEBTORS = DEBTORS_PATH_PREVIOUS + ".other_debtors";
-    private static final String PREVIOUS_GREATER_THAN_ONE_YEAR =
-            DEBTORS_PATH_PREVIOUS + ".greater_than_one_year";
 
     private CompanyService companyService;
     private CurrentPeriodService currentPeriodService;
@@ -51,14 +45,12 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
 
         Errors errors = new Errors();
 
-        crossValidate(errors, request, companyAccountsId, debtors);
-
         if (debtors != null) {
 
             if (debtors.getCurrentPeriod() != null) {
 
                 validateCurrentPeriodDebtors(errors, debtors);
-
+                crossValidateCurrentPeriod(errors, request, debtors, companyAccountsId);
             }
 
             if (debtors.getPreviousPeriod() != null) {
@@ -67,10 +59,10 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
                     if (companyService.isMultipleYearFiler(transaction)) {
 
                         validatePreviousPeriodDebtors(errors, debtors);
-
+                        crossValidatePreviousPeriod(errors, request, companyAccountsId, debtors);
                     } else {
 
-                        validateInconsistentPeriodFiling(debtors, errors);
+                        addInconsistentDataError(errors, DEBTORS_PATH_PREVIOUS);
                     }
                 } catch (ServiceException e) {
                     throw new DataException(e.getMessage(), e);
@@ -150,30 +142,6 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
             Long sum = traderDebtors + prepayments + otherDebtors;
 
             validateAggregateTotal(total, sum, PREVIOUS_TOTAL_PATH, errors);
-        }
-    }
-
-
-    private void validateInconsistentPeriodFiling(Debtors debtors, Errors errors) {
-
-        if (debtors.getPreviousPeriod().getTradeDebtors() != null) {
-            addInconsistentDataError(errors, PREVIOUS_TRADE_DEBTORS);
-        }
-
-        if (debtors.getPreviousPeriod().getGreaterThanOneYear() != null) {
-            addInconsistentDataError(errors, PREVIOUS_GREATER_THAN_ONE_YEAR);
-        }
-
-        if (debtors.getPreviousPeriod().getPrepaymentsAndAccruedIncome() != null) {
-            addInconsistentDataError(errors, PREVIOUS_PREPAYMENTS);
-        }
-
-        if (debtors.getPreviousPeriod().getOtherDebtors() != null) {
-            addInconsistentDataError(errors, PREVIOUS_OTHER_DEBTORS);
-        }
-
-        if (debtors.getPreviousPeriod().getTotal() != null) {
-            addInconsistentDataError(errors, PREVIOUS_TOTAL_PATH);
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -1,6 +1,7 @@
 
 package uk.gov.companieshouse.api.accounts.validation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,10 +42,6 @@ public class DebtorsValidatorTest {
     private static final String DEBTORS_PATH_PREVIOUS = DEBTORS_PATH + ".previous_period";
     private static final String CURRENT_TOTAL_PATH = DEBTORS_PATH + ".current_period.total";
     private static final String PREVIOUS_TOTAL_PATH = DEBTORS_PATH_PREVIOUS + ".total";
-    private static final String PREVIOUS_TRADE_DEBTORS = DEBTORS_PATH_PREVIOUS + ".trade_debtors";
-    private static final String PREVIOUS_PREPAYMENTS = DEBTORS_PATH_PREVIOUS + ".prepayments_and_accrued_income";
-    private static final String PREVIOUS_OTHER_DEBTORS = DEBTORS_PATH_PREVIOUS + ".other_debtors";
-    private static final String PREVIOUS_GREATER_THAN_ONE_YEAR = DEBTORS_PATH_PREVIOUS + ".greater_than_one_year";
     private static final String INVALID_NOTE_VALUE = "invalid_note";
     private static final String INVALID_NOTE_NAME = "invalidNote";
     private static final String INCORRECT_TOTAL_NAME = "incorrectTotal";
@@ -110,12 +107,6 @@ public class DebtorsValidatorTest {
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
                 COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(
-                COMPANY_ACCOUNTS_ID,
-                mockRequest);
-
         errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertFalse(errors.hasErrors());
@@ -163,12 +154,6 @@ public class DebtorsValidatorTest {
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
                 COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
-                COMPANY_ACCOUNTS_ID,
-                mockRequest);
-
         when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(false);
 
         ReflectionTestUtils.setField(validator, INCONSISTENT_DATA_NAME, INCONSISTENT_DATA_VALUE);
@@ -180,11 +165,8 @@ public class DebtorsValidatorTest {
         errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.hasErrors());
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TRADE_DEBTORS)));
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_PREPAYMENTS)));
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_GREATER_THAN_ONE_YEAR)));
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_OTHER_DEBTORS)));
-        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, PREVIOUS_TOTAL_PATH)));
+        assertEquals(1, errors.getErrorCount());
+        assertTrue(errors.containsError(createError(INCONSISTENT_DATA_VALUE, DEBTORS_PATH_PREVIOUS)));
     }
 
     @Test
@@ -276,12 +258,6 @@ public class DebtorsValidatorTest {
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
                 COMPANY_ACCOUNTS_ID, mockRequest);
 
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(
-                COMPANY_ACCOUNTS_ID,
-                mockRequest);
-
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
                 CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
         errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
@@ -300,12 +276,6 @@ public class DebtorsValidatorTest {
                 COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
                 COMPANY_ACCOUNTS_ID, mockRequest);
-
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateNPreviousNullDebtorsBalanceSheetResponse()).when(mockPreviousPeriodService).findById(
-                COMPANY_ACCOUNTS_ID,
-                mockRequest);
 
         debtors.setCurrentPeriod(currentDebtors);
         ReflectionTestUtils.setField(validator, INVALID_NOTE_NAME, INVALID_NOTE_VALUE);
@@ -330,12 +300,6 @@ public class DebtorsValidatorTest {
                 COMPANY_ACCOUNTS_ID);
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).findById(
                 COMPANY_ACCOUNTS_ID, mockRequest);
-
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
-                COMPANY_ACCOUNTS_ID,
-                mockRequest);
 
         when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenThrow(mockServiceException);
 
@@ -464,8 +428,11 @@ public class DebtorsValidatorTest {
     }
 
     @Test
-    @DisplayName("Assert empty note and populated balance sheet value throws error")
-    void testEmptyNoteMismatchedDebtorsValues() throws DataException, ServiceException {
+    @DisplayName("Assert empty note values and populated balance sheet values returns errors")
+    void testEmptyNoteValuesMismatchBalanceSheetValues() throws DataException, ServiceException {
+
+        debtors.setCurrentPeriod(new CurrentPeriod());
+        debtors.setPreviousPeriod(new PreviousPeriod());
 
         when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
                 COMPANY_ACCOUNTS_ID);
@@ -477,6 +444,8 @@ public class DebtorsValidatorTest {
         doReturn(generateValidPreviousPeriodResponseObject()).when(mockPreviousPeriodService).findById(
                 COMPANY_ACCOUNTS_ID,
                 mockRequest);
+
+        when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(true);
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
                 CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);


### PR DESCRIPTION
These changes ensure that only a single `inconsistent_data` error is returned for the `previous_period` field when it has been supplied in a request for a first year filer.