### PR TITLE
Correct Tangible iXBRL Disposals / On Disposals Display

### DIFF
--- a/src/main/resources/filing/templates/small-full-accounts.html
+++ b/src/main/resources/filing/templates/small-full-accounts.html
@@ -1898,44 +1898,44 @@
                         <td id="tangible-cost-disposals">Disposals</td>
                         <td id="tangible-cost-disposals-land-and-building" class="strong figure">
                             {{if isNotEmpty $cost.disposals.land_and_buildings}}
-                            {{if gt $cost.disposals.land_and_buildings 0.0}}({{end}}
+                            {{emitIfPositive $cost.disposals.land_and_buildings "("}}
                             <ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.land_and_buildings}}</ix:nonFraction>
-                            {{if gt $cost.disposals.land_and_buildings 0.0}}){{end}}
+                            {{emitIfPositive $cost.disposals.land_and_buildings ")"}}
                             {{end}}
                         </td>
                         <td id="tangible-cost-disposals-plant-and-machinery" class="strong figure">
                             {{if isNotEmpty $cost.disposals.plant_and_machinery}}
-                            {{if gt $cost.disposals.plant_and_machinery 0.0}}({{end}}
+                            {{emitIfPositive $cost.disposals.plant_and_machinery "("}}
                             <ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.plant_and_machinery}}</ix:nonFraction>
-                            {{if gt $cost.disposals.plant_and_machinery 0.0}}){{end}}
+                            {{emitIfPositive $cost.disposals.plant_and_machinery ")"}}
                             {{end}}
                         </td>
                         <td id="tangible-cost-disposals-fixtures-and-fitting" class="strong figure">
                             {{if isNotEmpty $cost.disposals.fixtures_and_fittings}}
-                            {{if gt $cost.disposals.fixtures_and_fittings 0.0}}({{end}}
+                            {{emitIfPositive $cost.disposals.fixtures_and_fittings "("}}
                             <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.fixtures_and_fittings}}</ix:nonFraction>
-                            {{if gt $cost.disposals.fixtures_and_fittings 0.0}}){{end}}
+                            {{emitIfPositive $cost.disposals.fixtures_and_fittings ")"}}
                             {{end}}
                         </td>
                         <td id="tangible-cost-disposals-office-equipment" class="strong figure">
                             {{if isNotEmpty $cost.disposals.office_equipment}}
-                            {{if gt $cost.disposals.office_equipment 0.0}}({{end}}
+                            {{emitIfPositive $cost.disposals.office_equipment "("}}
                             <ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.office_equipment}}</ix:nonFraction>
-                            {{if gt $cost.disposals.office_equipment 0.0}}){{end}}
+                            {{emitIfPositive $cost.disposals.office_equipment ")"}}
                             {{end}}
                         </td>
                         <td id="tangible-cost-disposals-motor-vehicles" class="strong figure">
                             {{if isNotEmpty $cost.disposals.motor_vehicles}}
-                            {{if gt $cost.disposals.motor_vehicles 0.0}}({{end}}
+                            {{emitIfPositive $cost.disposals.motor_vehicles "("}}
                             <ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.motor_vehicles}}</ix:nonFraction>
-                            {{if gt $cost.disposals.motor_vehicles 0.0}}){{end}}
+                            {{emitIfPositive $cost.disposals.motor_vehicles ")"}}
                             {{end}}
                         </td>
                         <td id="tangible-cost-disposals-total" class="strong figure">
                             {{if isNotEmpty $cost.disposals.total}}
-                            {{if gt $cost.disposals.total 0.0}}({{end}}
+                            {{emitIfPositive $cost.disposals.total "("}}
                             <ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.total}}</ix:nonFraction>
-                            {{if gt $cost.disposals.total 0.0}}){{end}}
+                            {{emitIfPositive $cost.disposals.total ")"}}
                             {{end}}
                         </td>
                     </tr>
