### PR TITLE
Throw empty_resource error if empty note is submitted

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
@@ -53,11 +53,7 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
     public ResponseObject<CreditorsAfterOneYear> create(CreditorsAfterOneYear rest,
             Transaction transaction, String companyAccountId, HttpServletRequest request) throws DataException {
 
-        Errors errors = validator.validateIfEmptyResource(rest, request, companyAccountId);
-
-        if (!errors.hasErrors()) {
-            errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
-        }
+        Errors errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
 
         if (errors.hasErrors()) {
 
@@ -88,11 +84,7 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
     public ResponseObject<CreditorsAfterOneYear> update(CreditorsAfterOneYear rest,
             Transaction transaction, String companyAccountId, HttpServletRequest request) throws DataException {
 
-        Errors errors = validator.validateIfEmptyResource(rest, request, companyAccountId);
-
-        if (!errors.hasErrors()) {
-            errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
-        }
+        Errors errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
 
         if (errors.hasErrors()) {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
@@ -53,13 +53,17 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
     public ResponseObject<CreditorsAfterOneYear> create(CreditorsAfterOneYear rest,
             Transaction transaction, String companyAccountId, HttpServletRequest request) throws DataException {
 
-        Errors errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
+        Errors errors = validator.validateIfEmptyResource(rest, request, companyAccountId);
+
+        if (!errors.hasErrors()) {
+            errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
+        }
 
         if (errors.hasErrors()) {
 
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);
-        }
 
+        }
         setMetadataOnRestObject(rest, transaction, companyAccountId);
 
         CreditorsAfterOneYearEntity entity = transformer.transform(rest);
@@ -73,7 +77,8 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
             throw new DataException(e);
         }
 
-        smallFullService.addLink(companyAccountId, SmallFullLinkType.CREDITORS_AFTER_MORE_THAN_ONE_YEAR_NOTE,
+        smallFullService.addLink(companyAccountId,
+                SmallFullLinkType.CREDITORS_AFTER_MORE_THAN_ONE_YEAR_NOTE,
                 getSelfLinkFromCreditorsAfterOneYearEntity(entity), request);
 
         return new ResponseObject<>(ResponseStatus.CREATED, rest);
@@ -83,7 +88,11 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
     public ResponseObject<CreditorsAfterOneYear> update(CreditorsAfterOneYear rest,
             Transaction transaction, String companyAccountId, HttpServletRequest request) throws DataException {
 
-        Errors errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
+        Errors errors = validator.validateIfEmptyResource(rest, request, companyAccountId);
+
+        if (!errors.hasErrors()) {
+            errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
+        }
 
         if (errors.hasErrors()) {
 
@@ -133,7 +142,8 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
             if (repository.existsById(creditorsAfterOneYearId)) {
                 repository.deleteById(creditorsAfterOneYearId);
                 smallFullService
-                        .removeLink(companyAccountsId, SmallFullLinkType.CREDITORS_AFTER_MORE_THAN_ONE_YEAR_NOTE, request);
+                        .removeLink(companyAccountsId,
+                                SmallFullLinkType.CREDITORS_AFTER_MORE_THAN_ONE_YEAR_NOTE, request);
                 return new ResponseObject<>(ResponseStatus.UPDATED);
             } else {
                 return new ResponseObject<>(ResponseStatus.NOT_FOUND);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
@@ -53,13 +53,8 @@ public class CreditorsWithinOneYearService implements ResourceService<CreditorsW
             String companyAccountId,
             HttpServletRequest request) throws DataException {
 
+        Errors errors = validator.validateCreditorsWithinOneYear(rest, transaction, companyAccountId, request);
 
-        Errors errors = validator.validateIfEmptyResource(rest, request, companyAccountId);
-
-        if (!errors.hasErrors()) {
-
-            errors = validator.validateCreditorsWithinOneYear(rest, transaction, companyAccountId, request);
-        }
         if (errors.hasErrors()) {
 
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
@@ -53,8 +53,13 @@ public class CreditorsWithinOneYearService implements ResourceService<CreditorsW
             String companyAccountId,
             HttpServletRequest request) throws DataException {
 
-        Errors errors = validator.validateCreditorsWithinOneYear(rest, transaction, companyAccountId, request);
 
+        Errors errors = validator.validateIfEmptyResource(rest, request, companyAccountId);
+
+        if (!errors.hasErrors()) {
+
+            errors = validator.validateCreditorsWithinOneYear(rest, transaction, companyAccountId, request);
+        }
         if (errors.hasErrors()) {
 
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/BaseValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/BaseValidator.java
@@ -26,15 +26,15 @@ public class BaseValidator {
     protected String mandatoryElementMissing;
 
     @Value("${empty.resource}")
-    protected String emptyResource;
+    private String emptyResource;
 
     /**
      * Validate the given total is correctly aggregated
      *
-     * @param total
-     * @param expectedTotal
-     * @param location
-     * @param errors
+     * @param total actual total of the number fields
+     * @param expectedTotal expected total of the number fields
+     * @param location location json path location of the error
+     * @param errors errors errors object that holds any errors from submission
      */
     protected void validateAggregateTotal(Long total, Long expectedTotal, String location,
             Errors errors) {
@@ -50,9 +50,9 @@ public class BaseValidator {
     /**
      * Add an error for the given location
      *
-     * @param errors
-     * @param messageKey
-     * @param location
+     * @param errors errors errors object that holds any errors from submission
+     * @param messageKey relevent message key for the given error
+     * @param location location json path location of the error
      */
     protected void addError(Errors errors, String messageKey, String location) {
         errors.addError(new Error(messageKey, location, LocationType.JSON_PATH.getValue(),
@@ -62,8 +62,8 @@ public class BaseValidator {
     /**
      * Add an empty resource error for the given location
      *
-     * @param errors
-     * @param location
+     * @param errors errors object that holds any errors from submission
+     * @param location json path location of the error
      */
     public Errors addEmptyResourceError(Errors errors, String location) {
         addError(errors, emptyResource, location);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/BaseValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/BaseValidator.java
@@ -25,6 +25,9 @@ public class BaseValidator {
     @Value("${mandatory.element.missing}")
     protected String mandatoryElementMissing;
 
+    @Value("${empty.resource}")
+    protected String emptyResource;
+
     /**
      * Validate the given total is correctly aggregated
      *
@@ -34,12 +37,12 @@ public class BaseValidator {
      * @param errors
      */
     protected void validateAggregateTotal(Long total, Long expectedTotal, String location,
-        Errors errors) {
+            Errors errors) {
         if (expectedTotal == null) {
-            if (total != null && !total.equals(0L)) {
+            if (total != null && ! total.equals(0L)) {
                 addError(errors, incorrectTotal, location);
             }
-        } else if (total == null || !total.equals(expectedTotal)) {
+        } else if (total == null || ! total.equals(expectedTotal)) {
             addError(errors, incorrectTotal, location);
         }
     }
@@ -53,7 +56,19 @@ public class BaseValidator {
      */
     protected void addError(Errors errors, String messageKey, String location) {
         errors.addError(new Error(messageKey, location, LocationType.JSON_PATH.getValue(),
-            ErrorType.VALIDATION.getType()));
+                ErrorType.VALIDATION.getType()));
+    }
+
+    /**
+     * Add an empty resource error for the given location
+     *
+     * @param errors
+     * @param location
+     */
+    public Errors addEmptyResourceError(Errors errors, String location) {
+        addError(errors, emptyResource, location);
+
+        return errors;
     }
 }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
@@ -117,9 +117,6 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
 
             if (hasCurrentPeriodNoteData) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
-            }
-
-            if (hasCurrentPeriodNoteData && hasCurrentPeriodBalanceSheetNoteValue) {
                 crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet,
                         errors);
             }
@@ -158,9 +155,6 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
 
             if (hasPreviousPeriodNoteData) {
                 validatePreviousPeriodFields(previousPeriodNote, errors);
-            }
-
-            if (hasPreviousPeriodNoteData && hasPreviousPeriodBalanceSheetNoteValue) {
                 crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet,
                         errors);
             }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
@@ -37,11 +37,32 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
     private PreviousPeriodService previousPeriodService;
 
     @Autowired
-    public CreditorsAfterOneYearValidator(CompanyService companyService, CurrentPeriodService currentPeriodService,
+    public CreditorsAfterOneYearValidator(CompanyService companyService,
+            CurrentPeriodService currentPeriodService,
             PreviousPeriodService previousPeriodService) {
         this.companyService = companyService;
         this.currentPeriodService = currentPeriodService;
         this.previousPeriodService = previousPeriodService;
+    }
+
+    public Errors validateIfEmptyResource(CreditorsAfterOneYear creditorsAfterOneYear,
+            HttpServletRequest request, String companyAccountsId) throws DataException {
+
+        Errors errors = new Errors();
+
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
+
+        if ((currentPeriodBalanceSheet == null && previousPeriodBalanceSheet == null) &&
+                (creditorsAfterOneYear.getCurrentPeriod() == null &&
+                        creditorsAfterOneYear.getPreviousPeriod() == null)) {
+
+            addEmptyResourceError(errors, CREDITORS_AFTER_PATH);
+        }
+
+        return errors;
     }
 
     public Errors validateCreditorsAfterOneYear(@Valid CreditorsAfterOneYear creditorsAfterOneYear,
@@ -53,8 +74,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
 
         boolean isMultipleYearFiler = getIsMultipleYearFiler(transaction);
 
-        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request, companyAccountsId);
-        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request, companyAccountsId);
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
 
         CurrentPeriod currentPeriodNote = creditorsAfterOneYear.getCurrentPeriod();
         PreviousPeriod previousPeriodNote = creditorsAfterOneYear.getPreviousPeriod();
@@ -70,26 +93,31 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
         return errors;
     }
 
-    private void validateCurrentPeriod(CurrentPeriod currentPeriodNote, BalanceSheet currentPeriodBalanceSheet, Errors errors) {
+    private void validateCurrentPeriod(CurrentPeriod currentPeriodNote,
+            BalanceSheet currentPeriodBalanceSheet, Errors errors) {
 
         boolean hasCurrentPeriodBalanceSheet = currentPeriodBalanceSheet != null;
-        boolean hasCurrentPeriodBalanceSheetNoteValue = !isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet);
+        boolean hasCurrentPeriodBalanceSheetNoteValue =
+                ! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet);
         boolean hasCurrentPeriodNoteData = currentPeriodNote != null;
 
-        if (!hasCurrentPeriodBalanceSheetNoteValue && hasCurrentPeriodNoteData) {
+        if (! hasCurrentPeriodBalanceSheetNoteValue && hasCurrentPeriodNoteData) {
 
-            if (validateNoUnexpectedDataPresent(hasCurrentPeriodBalanceSheet, CREDITORS_AFTER_CURRENT_PERIOD_PATH, errors)) {
+            if (validateNoUnexpectedDataPresent(hasCurrentPeriodBalanceSheet,
+                    CREDITORS_AFTER_CURRENT_PERIOD_PATH, errors)) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
             }
 
-        } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue, hasCurrentPeriodNoteData, errors)) {
+        } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue,
+                hasCurrentPeriodNoteData, errors)) {
 
             if (hasCurrentPeriodNoteData) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
             }
 
             if (hasCurrentPeriodNoteData && hasCurrentPeriodBalanceSheetNoteValue) {
-                crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet, errors);
+                crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet,
+                        errors);
             }
         }
     }
@@ -106,26 +134,31 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
         return true;
     }
 
-    private void validatePreviousPeriod(PreviousPeriod previousPeriodNote, BalanceSheet previousPeriodBalanceSheet, Errors errors) {
+    private void validatePreviousPeriod(PreviousPeriod previousPeriodNote,
+            BalanceSheet previousPeriodBalanceSheet, Errors errors) {
 
         boolean hasPreviousPeriodBalanceSheet = previousPeriodBalanceSheet != null;
-        boolean hasPreviousPeriodBalanceSheetNoteValue = !isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet);
+        boolean hasPreviousPeriodBalanceSheetNoteValue =
+                ! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet);
         boolean hasPreviousPeriodNoteData = previousPeriodNote != null;
 
-        if (!hasPreviousPeriodBalanceSheetNoteValue && hasPreviousPeriodNoteData) {
+        if (! hasPreviousPeriodBalanceSheetNoteValue && hasPreviousPeriodNoteData) {
 
-            if (validateNoUnexpectedDataPresent(hasPreviousPeriodBalanceSheet, CREDITORS_AFTER_PREVIOUS_PERIOD_PATH, errors)) {
+            if (validateNoUnexpectedDataPresent(hasPreviousPeriodBalanceSheet,
+                    CREDITORS_AFTER_PREVIOUS_PERIOD_PATH, errors)) {
                 validatePreviousPeriodFields(previousPeriodNote, errors);
             }
 
-        } else if (validatePreviousPeriodExists(hasPreviousPeriodBalanceSheetNoteValue, hasPreviousPeriodNoteData, errors)) {
+        } else if (validatePreviousPeriodExists(hasPreviousPeriodBalanceSheetNoteValue,
+                hasPreviousPeriodNoteData, errors)) {
 
             if (hasPreviousPeriodNoteData) {
                 validatePreviousPeriodFields(previousPeriodNote, errors);
             }
 
             if (hasPreviousPeriodNoteData && hasPreviousPeriodBalanceSheetNoteValue) {
-                crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet, errors);
+                crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet,
+                        errors);
             }
         }
     }
@@ -177,10 +210,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             boolean hasCurrentPeriodNoteData,
             Errors errors) {
 
-        if (hasCurrentPeriodBalanceSheetValue && !hasCurrentPeriodNoteData) {
+        if (hasCurrentPeriodBalanceSheetValue && ! hasCurrentPeriodNoteData) {
             addError(errors, mandatoryElementMissing, CREDITORS_AFTER_CURRENT_PERIOD_PATH);
             return false;
-        } else if (!hasCurrentPeriodBalanceSheetValue && hasCurrentPeriodNoteData) {
+        } else if (! hasCurrentPeriodBalanceSheetValue && hasCurrentPeriodNoteData) {
             addError(errors, unexpectedData, CREDITORS_AFTER_CURRENT_PERIOD_PATH);
             return false;
         }
@@ -192,10 +225,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             boolean hasPreviousPeriodNoteData,
             Errors errors) {
 
-        if (hasPreviousPeriodBalanceSheetValue && !hasPreviousPeriodNoteData) {
+        if (hasPreviousPeriodBalanceSheetValue && ! hasPreviousPeriodNoteData) {
             addError(errors, mandatoryElementMissing, CREDITORS_AFTER_PREVIOUS_PERIOD_PATH);
             return false;
-        } else if (!hasPreviousPeriodBalanceSheetValue && hasPreviousPeriodNoteData) {
+        } else if (! hasPreviousPeriodBalanceSheetValue && hasPreviousPeriodNoteData) {
             addError(errors, unexpectedData, CREDITORS_AFTER_PREVIOUS_PERIOD_PATH);
             return false;
         }
@@ -234,11 +267,15 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             String companyAccountsId,
             Errors errors) throws DataException {
 
-        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request, companyAccountsId);
-        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request, companyAccountsId);
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
 
-        crossValidateCurrentPeriodFields(creditorsAfterOneYear.getCurrentPeriod(), currentPeriodBalanceSheet, errors);
-        crossValidatePreviousPeriodFields(creditorsAfterOneYear.getPreviousPeriod(), previousPeriodBalanceSheet, errors);
+        crossValidateCurrentPeriodFields(creditorsAfterOneYear.getCurrentPeriod(),
+                currentPeriodBalanceSheet, errors);
+        crossValidatePreviousPeriodFields(creditorsAfterOneYear.getPreviousPeriod(),
+                previousPeriodBalanceSheet, errors);
 
         return errors;
     }
@@ -247,22 +284,26 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             BalanceSheet previousPeriodBalanceSheet,
             Errors errors) {
 
-        checkIfPreviousNoteIsNullAndBalanceNot(previousPeriodNote, previousPeriodBalanceSheet, errors);
-        checkIsPreviousBalanceNullAndNoteNot(previousPeriodNote, previousPeriodBalanceSheet, errors);
-        checkIfPreviousBalanceAndNoteValuesAreEqual(previousPeriodNote, previousPeriodBalanceSheet, errors);
+        checkIfPreviousNoteIsNullAndBalanceNot(previousPeriodNote, previousPeriodBalanceSheet,
+                errors);
+        checkIsPreviousBalanceNullAndNoteNot(previousPeriodNote, previousPeriodBalanceSheet,
+                errors);
+        checkIfPreviousBalanceAndNoteValuesAreEqual(previousPeriodNote,
+                previousPeriodBalanceSheet, errors);
     }
 
     private void checkIfPreviousBalanceAndNoteValuesAreEqual(PreviousPeriod previousPeriodNote,
             BalanceSheet previousPeriodBalanceSheet,
             Errors errors) {
 
-        if (!isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet) &&
-                (!isPreviousPeriodNoteDataNull(previousPeriodNote))
-                && (!previousPeriodNote.getTotal().equals(
+        if (! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet) &&
+                (! isPreviousPeriodNoteDataNull(previousPeriodNote))
+                && (! previousPeriodNote.getTotal().equals(
                 previousPeriodBalanceSheet.getOtherLiabilitiesOrAssets()
                         .getCreditorsAfterOneYear()))) {
 
-            addError(errors, previousBalanceSheetNotEqual, CREDITORS_AFTER_PREVIOUS_PERIOD_TOTAL_PATH);
+            addError(errors, previousBalanceSheetNotEqual,
+                    CREDITORS_AFTER_PREVIOUS_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -271,9 +312,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             Errors errors) {
 
         if (isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet) &&
-                (!isPreviousPeriodNoteDataNull(previousPeriodNote))) {
+                (! isPreviousPeriodNoteDataNull(previousPeriodNote))) {
 
-            addError(errors, previousBalanceSheetNotEqual, CREDITORS_AFTER_PREVIOUS_PERIOD_TOTAL_PATH);
+            addError(errors, previousBalanceSheetNotEqual,
+                    CREDITORS_AFTER_PREVIOUS_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -282,9 +324,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             Errors errors) {
 
         if (isPreviousPeriodNoteDataNull(previousPeriodNote) &&
-                (!isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet))) {
+                (! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet))) {
 
-            addError(errors, previousBalanceSheetNotEqual, CREDITORS_AFTER_PREVIOUS_PERIOD_TOTAL_PATH);
+            addError(errors, previousBalanceSheetNotEqual,
+                    CREDITORS_AFTER_PREVIOUS_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -307,21 +350,25 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             BalanceSheet currentPeriodBalanceSheet,
             Errors errors) {
 
-        checkIfCurrentNoteIsNullAndBalanceSheetNot(currentPeriodCreditors, currentPeriodBalanceSheet, errors);
-        checkIfCurrentBalanceSheetIsNullAndNoteNot(currentPeriodCreditors, currentPeriodBalanceSheet, errors);
-        checkIfCurrentBalanceAndNoteValuesAreEqual(currentPeriodCreditors, currentPeriodBalanceSheet, errors);
+        checkIfCurrentNoteIsNullAndBalanceSheetNot(currentPeriodCreditors,
+                currentPeriodBalanceSheet, errors);
+        checkIfCurrentBalanceSheetIsNullAndNoteNot(currentPeriodCreditors,
+                currentPeriodBalanceSheet, errors);
+        checkIfCurrentBalanceAndNoteValuesAreEqual(currentPeriodCreditors,
+                currentPeriodBalanceSheet, errors);
     }
 
     private void checkIfCurrentBalanceAndNoteValuesAreEqual(CurrentPeriod currentPeriodNote,
             BalanceSheet currentPeriodBalanceSheet,
             Errors errors) {
 
-        if (!isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)
-                && !isCurrentPeriodNoteDataNull(currentPeriodNote)
-                && !(currentPeriodNote.getTotal().equals(currentPeriodBalanceSheet.getOtherLiabilitiesOrAssets()
+        if (! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)
+                && ! isCurrentPeriodNoteDataNull(currentPeriodNote)
+                && ! (currentPeriodNote.getTotal().equals(currentPeriodBalanceSheet.getOtherLiabilitiesOrAssets()
                 .getCreditorsAfterOneYear()))) {
 
-            addError(errors, currentBalanceSheetNotEqual, CREDITORS_AFTER_CURRENT_PERIOD_TOTAL_PATH);
+            addError(errors, currentBalanceSheetNotEqual,
+                    CREDITORS_AFTER_CURRENT_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -330,9 +377,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             Errors errors) {
 
         if (isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet) &&
-                !isCurrentPeriodNoteDataNull(currentPeriodNote)) {
+                ! isCurrentPeriodNoteDataNull(currentPeriodNote)) {
 
-            addError(errors, currentBalanceSheetNotEqual, CREDITORS_AFTER_CURRENT_PERIOD_TOTAL_PATH);
+            addError(errors, currentBalanceSheetNotEqual,
+                    CREDITORS_AFTER_CURRENT_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -341,9 +389,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             Errors errors) {
 
         if (isCurrentPeriodNoteDataNull(currentPeriodNote) &&
-                !isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)) {
+                ! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)) {
 
-            addError(errors, currentBalanceSheetNotEqual, CREDITORS_AFTER_CURRENT_PERIOD_TOTAL_PATH);
+            addError(errors, currentBalanceSheetNotEqual,
+                    CREDITORS_AFTER_CURRENT_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -365,8 +414,8 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
 
     private boolean isCurrentPeriodNoteDataNull(CurrentPeriod currentPeriodCreditors) {
 
-        return !Optional.ofNullable(currentPeriodCreditors)
-                .map(CurrentPeriod::getTotal)
+        return ! Optional.ofNullable(currentPeriodCreditors)
+                .map(CurrentPeriod :: getTotal)
                 .isPresent();
 
     }
@@ -374,9 +423,9 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
     private boolean isCurrentPeriodBalanceSheetDataNull(
             BalanceSheet currentPeriodBalanceSheet) {
 
-        return !Optional.ofNullable(currentPeriodBalanceSheet)
-                .map(BalanceSheet::getOtherLiabilitiesOrAssets)
-                .map(OtherLiabilitiesOrAssets ::getCreditorsAfterOneYear)
+        return ! Optional.ofNullable(currentPeriodBalanceSheet)
+                .map(BalanceSheet :: getOtherLiabilitiesOrAssets)
+                .map(OtherLiabilitiesOrAssets :: getCreditorsAfterOneYear)
                 .isPresent();
 
     }
@@ -384,16 +433,16 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
     private boolean isPreviousPeriodBalanceSheetDataNull(
             BalanceSheet previousPeriodBalanceSheet) {
 
-        return !Optional.ofNullable(previousPeriodBalanceSheet)
-                .map(BalanceSheet::getOtherLiabilitiesOrAssets)
-                .map(OtherLiabilitiesOrAssets::getCreditorsAfterOneYear)
+        return ! Optional.ofNullable(previousPeriodBalanceSheet)
+                .map(BalanceSheet :: getOtherLiabilitiesOrAssets)
+                .map(OtherLiabilitiesOrAssets :: getCreditorsAfterOneYear)
                 .isPresent();
     }
 
     private boolean isPreviousPeriodNoteDataNull(PreviousPeriod previousPeriodNote) {
 
-        return !Optional.ofNullable(previousPeriodNote)
-                .map(PreviousPeriod::getTotal)
+        return ! Optional.ofNullable(previousPeriodNote)
+                .map(PreviousPeriod :: getTotal)
                 .isPresent();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
@@ -45,7 +45,7 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
         this.previousPeriodService = previousPeriodService;
     }
 
-    public Errors validateIfEmptyResource(CreditorsAfterOneYear creditorsAfterOneYear,
+    private Errors validateIfEmptyResource(CreditorsAfterOneYear creditorsAfterOneYear,
             HttpServletRequest request, String companyAccountsId) throws DataException {
 
         Errors errors = new Errors();
@@ -70,7 +70,11 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             String companyAccountsId,
             HttpServletRequest request) throws DataException {
 
-        Errors errors = new Errors();
+        Errors errors = validateIfEmptyResource( creditorsAfterOneYear, request,  companyAccountsId);
+
+        if (errors.hasErrors()) {
+            return errors;
+        }
 
         boolean isMultipleYearFiler = getIsMultipleYearFiler(transaction);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -45,6 +45,26 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
         this.previousPeriodService = previousPeriodService;
     }
 
+    public Errors validateIfEmptyResource(CreditorsWithinOneYear creditorsWithinOneYear,
+            HttpServletRequest request, String companyAccountsId) throws DataException {
+
+        Errors errors = new Errors();
+
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
+
+        if ((currentPeriodBalanceSheet == null && previousPeriodBalanceSheet == null) &&
+                (creditorsWithinOneYear.getCurrentPeriod() == null &&
+                        creditorsWithinOneYear.getPreviousPeriod() == null)) {
+
+            addEmptyResourceError(errors, CREDITORS_WITHIN_PATH);
+        }
+
+        return errors;
+    }
+
     public Errors validateCreditorsWithinOneYear(@Valid CreditorsWithinOneYear creditorsWithinOneYear,
                                                  Transaction transaction,
                                                  String companyAccountsId,

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -45,26 +45,6 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
         this.previousPeriodService = previousPeriodService;
     }
 
-    public Errors validateIfEmptyResource(CreditorsWithinOneYear creditorsWithinOneYear,
-            HttpServletRequest request, String companyAccountsId) throws DataException {
-
-        Errors errors = new Errors();
-
-        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
-                companyAccountsId);
-        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
-                companyAccountsId);
-
-        if ((currentPeriodBalanceSheet == null && previousPeriodBalanceSheet == null) &&
-                (creditorsWithinOneYear.getCurrentPeriod() == null &&
-                        creditorsWithinOneYear.getPreviousPeriod() == null)) {
-
-            addEmptyResourceError(errors, CREDITORS_WITHIN_PATH);
-        }
-
-        return errors;
-    }
-
     public Errors validateCreditorsWithinOneYear(@Valid CreditorsWithinOneYear creditorsWithinOneYear,
                                                  Transaction transaction,
                                                  String companyAccountsId,

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -87,9 +87,6 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
 
             if (hasCurrentPeriodNoteData) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
-            }
-
-            if (hasCurrentPeriodNoteData && hasCurrentPeriodBalanceSheetNoteValue) {
                 crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet, errors);
             }
         }
@@ -123,9 +120,6 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
 
             if (hasPreviousPeriodNoteData) {
                 validatePreviousPeriodFields(previousPeriodNote, errors);
-            }
-
-            if (hasPreviousPeriodNoteData && hasPreviousPeriodBalanceSheetNoteValue) {
                 crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet, errors);
             }
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -83,9 +83,6 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
 
             if (hasCurrentPeriodNoteData) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
-            }
-
-            if (hasCurrentPeriodNoteData && hasCurrentPeriodBalanceSheetNoteValue) {
                 crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet, errors);
             }
         }
@@ -107,9 +104,6 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
 
             if (hasPreviousPeriodNoteData) {
                 validatePreviousPeriodFields(previousPeriodNote, errors);
-            }
-
-            if (hasPreviousPeriodNoteData && hasPreviousPeriodBalanceSheetNoteValue) {
                 crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet, errors);
             }
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/StocksValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/StocksValidator.java
@@ -87,9 +87,6 @@ public class StocksValidator extends BaseValidator implements CrossValidator<Sto
 
             if (hasCurrentPeriodNoteData) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
-            }
-
-            if (hasCurrentPeriodNoteData && hasCurrentPeriodBalanceSheetNoteValue) {
                 crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet, errors);
             }
         }
