### PR TITLE
Remove duplicated exception logging from services

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/exception/DataException.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/exception/DataException.java
@@ -9,4 +9,6 @@ public class DataException extends Exception {
     public DataException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public DataException(Throwable cause) { super(cause); }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/ResourceService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/ResourceService.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.api.accounts.service;
 
-import java.util.HashMap;
-import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.model.rest.RestObject;
@@ -25,16 +23,5 @@ public interface ResourceService<T extends RestObject> {
         throws DataException;
 
     String generateID(String companyAccountId);
-
-    default Map<String, Object> getDebugMap(Transaction transaction, String companyAccountsId, String id) {
-
-        Map<String, Object> debugMap = new HashMap<>();
-
-        debugMap.put("transaction_id", transaction.getId());
-        debugMap.put("company_accounts_id", companyAccountsId);
-        debugMap.put("id", id);
-
-        return debugMap;
-    }
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/AccountingPoliciesService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/AccountingPoliciesService.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
-import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.Kind;
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/AccountingPoliciesService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/AccountingPoliciesService.java
@@ -20,8 +20,6 @@ import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.AccountingPoliciesTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
@@ -29,9 +27,6 @@ import java.util.Map;
 
 @Service
 public class AccountingPoliciesService implements ResourceService<AccountingPolicies> {
-
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
 
     private AccountingPoliciesRepository repository;
 
@@ -68,15 +63,10 @@ public class AccountingPoliciesService implements ResourceService<AccountingPoli
             repository.insert(entity);
         } catch (DuplicateKeyException e) {
 
-            LOGGER.errorRequest(request, e, getDebugMap(transaction, companyAccountsId, entity.getId()));
-
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
         } catch (MongoException e) {
 
-            DataException dataException = new DataException("Failed to insert " + ResourceName.ACCOUNTING_POLICIES.getName(), e);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction, companyAccountsId, entity.getId()));
-
-            throw dataException;
+            throw new DataException(e);
         }
 
         smallFullService
@@ -101,10 +91,7 @@ public class AccountingPoliciesService implements ResourceService<AccountingPoli
             repository.save(entity);
         } catch (MongoException e) {
 
-            DataException dataException = new DataException("Failed to update " + ResourceName.ACCOUNTING_POLICIES.getName(), e);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction, companyAccountsId, entity.getId()));
-
-            throw dataException;
+            throw new DataException(e);
         }
 
         return new ResponseObject<>(ResponseStatus.UPDATED, rest);
@@ -120,13 +107,7 @@ public class AccountingPoliciesService implements ResourceService<AccountingPoli
             entity = repository.findById(id).orElse(null);
         } catch (MongoException e) {
 
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", id);
-
-            DataException dataException = new DataException("Failed to find AccountingPolicies", e);
-            LOGGER.errorRequest(request, dataException, debugMap);
-
-            throw dataException;
+            throw new DataException(e);
         }
 
         if (entity == null) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/ApprovalService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/ApprovalService.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
