### PR TITLE
Scope the MessageDigest bean to the request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/ApplicationConfiguration.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.companieshouse.accountsdates.AccountsDatesHelper;
 import uk.gov.companieshouse.accountsdates.impl.AccountsDatesHelperImpl;
 import uk.gov.companieshouse.charset.validation.CharSetValidation;
@@ -22,6 +23,7 @@ import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
 public class ApplicationConfiguration {
 
     @Bean
+    @RequestScope
     public MessageDigest getMessageDigest() throws NoSuchAlgorithmException {
         return MessageDigest.getInstance(MessageDigestAlgorithms.SHA_256);
     }


### PR DESCRIPTION
Without this change, resource id's were being incorrectly generated for resources when executing concurrent requests, resulting in erroneous 404's being returned to the client.

Required for SFA-1270