### PR TITLE
 Make transactions interceptor use private get 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <hibernate-validator.version>6.0.13.Final</hibernate-validator.version>
     <api-sdk-java.version>3.13.7</api-sdk-java.version>
     <private-api-sdk-java.version>1.2.2</private-api-sdk-java.version>
-    <api-sdk-manager-java-library.version>1.0.0</api-sdk-manager-java-library.version>
+    <api-sdk-manager-java-library.version>1.0.1</api-sdk-manager-java-library.version>
     <gson.version>2.8.0</gson.version>
 
     <!-- Maven and Surefire plugins -->

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
@@ -14,7 +14,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
-import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.sdk.ApiClientService;
@@ -52,16 +52,9 @@ public class TransactionInterceptor extends HandlerInterceptorAdapter {
             String transactionId = pathVariables.get("transactionId");
             String passthroughHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
 
-            if (passthroughHeader == null || passthroughHeader.isEmpty()) {
-                debugMap.put("message", "ERIC passthrough token header is empty");
-                LOGGER.errorRequest(request, null, debugMap);
-                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-                return false;
-            }
-
-            ApiClient apiClient;
+            InternalApiClient apiClient;
             try {
-                apiClient = apiClientService.getApiClient(passthroughHeader);
+                apiClient = apiClientService.getInternalApiClient(passthroughHeader);
             } catch (IOException e) {
 
                 LOGGER.errorRequest(request, e, debugMap);
@@ -71,7 +64,7 @@ public class TransactionInterceptor extends HandlerInterceptorAdapter {
 
             Transaction transaction;
             try {
-                transaction = apiClient.transactions().get("/transactions/" + transactionId).execute();
+                transaction = apiClient.privateTransaction().get("/private/transactions/" + transactionId).execute();
             } catch (ApiErrorResponseException e) {
 
                 LOGGER.errorRequest(request, e, debugMap);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
@@ -19,11 +19,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.servlet.HandlerMapping;
-import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.accounts.sdk.ApiClientService;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
-import uk.gov.companieshouse.api.handler.transaction.TransactionsResourceHandler;
-import uk.gov.companieshouse.api.handler.transaction.request.TransactionsGet;
+import uk.gov.companieshouse.api.handler.privatetransaction.PrivateTransactionResourceHandler;
+import uk.gov.companieshouse.api.handler.privatetransaction.request.PrivateTransactionGet;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,13 +37,13 @@ public class TransactionInterceptorTest {
     private ApiClientService apiClientServiceMock;
 
     @Mock
-    private ApiClient internalApiClientMock;
+    private InternalApiClient internalApiClientMock;
 
     @Mock
-    private TransactionsResourceHandler transactionResourceHandlerMock;
+    private PrivateTransactionResourceHandler transactionResourceHandlerMock;
 
     @Mock
-    private TransactionsGet transactionGetMock;
+    private PrivateTransactionGet transactionGetMock;
 
     @Mock
     private HttpServletRequest httpServletRequestMock;
@@ -62,8 +62,8 @@ public class TransactionInterceptorTest {
 
         httpServletResponseMock.setContentType("text/html");
 
-        when(apiClientServiceMock.getApiClient(anyString())).thenReturn(internalApiClientMock);
-        when(internalApiClientMock.transactions()).thenReturn(transactionResourceHandlerMock);
+        when(apiClientServiceMock.getInternalApiClient(anyString())).thenReturn(internalApiClientMock);
+        when(internalApiClientMock.privateTransaction()).thenReturn(transactionResourceHandlerMock);
         when(transactionResourceHandlerMock.get(anyString())).thenReturn(transactionGetMock);
         when(transactionGetMock.execute()).thenReturn(new Transaction());
     }


### PR DESCRIPTION
- Remove failing null check (not needed)
- Make interceptor use private transaction, negating need for OAuth2-specific authentication (if it didn't do this, the `document-generator` would fall over)