@@ -123,9 +120,6 @@ public class StocksValidator extends BaseValidator implements CrossValidator<Sto
 
             if (hasPreviousPeriodNoteData) {
                 validatePreviousPeriodFields(previousPeriodNote, errors);
-            }
-
-            if (hasPreviousPeriodNoteData && hasPreviousPeriodBalanceSheetNoteValue) {
                 crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet, errors);
             }
         }

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -17,3 +17,4 @@ current.balancesheet.not.equal=value_not_equal_to_current_period_on_balance_shee
 previous.balancesheet.not.equal=value_not_equal_to_previous_period_on_balance_sheet
 unexpected.data=unexpected_data
 value.required=value_required
+empty.resource=empty_resource

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearServiceTest.java
@@ -1,6 +1,24 @@
 package uk.gov.companieshouse.api.accounts.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.mongodb.MongoException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,33 +43,12 @@ import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.repository.CreditorsAfterOneYearRepository;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.CreditorsAfterOneYearTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
-
 import uk.gov.companieshouse.api.accounts.validation.CreditorsAfterOneYearValidator;
 import uk.gov.companieshouse.api.accounts.validation.ErrorType;
 import uk.gov.companieshouse.api.accounts.validation.LocationType;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 
 @ExtendWith(MockitoExtension.class)