@@ -2162,44 +2162,44 @@
                         <td id="tangible-depreciation-on-disposals">On disposals</td>
                         <td id="tangible-depreciation-on-disposals-land-and-building" class="strong figure">
                             {{if isNotEmpty $depreciation.on_disposals.land_and_buildings}}
-                            {{if gt $depreciation.on_disposals.land_and_buildings 0.0}}({{end}}
+                            {{emitIfPositive $depreciation.on_disposals.land_and_buildings "("}}
                             <ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.land_and_buildings}}</ix:nonFraction>
-                            {{if gt $depreciation.on_disposals.land_and_buildings 0.0}}){{end}}
+                            {{emitIfPositive $depreciation.on_disposals.land_and_buildings ")"}}
                             {{end}}
                         </td>
                         <td id="tangible-depreciation-on-disposals-plant-and-machinery" class="strong figure">
                             {{if isNotEmpty $depreciation.on_disposals.plant_and_machinery}}
-                            {{if gt $depreciation.on_disposals.plant_and_machinery 0.0}}({{end}}
+                            {{emitIfPositive $depreciation.on_disposals.plant_and_machinery "("}}
                             <ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.plant_and_machinery}}</ix:nonFraction>
-                            {{if gt $depreciation.on_disposals.plant_and_machinery 0.0}}){{end}}
+                            {{emitIfPositive $depreciation.on_disposals.plant_and_machinery ")"}}
                             {{end}}
                         </td>
                         <td id="tangible-depreciation-on-disposals-fixtures-and-fitting" class="strong figure">
                             {{if isNotEmpty $depreciation.on_disposals.fixtures_and_fittings}}
-                            {{if gt $depreciation.on_disposals.fixtures_and_fittings 0.0}}({{end}}
+                            {{emitIfPositive $depreciation.on_disposals.fixtures_and_fittings "("}}
                             <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.fixtures_and_fittings}}</ix:nonFraction>
-                            {{if gt $depreciation.on_disposals.fixtures_and_fittings 0.0}}){{end}}
+                            {{emitIfPositive $depreciation.on_disposals.fixtures_and_fittings ")"}}
                             {{end}}
                         </td>
                         <td id="tangible-depreciation-on-disposals-office-equipment" class="strong figure">
                             {{if isNotEmpty $depreciation.on_disposals.office_equipment}}
-                            {{if gt $depreciation.on_disposals.office_equipment 0.0}}({{end}}
+                            {{emitIfPositive $depreciation.on_disposals.office_equipment "("}}
                             <ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.office_equipment}}</ix:nonFraction>
-                            {{if gt $depreciation.on_disposals.office_equipment 0.0}}){{end}}
+                            {{emitIfPositive $depreciation.on_disposals.office_equipment ")"}}
                             {{end}}
                         </td>
                         <td id="tangible-depreciation-on-disposals-motor-vehicles" class="strong figure">
                             {{if isNotEmpty $depreciation.on_disposals.motor_vehicles}}
-                            {{if gt $depreciation.on_disposals.motor_vehicles 0.0}}({{end}}
+                            {{emitIfPositive $depreciation.on_disposals.motor_vehicles "("}}
                             <ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.motor_vehicles}}</ix:nonFraction>
-                            {{if gt $depreciation.on_disposals.motor_vehicles 0.0}}){{end}}
+                            {{emitIfPositive $depreciation.on_disposals.motor_vehicles ")"}}
                             {{end}}
                         </td>
                         <td id="tangible-depreciation-on-disposals-total" class="strong figure">
                             {{if isNotEmpty $depreciation.on_disposals.total}}
-                            {{if gt $depreciation.on_disposals.total 0.0}}({{end}}
+                            {{emitIfPositive $depreciation.on_disposals.total "("}}
                             <ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.total}}</ix:nonFraction>
-                            {{if gt $depreciation.on_disposals.total 0.0}}){{end}}
+                            {{emitIfPositive $depreciation.on_disposals.total ")"}}
                             {{end}}
                         </td>
                     </tr>

