### PR TITLE
Feature/privilged api pass through tokens

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
@@ -52,12 +52,6 @@ public class TransactionInterceptor extends HandlerInterceptorAdapter {
             String transactionId = pathVariables.get("transactionId");
             String passthroughHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
 
-            debugMap.put("header_eric_access_token", passthroughHeader);
-            debugMap.put("header_eric_access_key_roles", request.getHeader("ERIC-Authorised-Key-Roles"));
-            debugMap.put("header_eric_identity_type", request.getHeader("ERIC-Identity-Type"));
-            debugMap.put("header_eric_identity", request.getHeader("ERIC-Identity"));
-            LOGGER.infoRequest(request, "TxInterceptor Debug Headers", debugMap);
-
             ApiClient apiClient;
             try {
                 apiClient = apiClientService.getApiClient(passthroughHeader);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptor.java
@@ -14,7 +14,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
-import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
 import uk.gov.companieshouse.api.accounts.sdk.ApiClientService;
@@ -52,9 +52,15 @@ public class TransactionInterceptor extends HandlerInterceptorAdapter {
             String transactionId = pathVariables.get("transactionId");
             String passthroughHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
 
-            InternalApiClient apiClient;
+            debugMap.put("header_eric_access_token", passthroughHeader);
+            debugMap.put("header_eric_access_key_roles", request.getHeader("ERIC-Authorised-Key-Roles"));
+            debugMap.put("header_eric_identity_type", request.getHeader("ERIC-Identity-Type"));
+            debugMap.put("header_eric_identity", request.getHeader("ERIC-Identity"));
+            LOGGER.infoRequest(request, "TxInterceptor Debug Headers", debugMap);
+
+            ApiClient apiClient;
             try {
-                apiClient = apiClientService.getInternalApiClient(passthroughHeader);
+                apiClient = apiClientService.getApiClient(passthroughHeader);
             } catch (IOException e) {
 
                 LOGGER.errorRequest(request, e, debugMap);
@@ -64,7 +70,7 @@ public class TransactionInterceptor extends HandlerInterceptorAdapter {
 
             Transaction transaction;
             try {
-                transaction = apiClient.privateTransaction().get("/private/transactions/" + transactionId).execute();
+                transaction = apiClient.transactions().get("/transactions/" + transactionId).execute();
             } catch (ApiErrorResponseException e) {
 
                 LOGGER.errorRequest(request, e, debugMap);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
@@ -19,11 +19,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.servlet.HandlerMapping;
+import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.accounts.sdk.ApiClientService;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.handler.privatetransaction.PrivateTransactionResourceHandler;
 import uk.gov.companieshouse.api.handler.privatetransaction.request.PrivateTransactionGet;
+import uk.gov.companieshouse.api.handler.transaction.TransactionsResourceHandler;
+import uk.gov.companieshouse.api.handler.transaction.request.TransactionsGet;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,13 +40,13 @@ public class TransactionInterceptorTest {
     private ApiClientService apiClientServiceMock;
 
     @Mock
-    private InternalApiClient internalApiClientMock;
+    private ApiClient apiClientMock;
 
     @Mock
-    private PrivateTransactionResourceHandler transactionResourceHandlerMock;
+    private TransactionsResourceHandler transactionResourceHandlerMock;
 
     @Mock
-    private PrivateTransactionGet transactionGetMock;
+    private TransactionsGet transactionGetMock;
 
     @Mock
     private HttpServletRequest httpServletRequestMock;
@@ -62,8 +65,8 @@ public class TransactionInterceptorTest {
 
         httpServletResponseMock.setContentType("text/html");
 
-        when(apiClientServiceMock.getInternalApiClient(anyString())).thenReturn(internalApiClientMock);
-        when(internalApiClientMock.privateTransaction()).thenReturn(transactionResourceHandlerMock);
+        when(apiClientServiceMock.getApiClient(anyString())).thenReturn(apiClientMock);
+        when(apiClientMock.transactions()).thenReturn(transactionResourceHandlerMock);
         when(transactionResourceHandlerMock.get(anyString())).thenReturn(transactionGetMock);
         when(transactionGetMock.execute()).thenReturn(new Transaction());
     }


### PR DESCRIPTION
Switch transaction interceptor back to public sdk using public transactions endpoint with `ERIC-Access-Token` value passed through as authentication credentials.

Requires https://github.com/companieshouse/eric/pull/79 to allow API Key auth to be passed through via this eric header and grant privileged access to internal API keys.