@@ -121,6 +118,7 @@ public class CreditorsAfterOneYearServiceTest {
         Errors errors = new Errors();
         errors.addError(new Error("test.message.key", "location",
             LocationType.JSON_PATH.getValue(), ErrorType.VALIDATION.getType()));
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(new Errors());
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -133,11 +131,29 @@ public class CreditorsAfterOneYearServiceTest {
     }
 
     @Test
+    @DisplayName("Tests for validation error with empty note resource")
+    void validationErrorWhenEmptyresourceSubmitted() throws DataException {
+
+        Errors errors = new Errors();
+        errors.addError(new Error("test.message.key", "location",
+                LocationType.JSON_PATH.getValue(), ErrorType.VALIDATION.getType()));
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
+
+        ResponseObject<CreditorsAfterOneYear> result = mockCreditorsAfterOneYearService
+                .create(mockCreditorsAfterOneYear, mockTransaction, "", mockRequest);
+
+        assertEquals(ResponseStatus.VALIDATION_ERROR, result.getStatus());
+        verify(mockSmallFullService, times(0)).addLink(anyString(),
+                any(SmallFullLinkType.class), anyString(), any(HttpServletRequest.class));
+    }
+
+    @Test
     @DisplayName("Tests the successful creation of a creditors after one year resource")
     void canCreateCreditorsAfterOneYear() throws DataException {
 
         Errors errors = new Errors();
 
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -163,6 +179,7 @@ public class CreditorsAfterOneYearServiceTest {
 
         Errors errors = new Errors();
 
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -187,6 +204,8 @@ public class CreditorsAfterOneYearServiceTest {
     void createCreditorsAfterOneYearMongoExceptionFailure() throws DataException {
 
         Errors errors = new Errors();
+
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
 
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
@@ -250,6 +269,8 @@ public class CreditorsAfterOneYearServiceTest {
 
         Errors errors = new Errors();
 
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
+
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -270,6 +291,8 @@ public class CreditorsAfterOneYearServiceTest {
     void updateCreditorsAfterOneYearMongoExceptionFailure() throws DataException {
 
         Errors errors = new Errors();
+
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
 
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearServiceTest.java
@@ -118,7 +118,7 @@ public class CreditorsAfterOneYearServiceTest {
         Errors errors = new Errors();
         errors.addError(new Error("test.message.key", "location",
             LocationType.JSON_PATH.getValue(), ErrorType.VALIDATION.getType()));
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(new Errors());
+
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -131,29 +131,11 @@ public class CreditorsAfterOneYearServiceTest {
     }
 
     @Test
-    @DisplayName("Tests for validation error with empty note resource")
-    void validationErrorWhenEmptyresourceSubmitted() throws DataException {
-
-        Errors errors = new Errors();
-        errors.addError(new Error("test.message.key", "location",
-                LocationType.JSON_PATH.getValue(), ErrorType.VALIDATION.getType()));
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
-
-        ResponseObject<CreditorsAfterOneYear> result = mockCreditorsAfterOneYearService
-                .create(mockCreditorsAfterOneYear, mockTransaction, "", mockRequest);
-
-        assertEquals(ResponseStatus.VALIDATION_ERROR, result.getStatus());
-        verify(mockSmallFullService, times(0)).addLink(anyString(),
-                any(SmallFullLinkType.class), anyString(), any(HttpServletRequest.class));
-    }
-
-    @Test
     @DisplayName("Tests the successful creation of a creditors after one year resource")
     void canCreateCreditorsAfterOneYear() throws DataException {
 
         Errors errors = new Errors();
 
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -179,7 +161,6 @@ public class CreditorsAfterOneYearServiceTest {
 
         Errors errors = new Errors();
 
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -204,8 +185,6 @@ public class CreditorsAfterOneYearServiceTest {
     void createCreditorsAfterOneYearMongoExceptionFailure() throws DataException {
 
         Errors errors = new Errors();
-
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
 
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
@@ -269,8 +248,6 @@ public class CreditorsAfterOneYearServiceTest {
 
         Errors errors = new Errors();
 
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
-
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -291,8 +268,6 @@ public class CreditorsAfterOneYearServiceTest {
     void updateCreditorsAfterOneYearMongoExceptionFailure() throws DataException {
 
         Errors errors = new Errors();
-
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
 
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidatorTest.java
@@ -110,6 +110,21 @@ public class CreditorsAfterOneYearValidatorTest {
     }
 
     @Test
+    @DisplayName("Validation fails when empty periods and empty note resource")
+    void testValidationAgainstEmptyResource() throws DataException {
+
+        CreditorsAfterOneYear creditorsAfterOneYear = new CreditorsAfterOneYear();
+
+        ReflectionTestUtils.setField(validator, EMPTY_RESOURCE_NAME,
+                EMPTY_RESOURCE_VALUE);
+
+        errors = validator.validateCreditorsAfterOneYear(creditorsAfterOneYear, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
+
+        assertTrue(errors.containsError(createError(EMPTY_RESOURCE_VALUE,
+                CREDITORS_AFTER_PATH)));
+    }
+
+    @Test
     @DisplayName("Note validation and cross validation passes with valid note for multiple year filer")
     void testSuccessfulMultipleYearNoteValidationAndCrossValidation() throws ServiceException, DataException {
 
@@ -368,6 +383,11 @@ public class CreditorsAfterOneYearValidatorTest {
     @DisplayName("Data exception thrown when company service API call fails")
     void testDataExceptionThrown() throws ServiceException {
 
+        Errors errors = new Errors();
+
+        createValidNoteCurrentPeriod();
+        createValidNotePreviousPeriod();
+
         when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenThrow(mockServiceException);
 
         assertThrows(DataException.class,
@@ -406,28 +426,9 @@ public class CreditorsAfterOneYearValidatorTest {
                 COMPANY_ACCOUNTS_ID);
         when(mockPreviousPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
-        when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(true);
-
         assertThrows(DataException.class,
                 () -> validator.validateCreditorsAfterOneYear(creditorsAfterOneYear,
                         mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest));
-    }
-
-    @Test
-    @DisplayName("Empty resource error thrown when periods and note resources are empty")
-    void testErrorThrownWhenEmptyResourceSubmitted() throws DataException {
-
-        CreditorsAfterOneYear creditorsAfterOneYear = new CreditorsAfterOneYear();
-
-        ReflectionTestUtils.setField(validator, EMPTY_RESOURCE_NAME,
-                EMPTY_RESOURCE_VALUE);
-
-        errors = validator.validateIfEmptyResource(creditorsAfterOneYear, mockRequest, "");
-
-        assertTrue(errors.hasErrors());
-        assertTrue(errors.containsError(createError(EMPTY_RESOURCE_VALUE,
-                CREDITORS_AFTER_PATH)));
-
     }
 
     private void createValidNoteCurrentPeriod() {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidatorTest.java
@@ -55,6 +55,9 @@ public class CreditorsAfterOneYearValidatorTest {
     private static final String MANDATORY_ELEMENT_MISSING_NAME = "mandatoryElementMissing";
     private static final String MANDATORY_ELEMENT_MISSING_VALUE =
             "mandatory_element_missing";
+    private static final String EMPTY_RESOURCE_NAME = "emptyResource";
+    private static final String EMPTY_RESOURCE_VALUE =
+            "empty_resource";
     private static final String UNEXPECTED_DATA_NAME = "unexpectedData";
     private static final String UNEXPECTED_DATA_VALUE = "unexpected.data";
 
@@ -408,6 +411,23 @@ public class CreditorsAfterOneYearValidatorTest {
         assertThrows(DataException.class,
                 () -> validator.validateCreditorsAfterOneYear(creditorsAfterOneYear,
                         mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest));
+    }
+
+    @Test
+    @DisplayName("Empty resource error thrown when periods and note resources are empty")
+    void testErrorThrownWhenEmptyResourceSubmitted() throws DataException {
+
+        CreditorsAfterOneYear creditorsAfterOneYear = new CreditorsAfterOneYear();
+
+        ReflectionTestUtils.setField(validator, EMPTY_RESOURCE_NAME,
+                EMPTY_RESOURCE_VALUE);
+
+        errors = validator.validateIfEmptyResource(creditorsAfterOneYear, mockRequest, "");
+
+        assertTrue(errors.hasErrors());
+        assertTrue(errors.containsError(createError(EMPTY_RESOURCE_VALUE,
+                CREDITORS_AFTER_PATH)));
+
     }
 
     private void createValidNoteCurrentPeriod() {


### PR DESCRIPTION
If creditors-after note resource and current/previous period is empty, throw 'empty-resource' error, otherwise continue with note validation.

Other notes to follow.

Add validateIfEmptyResource method to validator
Call new method from creditors-after service
Add addEmptyResourceError to base validator to use by other notes
Add new error to message.properties file
Update unit tests

SFA-1194