--- a/src/main/resources/filing/templates/small-full-accounts.html
+++ b/src/main/resources/filing/templates/small-full-accounts.html
@@ -1898,32 +1898,44 @@
                         <td id="tangible-cost-disposals">Disposals</td>
                         <td id="tangible-cost-disposals-land-and-building" class="strong figure">
                             {{if isNotEmpty $cost.disposals.land_and_buildings}}
-                            <span class="debit">(<ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.land_and_buildings}}</ix:nonFraction>)</span>
+                            {{if gt $cost.disposals.land_and_buildings 0.0}}({{end}}
+                            <ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.land_and_buildings}}</ix:nonFraction>
+                            {{if gt $cost.disposals.land_and_buildings 0.0}}){{end}}
                             {{end}}
                         </td>
                         <td id="tangible-cost-disposals-plant-and-machinery" class="strong figure">
                             {{if isNotEmpty $cost.disposals.plant_and_machinery}}
-                            <span class="debit">(<ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.plant_and_machinery}}</ix:nonFraction>)</span>
+                            {{if gt $cost.disposals.plant_and_machinery 0.0}}({{end}}
+                            <ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.plant_and_machinery}}</ix:nonFraction>
+                            {{if gt $cost.disposals.plant_and_machinery 0.0}}){{end}}
                             {{end}}
                         </td>
                         <td id="tangible-cost-disposals-fixtures-and-fitting" class="strong figure">
                             {{if isNotEmpty $cost.disposals.fixtures_and_fittings}}
-                            <span class="debit">(<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.fixtures_and_fittings}}</ix:nonFraction>)</span>
+                            {{if gt $cost.disposals.fixtures_and_fittings 0.0}}({{end}}
+                            <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.fixtures_and_fittings}}</ix:nonFraction>
+                            {{if gt $cost.disposals.fixtures_and_fittings 0.0}}){{end}}
                             {{end}}
                         </td>
                         <td id="tangible-cost-disposals-office-equipment" class="strong figure">
                             {{if isNotEmpty $cost.disposals.office_equipment}}
-                            <span class="debit">(<ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.office_equipment}}</ix:nonFraction>)</span>
+                            {{if gt $cost.disposals.office_equipment 0.0}}({{end}}
+                            <ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.office_equipment}}</ix:nonFraction>
+                            {{if gt $cost.disposals.office_equipment 0.0}}){{end}}
                             {{end}}
                         </td>
                         <td id="tangible-cost-disposals-motor-vehicles" class="strong figure">
                             {{if isNotEmpty $cost.disposals.motor_vehicles}}
-                            <span class="debit">(<ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.motor_vehicles}}</ix:nonFraction>)</span>
+                            {{if gt $cost.disposals.motor_vehicles 0.0}}({{end}}
+                            <ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.motor_vehicles}}</ix:nonFraction>
+                            {{if gt $cost.disposals.motor_vehicles 0.0}}){{end}}
                             {{end}}
                         </td>
                         <td id="tangible-cost-disposals-total" class="strong figure">
                             {{if isNotEmpty $cost.disposals.total}}
-                            <span class="debit">(<ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.total}}</ix:nonFraction>)</span>
+                            {{if gt $cost.disposals.total 0.0}}({{end}}
+                            <ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:DisposalsPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $cost.disposals.total}}</ix:nonFraction>
+                            {{if gt $cost.disposals.total 0.0}}){{end}}
                             {{end}}
                         </td>
                     </tr>
@@ -2150,32 +2162,44 @@
                         <td id="tangible-depreciation-on-disposals">On disposals</td>
                         <td id="tangible-depreciation-on-disposals-land-and-building" class="strong figure">
                             {{if isNotEmpty $depreciation.on_disposals.land_and_buildings}}
