### PR TITLE
Rectify sonar ApiResponseMapper bug

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/AccountingPoliciesController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/AccountingPoliciesController.java
@@ -66,7 +66,7 @@ public class AccountingPoliciesController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to create accounting policies resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -89,7 +89,7 @@ public class AccountingPoliciesController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to retrieve accounting policies resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -123,7 +123,7 @@ public class AccountingPoliciesController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to update accounting policies resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/ApprovalController.java
@@ -63,7 +63,7 @@ public class ApprovalController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to create approval resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
 
     }
@@ -89,7 +89,7 @@ public class ApprovalController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to retrieve approval resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
@@ -53,21 +53,18 @@ public class CompanyAccountController {
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        ResponseEntity responseEntity;
         try {
             ResponseObject<CompanyAccount> responseObject = companyAccountService
                 .create(companyAccount, transaction, request);
-            responseEntity = apiResponseMapper
+            return apiResponseMapper
                 .map(responseObject.getStatus(), responseObject.getData(),
                     responseObject.getErrors());
         } catch (PatchException | DataException ex) {
             final Map<String, Object> debugMap = new HashMap<>();
             debugMap.put("transaction_id", transaction.getId());
             LOGGER.errorRequest(request, ex, debugMap);
-            responseEntity = apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
-
-        return responseEntity;
     }
 
     @GetMapping("/{companyAccountId}")

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CreditorsAfterOneYearController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CreditorsAfterOneYearController.java
@@ -67,7 +67,7 @@ public class CreditorsAfterOneYearController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to create creditors after one year resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -90,7 +90,7 @@ public class CreditorsAfterOneYearController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to retrieve creditors after one year resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -123,7 +123,7 @@ public class CreditorsAfterOneYearController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to update creditors after one year resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -146,7 +146,7 @@ public class CreditorsAfterOneYearController {
 
             LoggingHelper.logException(companyAccountsId, transaction,
                     "Failed to delete creditors after one year resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CreditorsWithinOneYearController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CreditorsWithinOneYearController.java
@@ -68,7 +68,7 @@ public class CreditorsWithinOneYearController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to create creditors within one year resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
     
@@ -101,7 +101,7 @@ public class CreditorsWithinOneYearController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to update creditors within one year resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -124,7 +124,7 @@ public class CreditorsWithinOneYearController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to retrieve creditors within one year resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -144,7 +144,7 @@ public class CreditorsWithinOneYearController {
 
             LoggingHelper.logException(companyAccountsId, transaction,
                     "Failed to delete creditors within one year resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
@@ -65,7 +65,7 @@ public class CurrentPeriodController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to create current period resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -98,7 +98,7 @@ public class CurrentPeriodController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to update current period resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -121,7 +121,7 @@ public class CurrentPeriodController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to retrieve current period resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/DebtorsController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/DebtorsController.java
@@ -65,7 +65,7 @@ public class DebtorsController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to create debtors resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -88,7 +88,7 @@ public class DebtorsController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to retrieve debtors resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -121,7 +121,7 @@ public class DebtorsController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to update debtors resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -141,7 +141,7 @@ public class DebtorsController {
 
             LoggingHelper.logException(companyAccountsId, transaction,
                     "Failed to delete debtors resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodController.java
@@ -64,7 +64,7 @@ public class PreviousPeriodController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to create previous period resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -87,7 +87,7 @@ public class PreviousPeriodController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to retrieve previous period resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -120,7 +120,7 @@ public class PreviousPeriodController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to update previous period resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/SmallFullController.java
@@ -53,7 +53,7 @@ public class SmallFullController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to create small full resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/StatementsController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/StatementsController.java
@@ -51,7 +51,7 @@ public class StatementsController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to create statements resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -74,7 +74,7 @@ public class StatementsController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to update statements resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -97,7 +97,7 @@ public class StatementsController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to retrieve statements resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/StocksController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/StocksController.java
@@ -66,7 +66,7 @@ public class StocksController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to create stocks resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -99,7 +99,7 @@ public class StocksController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to update stocks resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -122,7 +122,7 @@ public class StocksController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to retrieve stocks resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -144,7 +144,7 @@ public class StocksController {
 
             LoggingHelper.logException(companyAccountsId, transaction,
                     "Failed to delete stocks resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/TangibleAssetsController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/TangibleAssetsController.java
@@ -67,7 +67,7 @@ public class TangibleAssetsController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to create tangible assets resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -91,7 +91,7 @@ public class TangibleAssetsController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to retrieve tangible assets resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -125,7 +125,7 @@ public class TangibleAssetsController {
 
             LoggingHelper.logException(companyAccountId, transaction,
                     "Failed to update tangible assets resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 
@@ -147,7 +147,7 @@ public class TangibleAssetsController {
 
             LoggingHelper.logException(companyAccountsId, transaction,
                     "Failed to delete tangible assets resource", ex, request);
-            return apiResponseMapper.map(ex);
+            return apiResponseMapper.getErrorResponse();
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/ApiResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/ApiResponseMapper.java
@@ -6,8 +6,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.api.accounts.exception.DataException;
-import uk.gov.companieshouse.api.accounts.exception.PatchException;
 import uk.gov.companieshouse.api.accounts.model.rest.RestObject;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/ApiResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/ApiResponseMapper.java
@@ -42,12 +42,8 @@ public class ApiResponseMapper {
         }
     }
 
-    public ResponseEntity map(Exception exception) {
-        if (exception instanceof DataException || exception instanceof PatchException) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        } else {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        }
+    public ResponseEntity getErrorResponse() {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
 
     public ResponseEntity mapGetResponse(RestObject restObject, HttpServletRequest request) {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/AccountingPoliciesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/AccountingPoliciesControllerTest.java
@@ -116,12 +116,11 @@ public class AccountingPoliciesControllerTest {
         when(bindingResult.hasErrors()).thenReturn(false);
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        DataException dataException = new DataException("");
         when(accountingPoliciesService.create(accountingPolicies, transaction, COMPANY_ACCOUNTS_ID, request))
-                .thenThrow(dataException);
+                .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(apiResponseMapper.map(dataException))
+        when(apiResponseMapper.getErrorResponse())
                 .thenReturn(responseEntity);
 
         ResponseEntity returnedResponse =
@@ -164,12 +163,11 @@ public class AccountingPoliciesControllerTest {
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
         when(accountingPoliciesService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(ACCOUNTING_POLICIES_ID);
 
-        DataException dataException = new DataException("");
         when(accountingPoliciesService.findById(ACCOUNTING_POLICIES_ID, request))
-                .thenThrow(dataException);
+                .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(apiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(apiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse = controller.get(COMPANY_ACCOUNTS_ID, request);
 
@@ -247,12 +245,11 @@ public class AccountingPoliciesControllerTest {
         when(smallFullLinks.get(SmallFullLinkType.ACCOUNTING_POLICY_NOTE.getLink())).thenReturn("");
         when(bindingResult.hasErrors()).thenReturn(false);
 
-        DataException dataException = new DataException("");
         when(accountingPoliciesService.update(accountingPolicies, transaction, COMPANY_ACCOUNTS_ID, request))
-                .thenThrow(dataException);
+                .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(apiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(apiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse =
                 controller.update(accountingPolicies, bindingResult, COMPANY_ACCOUNTS_ID, request);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/ApprovalControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/ApprovalControllerTest.java
@@ -86,16 +86,16 @@ public class ApprovalControllerTest {
     @Test
     @DisplayName("Tests the unsuccessful request to create Approval")
     void createApprovalError() throws DataException {
-        DataException exception = new DataException("string");
-        when(approvalService.create(any(), any(), any(), any())).thenThrow(exception);
-        when(apiResponseMapper.map(exception))
+
+        when(approvalService.create(any(), any(), any(), any())).thenThrow(new DataException(""));
+        when(apiResponseMapper.getErrorResponse())
             .thenReturn(new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR));
 
         ResponseEntity response = approvalController
             .create(approval, bindingResult, "", request);
 
         verify(approvalService, times(1)).create(any(), any(), any(), any());
-        verify(apiResponseMapper, times(1)).map(exception);
+        verify(apiResponseMapper, times(1)).getErrorResponse();
         assertNotNull(response);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
@@ -121,8 +121,7 @@ public class CompanyAccountControllerTest {
                 .create(companyAccount, transactionMock, httpServletRequestMock);
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(null);
-        when(apiResponseMapper.map(any(DataException.class)))
-                .thenReturn(responseEntity);
+        when(apiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity response = companyAccountController
                 .createCompanyAccount(companyAccount, httpServletRequestMock);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CreditorsAfterOneYearControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CreditorsAfterOneYearControllerTest.java
@@ -103,13 +103,12 @@ public class CreditorsAfterOneYearControllerTest {
         when(mockBindingResult.hasErrors()).thenReturn(false);
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
 
-        DataException dataException = new DataException("");
         when(mockCreditorsAfterOneYearService.create(mockCreditorsAfterOneYear, mockTransaction,
-                COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(dataException);
+                COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         ResponseEntity responseEntity =
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException))
+        when(mockApiResponseMapper.getErrorResponse())
                 .thenReturn(responseEntity);
 
         ResponseEntity returnedResponse =
@@ -168,14 +167,12 @@ public class CreditorsAfterOneYearControllerTest {
 
         when(mockRequest.getAttribute(anyString())).thenReturn(mockTransaction);
 
-        DataException dataException = new DataException("");
-
         when(mockCreditorsAfterOneYearService.delete(COMPANY_ACCOUNTS_ID, mockRequest))
-                .thenThrow(dataException);
+                .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity =
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(mockApiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse = controller.delete(COMPANY_ACCOUNTS_ID, mockRequest);
 
@@ -218,13 +215,12 @@ public class CreditorsAfterOneYearControllerTest {
         mockTransactionAndLinks();
         when(mockBindingResult.hasErrors()).thenReturn(false);
 
-        DataException dataException = new DataException("");
         when(mockCreditorsAfterOneYearService.update(mockCreditorsAfterOneYear, mockTransaction,
-                COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(dataException);
+                COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         ResponseEntity responseEntity =
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(mockApiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse =
                 controller.update(mockCreditorsAfterOneYear, mockBindingResult,
@@ -267,13 +263,12 @@ public class CreditorsAfterOneYearControllerTest {
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
         when(mockCreditorsAfterOneYearService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(CREDITORS_AFTER_ONE_YEAR_ID);
 
-        DataException dataException = new DataException("");
         when(mockCreditorsAfterOneYearService.findById(CREDITORS_AFTER_ONE_YEAR_ID, mockRequest))
-                .thenThrow(dataException);
+                .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity =
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(mockApiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse = controller.get(COMPANY_ACCOUNTS_ID, mockRequest);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CreditorsWithinOneYearControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CreditorsWithinOneYearControllerTest.java
@@ -103,13 +103,12 @@ public class CreditorsWithinOneYearControllerTest {
         when(mockBindingResult.hasErrors()).thenReturn(false);
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
 
-        DataException dataException = new DataException("");
         when(mockCreditorsWithinOneYearService.create(mockCreditorsWithinOneYear, mockTransaction,
-                COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(dataException);
+                COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         ResponseEntity responseEntity =
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException))
+        when(mockApiResponseMapper.getErrorResponse())
                 .thenReturn(responseEntity);
 
         ResponseEntity returnedResponse =
@@ -203,13 +202,12 @@ public class CreditorsWithinOneYearControllerTest {
         mockTransactionAndLinks();
         when(mockBindingResult.hasErrors()).thenReturn(false);
 
-        DataException dataException = new DataException("");
         when(mockCreditorsWithinOneYearService.update(mockCreditorsWithinOneYear, mockTransaction,
-                COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(dataException);
+                COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         ResponseEntity responseEntity =
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(mockApiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse =
                 controller.update(mockCreditorsWithinOneYear, mockBindingResult,
@@ -252,13 +250,12 @@ public class CreditorsWithinOneYearControllerTest {
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
         when(mockCreditorsWithinOneYearService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(CREDITORS_WITHIN_ONE_YEAR_ID);
 
-        DataException dataException = new DataException("");
         when(mockCreditorsWithinOneYearService.findById(CREDITORS_WITHIN_ONE_YEAR_ID, mockRequest))
-                .thenThrow(dataException);
+                .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity =
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(mockApiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse = controller.get(COMPANY_ACCOUNTS_ID, mockRequest);
 
@@ -298,14 +295,12 @@ public class CreditorsWithinOneYearControllerTest {
 
         when(mockRequest.getAttribute(anyString())).thenReturn(mockTransaction);
 
-        DataException dataException = new DataException("");
-
         when(mockCreditorsWithinOneYearService.delete(COMPANY_ACCOUNTS_ID, mockRequest))
-            .thenThrow(dataException);
+            .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity =
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(mockApiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse = controller.delete(COMPANY_ACCOUNTS_ID, mockRequest);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/DebtorsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/DebtorsControllerTest.java
@@ -101,12 +101,11 @@ public class DebtorsControllerTest {
         when(mockBindingResult.hasErrors()).thenReturn(false);
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
 
-        DataException dataException = new DataException("");
         when(mockDebtorsService.create(mockDebtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest))
-            .thenThrow(dataException);
+            .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException))
+        when(mockApiResponseMapper.getErrorResponse())
             .thenReturn(responseEntity);
 
         ResponseEntity returnedResponse =
@@ -163,12 +162,11 @@ public class DebtorsControllerTest {
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
         when(mockDebtorsService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(DEBTORS_ID);
 
-        DataException dataException = new DataException("");
         when(mockDebtorsService.findById(DEBTORS_ID, mockRequest))
-            .thenThrow(dataException);
+            .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(mockApiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse = controller.get(COMPANY_ACCOUNTS_ID, mockRequest);
 
@@ -240,12 +238,11 @@ public class DebtorsControllerTest {
         mockTransactionAndLinks();
         when(mockBindingResult.hasErrors()).thenReturn(false);
 
-        DataException dataException = new DataException("");
         when(mockDebtorsService.update(mockDebtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest))
-            .thenThrow(dataException);
+            .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(mockApiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse =
             controller.update(mockDebtors, mockBindingResult, COMPANY_ACCOUNTS_ID, mockRequest);
@@ -284,12 +281,11 @@ public class DebtorsControllerTest {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
 
-        DataException dataException = new DataException("");
         when(mockDebtorsService.delete(COMPANY_ACCOUNTS_ID, mockRequest))
-            .thenThrow(dataException);
+            .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(mockApiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse = controller.delete(COMPANY_ACCOUNTS_ID, mockRequest);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodControllerTest.java
@@ -118,17 +118,15 @@ public class PreviousPeriodControllerTest {
 
         doReturn(transaction).when(request).getAttribute(AttributeName.TRANSACTION.getValue());
 
-        DataException exception = new DataException("string");
+        when(previousPeriodService.create(any(), any(), any(), any())).thenThrow(new DataException(""));
 
-        when(previousPeriodService.create(any(), any(), any(), any())).thenThrow(exception);
-
-        when(apiResponseMapper.map(exception))
+        when(apiResponseMapper.getErrorResponse())
             .thenReturn(new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR));
         ResponseEntity response = previousPeriodController
             .create(previousPeriod, bindingResult, "", request);
 
         verify(previousPeriodService, times(1)).create(any(), any(), any(), any());
-        verify(apiResponseMapper, times(1)).map(exception);
+        verify(apiResponseMapper, times(1)).getErrorResponse();
 
         assertNotNull(response);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
@@ -214,8 +212,8 @@ public class PreviousPeriodControllerTest {
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(null);
         when(previousPeriodService.findById(anyString(), any(HttpServletRequest.class)))
-            .thenThrow(new DataException("error"));
-        when(apiResponseMapper.map(any(DataException.class))).thenReturn(responseEntity);
+            .thenThrow(new DataException(""));
+        when(apiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity response = previousPeriodController.get("123456", request);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/StatementsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/StatementsControllerTest.java
@@ -77,13 +77,11 @@ public class StatementsControllerTest {
     void shouldNotCreateStatement() throws DataException {
         when(requestMock.getAttribute(anyString())).thenReturn(transactionMock);
 
-        DataException dataException = new DataException("string");
-
         when(statementServiceMock.create(any(Statement.class), any(Transaction.class), anyString(),
             any(HttpServletRequest.class)))
-            .thenThrow(dataException);
+            .thenThrow(new DataException(""));
 
-        when(apiResponseMapperMock.map(dataException))
+        when(apiResponseMapperMock.getErrorResponse())
             .thenReturn(createResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, null));
 
         ResponseEntity response =
@@ -91,7 +89,7 @@ public class StatementsControllerTest {
 
         assertStatementControllerResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, false);
         verifyStatementServiceCreateCall();
-        verify(apiResponseMapperMock, times(1)).map(dataException);
+        verify(apiResponseMapperMock, times(1)).getErrorResponse();
     }
 
 
@@ -123,13 +121,11 @@ public class StatementsControllerTest {
     void shouldNotUpdateStatement() throws DataException {
         when(requestMock.getAttribute(anyString())).thenReturn(transactionMock);
 
-        DataException dataException = new DataException("string");
-
         when(statementServiceMock.update(any(Statement.class), any(Transaction.class), anyString(),
             any(HttpServletRequest.class)))
-            .thenThrow(dataException);
+            .thenThrow(new DataException(""));
 
-        when(apiResponseMapperMock.map(dataException))
+        when(apiResponseMapperMock.getErrorResponse())
             .thenReturn(createResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, null));
 
         ResponseEntity response =
@@ -137,7 +133,7 @@ public class StatementsControllerTest {
 
         assertStatementControllerResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, false);
         verifyStatementServiceUpdate();
-        verify(apiResponseMapperMock, times(1)).map(dataException);
+        verify(apiResponseMapperMock, times(1)).getErrorResponse();
     }
 
     @Test
@@ -189,11 +185,10 @@ public class StatementsControllerTest {
 
         when(statementServiceMock.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(STATEMENT_ID);
 
-        DataException dataException = new DataException("string");
         when(statementServiceMock.findById(STATEMENT_ID, requestMock))
-            .thenThrow(dataException);
+            .thenThrow(new DataException(""));
 
-        when(apiResponseMapperMock.map(dataException))
+        when(apiResponseMapperMock.getErrorResponse())
             .thenReturn(createResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, null));
 
         ResponseEntity response =
@@ -201,7 +196,7 @@ public class StatementsControllerTest {
 
         assertStatementControllerResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, false);
         verifyStatementServiceGenerateAndFind(STATEMENT_ID);
-        verify(apiResponseMapperMock, times(1)).map(dataException);
+        verify(apiResponseMapperMock, times(1)).getErrorResponse();
     }
 
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/StocksControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/StocksControllerTest.java
@@ -103,12 +103,11 @@ public class StocksControllerTest {
         when(mockBindingResult.hasErrors()).thenReturn(false);
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
 
-        DataException dataException = new DataException("");
         when(mockStocksService.create(mockStocks, mockTransaction,
-                COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(dataException);
+                COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException))
+        when(mockApiResponseMapper.getErrorResponse())
                 .thenReturn(responseEntity);
 
         ResponseEntity returnedResponse =
@@ -196,12 +195,11 @@ public class StocksControllerTest {
         mockTransactionAndLinks();
         when(mockBindingResult.hasErrors()).thenReturn(false);
 
-        DataException dataException = new DataException("");
         when(mockStocksService.update(mockStocks, mockTransaction,
-                COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(dataException);
+                COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(mockApiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse =
                 controller.update(mockStocks, mockBindingResult, COMPANY_ACCOUNTS_ID, mockRequest);
@@ -243,12 +241,11 @@ public class StocksControllerTest {
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
         when(mockStocksService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(STOCKS_ID);
 
-        DataException dataException = new DataException("");
         when(mockStocksService.findById(STOCKS_ID, mockRequest))
-                .thenThrow(dataException);
+                .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(mockApiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse = controller.get(COMPANY_ACCOUNTS_ID, mockRequest);
 
@@ -288,12 +285,11 @@ public class StocksControllerTest {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
 
-        DataException dataException = new DataException("");
         when(mockStocksService.delete(COMPANY_ACCOUNTS_ID, mockRequest))
-                .thenThrow(dataException);
+                .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(mockApiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(mockApiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity returnedResponse = controller.delete(COMPANY_ACCOUNTS_ID, mockRequest);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/TangibleAssetsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/TangibleAssetsControllerTest.java
@@ -133,12 +133,11 @@ public class TangibleAssetsControllerTest {
         when(bindingResult.hasErrors()).thenReturn(false);
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        DataException dataException = new DataException("");
-        doThrow(dataException).when(tangibleAssetsService)
+        doThrow(new DataException("")).when(tangibleAssetsService)
                 .create(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(apiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(apiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity response =
                 controller.create(tangibleAssets, bindingResult, COMPANY_ACCOUNTS_ID, request);
@@ -151,7 +150,7 @@ public class TangibleAssetsControllerTest {
         verify(tangibleAssetsService, times(1))
                 .create(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
         verify(apiResponseMapper, times(1))
-                .map(dataException);
+                .getErrorResponse();
     }
 
     @Test
@@ -188,11 +187,10 @@ public class TangibleAssetsControllerTest {
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
         when(tangibleAssetsService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(GENERATED_ID);
 
-        DataException dataException = new DataException("");
-        doThrow(dataException).when(tangibleAssetsService).findById(GENERATED_ID, request);
+        doThrow(new DataException("")).when(tangibleAssetsService).findById(GENERATED_ID, request);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(apiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(apiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity response = controller.get(COMPANY_ACCOUNTS_ID, request);
 
@@ -203,7 +201,7 @@ public class TangibleAssetsControllerTest {
         verify(tangibleAssetsService, times(1))
                 .findById(GENERATED_ID, request);
         verify(apiResponseMapper, never()).mapGetResponse(any(), any());
-        verify(apiResponseMapper, times(1)).map(dataException);
+        verify(apiResponseMapper, times(1)).getErrorResponse();
     }
 
     @Test
@@ -295,12 +293,11 @@ public class TangibleAssetsControllerTest {
 
         when(bindingResult.hasErrors()).thenReturn(false);
 
-        DataException dataException = new DataException("");
-        doThrow(dataException).when(tangibleAssetsService)
+        doThrow(new DataException("")).when(tangibleAssetsService)
                 .update(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(apiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(apiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity response =
                 controller.update(tangibleAssets, bindingResult, COMPANY_ACCOUNTS_ID, request);
@@ -313,7 +310,7 @@ public class TangibleAssetsControllerTest {
         verify(tangibleAssetsService, times(1))
                 .update(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
         verify(apiResponseMapper, times(1))
-                .map(dataException);
+                .getErrorResponse();
     }
 
     @Test
@@ -347,11 +344,10 @@ public class TangibleAssetsControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        DataException dataException = new DataException("");
-        doThrow(dataException).when(tangibleAssetsService).delete(COMPANY_ACCOUNTS_ID, request);
+        doThrow(new DataException("")).when(tangibleAssetsService).delete(COMPANY_ACCOUNTS_ID, request);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        when(apiResponseMapper.map(dataException)).thenReturn(responseEntity);
+        when(apiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 
         ResponseEntity response = controller.delete(COMPANY_ACCOUNTS_ID, request);
 
@@ -360,6 +356,6 @@ public class TangibleAssetsControllerTest {
         assertNull(response.getBody());
 
         verify(tangibleAssetsService, times(1)).delete(COMPANY_ACCOUNTS_ID, request);
-        verify(apiResponseMapper, times(1)).map(dataException);
+        verify(apiResponseMapper, times(1)).getErrorResponse();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/ApiResponseMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/ApiResponseMapperTest.java
@@ -16,7 +16,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import uk.gov.companieshouse.api.accounts.exception.PatchException;
 import uk.gov.companieshouse.api.accounts.model.rest.RestObject;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
@@ -30,12 +29,6 @@ public class ApiResponseMapperTest {
 
     @Mock
     private Errors errors;
-
-    @Mock
-    private PatchException patchException;
-
-    @Mock
-    private IllegalArgumentException illegalArgumentException;
 
     @Mock
     private HttpServletRequest request;
@@ -77,17 +70,8 @@ public class ApiResponseMapperTest {
 
     @Test
     @DisplayName("Tests exception response")
-    void canMapException() {
-        ResponseEntity responseEntity = apiResponseMapper.map(patchException);
-        assertNotNull(responseEntity);
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
-        assertNull(responseEntity.getBody());
-    }
-
-    @Test
-    @DisplayName("Tests exception response default")
-    void canMapExceptionDefault() {
-        ResponseEntity responseEntity = apiResponseMapper.map(illegalArgumentException);
+    void canGetErrorResponse() {
+        ResponseEntity responseEntity = apiResponseMapper.getErrorResponse();
         assertNotNull(responseEntity);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
         assertNull(responseEntity.getBody());


### PR DESCRIPTION
Rectify sonar ApiResponseMapper 'bug'. The former if/else block was redundant since we were returning the same 'internal server error' response regardless of exception type. This change adds a new method 'getErrorResponse' with an empty signature which returns an internal server error response entity. Whilst this could be explicitly returned in each controller, the method has been kept within the ApiResponseMapper class for encapsulation of responsibility to make it easier to return different responses dependent on exception type if we were to facilitate that in the future.

Required for SFA-1201