-import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.Kind;
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
@@ -25,14 +24,9 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.ApprovalTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
 import uk.gov.companieshouse.api.accounts.validation.ApprovalValidator;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Service
 public class ApprovalService implements ResourceService<Approval> {
-
-    private static final Logger LOGGER = LoggerFactory
-        .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
 
     private ApprovalRepository approvalRepository;
 
@@ -62,18 +56,11 @@ public class ApprovalService implements ResourceService<Approval> {
     public ResponseObject<Approval> create(Approval rest, Transaction transaction,
         String companyAccountId, HttpServletRequest request) throws DataException {
 
-        final Map<String, Object> debugMap = new HashMap<>();
-        debugMap.put("transaction_id", transaction.getId());
-        debugMap.put("company_accounts_id", companyAccountId);
         Errors errors = approvalValidator.validateApproval(rest, request);
 
         if (errors.hasErrors()) {
-            DataException dataException = new DataException(
-                "Failed to validate " + ResourceName.APPROVAL.getName());
-            LOGGER.errorRequest(request, dataException, debugMap);
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);
         }
-
 
         String selfLink = createSelfLink(transaction, companyAccountId);
         initLinks(rest, selfLink);
@@ -83,18 +70,16 @@ public class ApprovalService implements ResourceService<Approval> {
 
         String id = generateID(companyAccountId);
         approvalEntity.setId(id);
-        debugMap.put("id", id);
 
         try {
+
             approvalRepository.insert(approvalEntity);
         } catch (DuplicateKeyException dke) {
-            LOGGER.errorRequest(request, dke, debugMap);
+
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
-        } catch (MongoException me) {
-            DataException dataException = new DataException(
-                "Failed to insert " + ResourceName.SMALL_FULL.getName(), me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-            throw dataException;
+        } catch (MongoException e) {
+
+            throw new DataException(e);
         }
 
         smallFullService
@@ -112,20 +97,21 @@ public class ApprovalService implements ResourceService<Approval> {
 
     @Override
     public ResponseObject<Approval> findById(String id, HttpServletRequest request) throws DataException {
+
         ApprovalEntity approvalEntity;
+
         try {
+
             approvalEntity = approvalRepository.findById(id).orElse(null);
-        } catch (MongoException me) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", id);
-            DataException dataException = new DataException("Failed to find Approval", me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-            throw dataException;
+        } catch (MongoException e) {
+
+            throw new DataException(e);
         }
 
         if (approvalEntity == null) {
             return new ResponseObject<>(ResponseStatus.NOT_FOUND);
         }
+
         Approval approval = approvalTransformer.transform(approvalEntity);
         return new ResponseObject<>(ResponseStatus.FOUND, approval);
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
@@ -78,9 +78,7 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
 
             internalApiClient.privateTransaction().patch("/private/transactions/" + transaction.getId(), transaction).execute();
         } catch (IOException | URIValidationException e) {
-
-            PatchException patchException = new PatchException("Failed to patch transaction", e);
-            throw patchException;
+            throw new PatchException("Failed to patch transaction", e);
         }
 
         return new ResponseObject<>(ResponseStatus.CREATED, companyAccount);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
@@ -21,19 +21,13 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.CreditorsAfterOneYearTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
 import uk.gov.companieshouse.api.accounts.validation.CreditorsAfterOneYearValidator;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
 
-import static uk.gov.companieshouse.api.accounts.CompanyAccountsApplication.APPLICATION_NAME_SPACE;
-
 @Service
 public class CreditorsAfterOneYearService implements ResourceService<CreditorsAfterOneYear> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
 
     private CreditorsAfterOneYearRepository repository;
     private CreditorsAfterOneYearTransformer transformer;
@@ -74,13 +68,9 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
         try {
             repository.insert(entity);
         } catch (DuplicateKeyException e) {
-            LOGGER.errorRequest(request, e, getDebugMap(transaction, companyAccountId, entity.getId()));
-            return  new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
+            return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
         } catch (MongoException e) {
-            DataException dataException = new DataException("Failed to insert "
-                    + ResourceName.CREDITORS_AFTER_ONE_YEAR.getName(), e);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction, companyAccountId, entity.getId()));
-            throw dataException;
+            throw new DataException(e);
         }
 
         smallFullService.addLink(companyAccountId, SmallFullLinkType.CREDITORS_AFTER_MORE_THAN_ONE_YEAR_NOTE,
@@ -107,13 +97,9 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
 
         try {
             repository.save(entity);
-        } catch (MongoException me) {
-            DataException dataException =
-                    new DataException("Failed to update" + ResourceName.CREDITORS_AFTER_ONE_YEAR.getName(), me);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction,
-                    companyAccountId, entity.getId()));
+        } catch (MongoException e) {
 
-            throw dataException;
+            throw new DataException(e);
         }
 
         return new ResponseObject<>(ResponseStatus.UPDATED, rest);
@@ -126,13 +112,7 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
         try {
             entity = repository.findById(id).orElse(null);
         } catch (MongoException e) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", id);
-            DataException dataException = new DataException("Failed to find creditors after one " +
-                    "year", e);
-            LOGGER.errorRequest(request, dataException, debugMap);
-
-            throw dataException;
+            throw new DataException(e);
         }
 
         if (entity == null) {
@@ -158,13 +138,9 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
             } else {
                 return new ResponseObject<>(ResponseStatus.NOT_FOUND);
             }
-        } catch (MongoException me) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", companyAccountsId);
-            DataException dataException = new DataException("Failed to delete Creditors after one year", me);
-            LOGGER.errorRequest(request, dataException, debugMap);
+        } catch (MongoException e) {
 
-            throw dataException;
+            throw new DataException(e);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.api.accounts.service.impl;
 
-import static uk.gov.companieshouse.api.accounts.CompanyAccountsApplication.APPLICATION_NAME_SPACE;
-
 import com.mongodb.MongoException;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,13 +24,9 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.CreditorsWithinOneYearTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
 import uk.gov.companieshouse.api.accounts.validation.CreditorsWithinOneYearValidator;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Service
 public class CreditorsWithinOneYearService implements ResourceService<CreditorsWithinOneYear> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
 
     private CreditorsWithinOneYearRepository repository;
     private CreditorsWithinOneYearTransformer transformer;
@@ -74,15 +68,9 @@ public class CreditorsWithinOneYearService implements ResourceService<CreditorsW
         try {
             repository.insert(entity);
         } catch (DuplicateKeyException e) {
-            LOGGER.errorRequest(request, e, getDebugMap(transaction, companyAccountId,
-                    entity.getId()));
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
         } catch (MongoException e) {
-            DataException dataException = new DataException("Failed to insert "
-                    + ResourceName.CREDITORS_WITHIN_ONE_YEAR.getName(), e);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction, companyAccountId
-                    , entity.getId()));
-            throw dataException;
+            throw new DataException(e);
         }
 
         smallFullService.addLink(companyAccountId, SmallFullLinkType.CREDITORS_WITHIN_ONE_YEAR_NOTE,
@@ -111,13 +99,8 @@ public class CreditorsWithinOneYearService implements ResourceService<CreditorsW
 
         try {
             repository.save(entity);
-        } catch (MongoException me) {
-            DataException dataException =
-                    new DataException("Failed to update" + ResourceName.CREDITORS_WITHIN_ONE_YEAR.getName(), me);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction,
-                    companyAccountId, entity.getId()));
-
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
 
         return new ResponseObject<>(ResponseStatus.UPDATED, rest);
