### PR TITLE
Update IXBRL to correct profit and loss label

### DIFF
--- a/src/main/resources/filing/templates/small-full-accounts.html
+++ b/src/main/resources/filing/templates/small-full-accounts.html
@@ -2407,7 +2407,7 @@ ul.accounts-comps-ct {
                   {{if $profitAndLoss := $capitalAndReserves.profit_and_loss}}
 
                       <tr class="figures">
-                        <td id="profit-and-loss-label">Profit and loss:</td>
+                        <td id="profit-and-loss-label">Profit and loss account:</td>
 
                         <td class="figure noteIndex" id="uk-busEquityRetainedEarningsAccumulatedLosses_CY_ENDNoteIndexes"></td>
 


### PR DESCRIPTION
Profit and loss was missing account from the label. 

Resolves SFA-1250