-                            <span class="debit">(<ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.land_and_buildings}}</ix:nonFraction>)</span>
+                            {{if gt $depreciation.on_disposals.land_and_buildings 0.0}}({{end}}
+                            <ix:nonFraction contextRef="LandAndBuildings_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.land_and_buildings}}</ix:nonFraction>
+                            {{if gt $depreciation.on_disposals.land_and_buildings 0.0}}){{end}}
                             {{end}}
                         </td>
                         <td id="tangible-depreciation-on-disposals-plant-and-machinery" class="strong figure">
                             {{if isNotEmpty $depreciation.on_disposals.plant_and_machinery}}
-                            <span class="debit">(<ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.plant_and_machinery}}</ix:nonFraction>)</span>
+                            {{if gt $depreciation.on_disposals.plant_and_machinery 0.0}}({{end}}
+                            <ix:nonFraction contextRef="PlantMachinery_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.plant_and_machinery}}</ix:nonFraction>
+                            {{if gt $depreciation.on_disposals.plant_and_machinery 0.0}}){{end}}
                             {{end}}
                         </td>
                         <td id="tangible-depreciation-on-disposals-fixtures-and-fitting" class="strong figure">
                             {{if isNotEmpty $depreciation.on_disposals.fixtures_and_fittings}}
-                            <span class="debit">(<ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.fixtures_and_fittings}}</ix:nonFraction>)</span>
+                            {{if gt $depreciation.on_disposals.fixtures_and_fittings 0.0}}({{end}}
+                            <ix:nonFraction contextRef="FurnitureFittingsToolsEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.fixtures_and_fittings}}</ix:nonFraction>
+                            {{if gt $depreciation.on_disposals.fixtures_and_fittings 0.0}}){{end}}
                             {{end}}
                         </td>
                         <td id="tangible-depreciation-on-disposals-office-equipment" class="strong figure">
                             {{if isNotEmpty $depreciation.on_disposals.office_equipment}}
-                            <span class="debit">(<ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.office_equipment}}</ix:nonFraction>)</span>
+                            {{if gt $depreciation.on_disposals.office_equipment 0.0}}({{end}}
+                            <ix:nonFraction contextRef="OfficeEquipment_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.office_equipment}}</ix:nonFraction>
+                            {{if gt $depreciation.on_disposals.office_equipment 0.0}}){{end}}
                             {{end}}
                         </td>
                         <td id="tangible-depreciation-on-disposals-motor-vehicles" class="strong figure">
                             {{if isNotEmpty $depreciation.on_disposals.motor_vehicles}}
-                            <span class="debit">(<ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.motor_vehicles}}</ix:nonFraction>)</span>
+                            {{if gt $depreciation.on_disposals.motor_vehicles 0.0}}({{end}}
+                            <ix:nonFraction contextRef="Vehicles_CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.motor_vehicles}}</ix:nonFraction>
+                            {{if gt $depreciation.on_disposals.motor_vehicles 0.0}}){{end}}
                             {{end}}
                         </td>
                         <td id="tangible-depreciation-on-disposals-total" class="strong figure">
                             {{if isNotEmpty $depreciation.on_disposals.total}}
-                            <span class="debit">(<ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.total}}</ix:nonFraction>)</span>
+                            {{if gt $depreciation.on_disposals.total 0.0}}({{end}}
+                            <ix:nonFraction contextRef="CY" decimals="0" unitRef="GBP" name="core:DisposalsDecreaseInDepreciationImpairmentPropertyPlantEquipment" format="ixt2:numdotdecimal">{{getMagnitudeFormatted $depreciation.on_disposals.total}}</ix:nonFraction>
+                            {{if gt $depreciation.on_disposals.total 0.0}}){{end}}
                             {{end}}
                         </td>
                     </tr>


### PR DESCRIPTION
Only display brackets around 'disposals' and 'on disposals' if values are greater than 0

Addresses bug SFA-1267

(Reliant on https://github.com/companieshouse/document-render-service/pull/80)