@@ -132,13 +115,7 @@ public class CreditorsWithinOneYearService implements ResourceService<CreditorsW
         try {
             entity = repository.findById(id).orElse(null);
         } catch (MongoException e) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", id);
-            DataException dataException = new DataException("Failed to find creditors within one " +
-                    "year", e);
-            LOGGER.errorRequest(request, dataException, debugMap);
-
-            throw dataException;
+            throw new DataException(e);
         }
 
         if (entity == null) {
@@ -164,15 +141,8 @@ public class CreditorsWithinOneYearService implements ResourceService<CreditorsW
             } else {
                 return new ResponseObject<>(ResponseStatus.NOT_FOUND);
             }
-        } catch (MongoException me) {
-            final Map<String, Object> debugMap = new HashMap<>();
-
-            debugMap.put("id", creditorsWithinOneYearId);
-            DataException dataException = new DataException("Failed to delete creditors within one year", me);
-
-            LOGGER.errorRequest(request, dataException, debugMap);
-
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodService.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
-import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.Kind;
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
@@ -25,15 +24,10 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.CurrentPeriodTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
 import uk.gov.companieshouse.api.accounts.validation.CurrentPeriodValidator;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Service
 public class CurrentPeriodService implements
     ResourceService<CurrentPeriod> {
-
-    private static final Logger LOGGER = LoggerFactory
-        .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
 
     private CurrentPeriodRepository currentPeriodRepository;
 
@@ -64,35 +58,23 @@ public class CurrentPeriodService implements
         Transaction transaction, String companyAccountId, HttpServletRequest request)
         throws DataException {
 
-        final Map<String, Object> debugMap = new HashMap<>();
-        debugMap.put("transaction_id", transaction.getId());
-        debugMap.put("company_accounts_id", companyAccountId);
         Errors errors = currentPeriodValidator.validateCurrentPeriod(currentPeriod);
 
         if (errors.hasErrors()) {
-            DataException dataException = new DataException(
-                "Failed to validate " + ResourceName.CURRENT_PERIOD.getName());
-            LOGGER.errorRequest(request, dataException, debugMap);
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);
         }
 
         populateMetadata(currentPeriod, transaction, companyAccountId);
         CurrentPeriodEntity currentPeriodEntity = currentPeriodTransformer.transform(currentPeriod);
 
-        String id = generateID(companyAccountId);
-        currentPeriodEntity.setId(id);
-        debugMap.put("id", id);
+        currentPeriodEntity.setId(generateID(companyAccountId));
 
         try {
             currentPeriodRepository.insert(currentPeriodEntity);
         } catch (DuplicateKeyException dke) {
-            LOGGER.errorRequest(request, dke, debugMap);
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
-        } catch (MongoException me) {
-            DataException dataException = new DataException(
-                "Failed to insert " + ResourceName.SMALL_FULL.getName(), me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
 
         smallFullService
@@ -106,32 +88,20 @@ public class CurrentPeriodService implements
     public ResponseObject<CurrentPeriod> update(CurrentPeriod rest, Transaction transaction,
         String companyAccountId, HttpServletRequest request) throws DataException {
 
-        String id = generateID(companyAccountId);
-
-        final Map<String, Object> debugMap = new HashMap<>();
-        debugMap.put("transaction_id", transaction.getId());
-        debugMap.put("company_accounts_id", companyAccountId);
-        debugMap.put("id", id);
         Errors errors = currentPeriodValidator.validateCurrentPeriod(rest);
 
         if (errors.hasErrors()) {
-            DataException dataException = new DataException(
-                "Failed to validate " + ResourceName.CURRENT_PERIOD.getName());
-            LOGGER.errorRequest(request, dataException, debugMap);
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);
         }
 
         populateMetadata(rest, transaction, companyAccountId);
         CurrentPeriodEntity currentPeriodEntity = currentPeriodTransformer.transform(rest);
-        currentPeriodEntity.setId(id);
+        currentPeriodEntity.setId(generateID(companyAccountId));
 
         try {
             currentPeriodRepository.save(currentPeriodEntity);
-        } catch (MongoException me) {
-            DataException dataException = new DataException(
-                "Failed to update " + ResourceName.CURRENT_PERIOD.getName(), me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
 
         return new ResponseObject<>(ResponseStatus.UPDATED, rest);
@@ -144,12 +114,8 @@ public class CurrentPeriodService implements
         CurrentPeriodEntity currentPeriodEntity;
         try {
             currentPeriodEntity = currentPeriodRepository.findById(id).orElse(null);
-        } catch (MongoException me) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", id);
-            DataException dataException = new DataException("Failed to find Current period", me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
 
         if (currentPeriodEntity == null) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.api.accounts.service.impl;
 
-import static uk.gov.companieshouse.api.accounts.CompanyAccountsApplication.APPLICATION_NAME_SPACE;
-
 import com.mongodb.MongoException;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,13 +24,9 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.DebtorsTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
 import uk.gov.companieshouse.api.accounts.validation.DebtorsValidator;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Service
 public class DebtorsService implements ResourceService<Debtors> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
 
     private DebtorsRepository repository;
     private DebtorsTransformer transformer;
@@ -74,18 +68,10 @@ public class DebtorsService implements ResourceService<Debtors> {
             repository.insert(entity);
         } catch (DuplicateKeyException e) {
 
-            LOGGER.errorRequest(request, e, getDebugMap(transaction, companyAccountsId,
-                    entity.getId()));
-
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
         } catch (MongoException e) {
 
-            DataException dataException =
-                    new DataException("Failed to insert " + ResourceName.DEBTORS.getName(), e);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction,
-                    companyAccountsId, entity.getId()));
-
-            throw dataException;
+            throw new DataException(e);
         }
 
         smallFullService.addLink(companyAccountsId, SmallFullLinkType.DEBTORS_NOTE,
@@ -103,7 +89,6 @@ public class DebtorsService implements ResourceService<Debtors> {
                 request);
 
         if (errors.hasErrors()) {
-
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);
         }
 
@@ -112,14 +97,10 @@ public class DebtorsService implements ResourceService<Debtors> {
 
         try {
             repository.save(entity);
-        } catch (MongoException me) {
-            DataException dataException =
-                    new DataException("Failed to update" + ResourceName.DEBTORS.getName(), me);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction,
-                    companyAccountsId, entity.getId()));
-
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
+
         return new ResponseObject<>(ResponseStatus.UPDATED, rest);
     }
 
@@ -130,12 +111,7 @@ public class DebtorsService implements ResourceService<Debtors> {
         try {
             entity = repository.findById(id).orElse(null);
         } catch (MongoException e) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", id);
-            DataException dataException = new DataException("Failed to find " + ResourceName.DEBTORS.getName(), e);
-            LOGGER.errorRequest(request, dataException, debugMap);
-
-            throw dataException;
+            throw new DataException(e);
         }
 
         if (entity == null) {
@@ -159,13 +135,9 @@ public class DebtorsService implements ResourceService<Debtors> {
             } else {
                 return new ResponseObject<>(ResponseStatus.NOT_FOUND);
             }
-        } catch (MongoException me) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", companyAccountsId);
-            DataException dataException = new DataException("Failed to delete " + ResourceName.DEBTORS.getName(), me);
-            LOGGER.errorRequest(request, dataException, debugMap);
+        } catch (MongoException e) {
 
-            throw dataException;
+            throw new DataException(e);
         }
     }
     @Override

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodService.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
-import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.Kind;
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
@@ -25,14 +24,9 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.PreviousPeriodTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
 import uk.gov.companieshouse.api.accounts.validation.PreviousPeriodValidator;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Service
 public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
-
-    private static final Logger LOGGER = LoggerFactory
-        .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
 
     private PreviousPeriodRepository previousPeriodRepository;
 
@@ -63,15 +57,9 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
         Transaction transaction, String companyAccountId, HttpServletRequest request)
         throws DataException {
 
-        final Map<String, Object> debugMap = new HashMap<>();
-        debugMap.put("transaction_id", transaction.getId());
-        debugMap.put("company_accounts_id", companyAccountId);
         Errors errors = previousPeriodValidator.validatePreviousPeriod(previousPeriod);
 
         if (errors.hasErrors()) {
-            DataException dataException = new DataException(
-                "Failed to validate " + ResourceName.PREVIOUS_PERIOD.getName());
-            LOGGER.errorRequest(request, dataException, debugMap);
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);
         }
 
@@ -82,20 +70,14 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
         PreviousPeriodEntity previousPeriodEntity = previousPeriodTransformer
             .transform(previousPeriod);
 
-        String id = generateID(companyAccountId);
-        previousPeriodEntity.setId(id);
-        debugMap.put("id", id);
+        previousPeriodEntity.setId(generateID(companyAccountId));
 
         try {
             previousPeriodRepository.insert(previousPeriodEntity);
         } catch (DuplicateKeyException dke) {
-            LOGGER.errorRequest(request, dke, debugMap);
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
-        } catch (MongoException me) {
-            DataException dataException = new DataException(
-                "Failed to insert " + ResourceName.PREVIOUS_PERIOD.getName(), me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
 
         smallFullService
@@ -109,19 +91,17 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
         throws DataException {
 
         PreviousPeriodEntity previousPeriodEntity;
+
         try {
             previousPeriodEntity = previousPeriodRepository.findById(id).orElse(null);
-        } catch (MongoException me) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", id);
-            DataException dataException = new DataException("Failed to find Previous Period", me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
 
         if (previousPeriodEntity == null) {
             return new ResponseObject<>(ResponseStatus.NOT_FOUND);
         }
+
         PreviousPeriod previousPeriod = previousPeriodTransformer.transform(previousPeriodEntity);
         return new ResponseObject<>(ResponseStatus.FOUND, previousPeriod);
     }
@@ -134,32 +114,20 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
     public ResponseObject<PreviousPeriod> update(PreviousPeriod rest, Transaction transaction,
         String companyAccountId, HttpServletRequest request) throws DataException {
 
-        String id = generateID(companyAccountId);
-
-        final Map<String, Object> debugMap = new HashMap<>();
-        debugMap.put("transaction_id", transaction.getId());
-        debugMap.put("company_accounts_id", companyAccountId);
-        debugMap.put("id", id);
         Errors errors = previousPeriodValidator.validatePreviousPeriod(rest);
 
         if (errors.hasErrors()) {
-            DataException dataException = new DataException(
-                "Failed to validate " + ResourceName.PREVIOUS_PERIOD.getName());
-            LOGGER.errorRequest(request, dataException, debugMap);
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);
         }
 
         populateMetadata(rest, transaction, companyAccountId);
         PreviousPeriodEntity previousPeriodEntity = previousPeriodTransformer.transform(rest);
-        previousPeriodEntity.setId(id);
+        previousPeriodEntity.setId(generateID(companyAccountId));
 
         try {
             previousPeriodRepository.save(previousPeriodEntity);
-        } catch (MongoException me) {
-            DataException dataException = new DataException(
-                "Failed to update " + ResourceName.PREVIOUS_PERIOD.getName(), me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
 
         return new ResponseObject<>(ResponseStatus.UPDATED, rest);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullService.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
-import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.Kind;
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
@@ -24,15 +23,10 @@ import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.SmallFullTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Service
 public class SmallFullService implements
     ParentService<SmallFull, SmallFullLinkType> {
-
-    private static final Logger LOGGER = LoggerFactory
-        .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
 
     private SmallFullRepository smallFullRepository;
 
@@ -57,30 +51,20 @@ public class SmallFullService implements
     public ResponseObject<SmallFull> create(SmallFull smallFull, Transaction transaction,
         String companyAccountId, HttpServletRequest request)
         throws DataException {
+
         String selfLink = createSelfLink(transaction, companyAccountId);
         initLinks(smallFull, selfLink);
         smallFull.setEtag(GenerateEtagUtil.generateEtag());
         smallFull.setKind(Kind.SMALL_FULL_ACCOUNT.getValue());
         SmallFullEntity baseEntity = smallFullTransformer.transform(smallFull);
-
-        final Map<String, Object> debugMap = new HashMap<>();
-        debugMap.put("transaction_id", transaction.getId());
-        debugMap.put("company_accounts_id", companyAccountId);
-
-        String id = generateID(companyAccountId);
-        baseEntity.setId(id);
-        debugMap.put("id", id);
+        baseEntity.setId(generateID(companyAccountId));
 
         try {
             smallFullRepository.insert(baseEntity);
         } catch (DuplicateKeyException dke) {
-            LOGGER.errorRequest(request, dke, debugMap);
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
-        } catch (MongoException me) {
-            DataException dataException = new DataException(
-                "Failed to insert " + ResourceName.SMALL_FULL.getName(), me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
 
         companyAccountService
@@ -98,15 +82,12 @@ public class SmallFullService implements
 
     @Override
     public ResponseObject<SmallFull> findById(String id, HttpServletRequest request) throws DataException {
+
         SmallFullEntity smallFullEntity;
         try {
             smallFullEntity = smallFullRepository.findById(id).orElse(null);
-        } catch (MongoException me) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", id);
-            DataException dataException = new DataException("Failed to find Small full entity", me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
 
         if (smallFullEntity == null) {
@@ -133,16 +114,8 @@ public class SmallFullService implements
 
         try {
             smallFullRepository.save(smallFullEntity);
-        } catch (MongoException me) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("company_account_id", id);
-            debugMap.put("id", smallFullId);
-            debugMap.put("link", link);
-            debugMap.put("link_type", linkType.getLink());
-
-            DataException dataException = new DataException("Failed to add link to Small full", me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
     }
 
@@ -158,15 +131,8 @@ public class SmallFullService implements
 
         try {
             smallFullRepository.save(smallFullEntity);
-        } catch (MongoException me) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("company_account_id", id);
-            debugMap.put("id", smallFullId);
-            debugMap.put("link_type", linkType.getLink());
-
-            DataException dataException = new DataException("Failed to remove Small full link", me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
@@ -11,7 +11,6 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
 import uk.gov.companieshouse.api.accounts.AttributeName;
-import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.Kind;
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
@@ -27,14 +26,9 @@ import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.StatementTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Service
 public class StatementService implements ResourceService<Statement> {
-
-    private static final Logger LOGGER = LoggerFactory
-        .getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
 
     private static final String PERIOD_END_ON_PLACE_HOLDER = "{period_end_on}";
     private static final String LEGAL_STATEMENT_SECTION_477_KEY = "section_477";
@@ -79,20 +73,11 @@ public class StatementService implements ResourceService<Statement> {
 
         } catch (DuplicateKeyException ex) {
 
-            LOGGER.errorRequest(request, ex,
-                getDebugMap(transaction, companyAccountId, statementEntity.getId()));
-
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
 
         } catch (MongoException ex) {
 
-            DataException dataException = new DataException(
-                "Failed to insert " + ResourceName.STATEMENTS.getName(), ex);
-
-            LOGGER.errorRequest(request, dataException,
-                getDebugMap(transaction, companyAccountId, statementEntity.getId()));
-
-            throw dataException;
+            throw new DataException(ex);
         }
 
         smallFullService.addLink(companyAccountId,
@@ -121,13 +106,7 @@ public class StatementService implements ResourceService<Statement> {
 
         } catch (MongoException ex) {
 
-            DataException dataException = new DataException(
-                "Failed to update " + ResourceName.STATEMENTS.getName(), ex);
-
-            LOGGER.errorRequest(request, dataException,
-                getDebugMap(transaction, companyAccountId, statementEntity.getId()));
-
-            throw dataException;
+            throw new DataException(ex);
         }
 
         return new ResponseObject<>(ResponseStatus.UPDATED, rest);
@@ -144,13 +123,7 @@ public class StatementService implements ResourceService<Statement> {
 
         } catch (MongoException ex) {
 
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", id);
-
-            DataException dataException = new DataException("Failed to find Statements", ex);
-            LOGGER.errorRequest(request, dataException, debugMap);
-
-            throw dataException;
+            throw new DataException(ex);
         }
 
         if (statementEntity == null) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StocksService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StocksService.java
@@ -21,20 +21,14 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.StocksTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
 import uk.gov.companieshouse.api.accounts.validation.StocksValidator;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static uk.gov.companieshouse.api.accounts.CompanyAccountsApplication.APPLICATION_NAME_SPACE;
-
 @Service
 public class StocksService implements ResourceService<Stocks> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
 
     private StocksRepository repository;
     private StocksTransformer transformer;
@@ -73,13 +67,9 @@ public class StocksService implements ResourceService<Stocks> {
         try {
             repository.insert(entity);
         } catch (DuplicateKeyException e) {
-            LOGGER.errorRequest(request, e, getDebugMap(transaction, companyAccountId, entity.getId()));
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
         } catch (MongoException e) {
-            DataException dataException = new DataException("Failed to insert "
-                    + ResourceName.STOCKS.getName(), e);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction, companyAccountId, entity.getId()));
-            throw dataException;
+            throw new DataException(e);
         }
 
         smallFullService.addLink(companyAccountId, SmallFullLinkType.STOCKS_NOTE,
@@ -104,13 +94,8 @@ public class StocksService implements ResourceService<Stocks> {
 
         try {
             repository.save(entity);
-        } catch (MongoException me) {
-            DataException dataException =
-                    new DataException("Failed to update" + ResourceName.STOCKS.getName(), me);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction,
-                    companyAccountId, entity.getId()));
-
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
 
         return new ResponseObject<>(ResponseStatus.UPDATED, rest);
@@ -124,12 +109,7 @@ public class StocksService implements ResourceService<Stocks> {
         try {
             entity = repository.findById(id).orElse(null);
         } catch (MongoException e) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", id);
-            DataException dataException = new DataException("Failed to find Stocks", e);
-            LOGGER.errorRequest(request, dataException, debugMap);
-
-            throw dataException;
+            throw new DataException(e);
         }
 
         if (entity == null) {
@@ -153,13 +133,8 @@ public class StocksService implements ResourceService<Stocks> {
             } else {
                 return new ResponseObject<>(ResponseStatus.NOT_FOUND);
             }
-        } catch (MongoException me) {
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", companyAccountsId);
-            DataException dataException = new DataException("Failed to delete Stocks", me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-
-            throw dataException;
+        } catch (MongoException e) {
+            throw new DataException(e);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TangibleAssetsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TangibleAssetsService.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.api.accounts.service.impl;
 
-import static uk.gov.companieshouse.api.accounts.CompanyAccountsApplication.APPLICATION_NAME_SPACE;
-
 import com.mongodb.MongoException;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,13 +24,9 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.TangibleAssetsTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
 import uk.gov.companieshouse.api.accounts.validation.TangibleAssetsValidator;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Service
 public class TangibleAssetsService implements ResourceService<TangibleAssets> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
 
     private TangibleAssetsRepository repository;
     private TangibleAssetsTransformer transformer;
@@ -70,18 +64,10 @@ public class TangibleAssetsService implements ResourceService<TangibleAssets> {
             repository.insert(entity);
         } catch (DuplicateKeyException e) {
 
-            LOGGER.errorRequest(request, e, getDebugMap(transaction, companyAccountsId,
-                    entity.getId()));
-
             return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
         } catch (MongoException e) {
 
-            DataException dataException =
-                    new DataException("Failed to insert " + ResourceName.TANGIBLE_ASSETS.getName(), e);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction,
-                    companyAccountsId, entity.getId()));
-
-            throw dataException;
+            throw new DataException(e);
         }
 
         smallFullService.addLink(companyAccountsId, SmallFullLinkType.TANGIBLE_ASSETS_NOTE,
@@ -107,14 +93,9 @@ public class TangibleAssetsService implements ResourceService<TangibleAssets> {
         try {
 
             repository.save(entity);
-        } catch (MongoException me) {
+        } catch (MongoException e) {
 
-            DataException dataException =
-                    new DataException("Failed to update " + ResourceName.TANGIBLE_ASSETS.getName(), me);
-            LOGGER.errorRequest(request, dataException, getDebugMap(transaction,
-                    companyAccountsId, entity.getId()));
-
-            throw dataException;
+            throw new DataException(e);
         }
         return new ResponseObject<>(ResponseStatus.UPDATED, rest);
     }
@@ -130,14 +111,7 @@ public class TangibleAssetsService implements ResourceService<TangibleAssets> {
             entity = repository.findById(id).orElse(null);
         } catch (MongoException e) {
 
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", id);
-
-            DataException dataException =
-                    new DataException("Failed to find " + ResourceName.TANGIBLE_ASSETS.getName(), e);
-            LOGGER.errorRequest(request, dataException, debugMap);
-
-            throw dataException;
+            throw new DataException(e);
         }
 
         if (entity == null) {
@@ -165,16 +139,9 @@ public class TangibleAssetsService implements ResourceService<TangibleAssets> {
 
                 return new ResponseObject<>(ResponseStatus.NOT_FOUND);
             }
-        } catch (MongoException me) {
+        } catch (MongoException e) {
 
-            final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("id", companyAccountsId);
-
-            DataException dataException =
-                    new DataException("Failed to delete " + ResourceName.TANGIBLE_ASSETS.getName(), me);
-            LOGGER.errorRequest(request, dataException, debugMap);
-
-            throw dataException;
+            throw new DataException(e);
         }
     }
 


### PR DESCRIPTION
Remove duplicated exception logging from services. All exceptions are logged at the controller level, and duplicating the logging in the service with a slightly different message is both redundant and could obfuscate the problem by leading a person troubleshooting to believe multiple errors have occurred.

Required for SFA-1201