### PR TITLE
Validate an empty note submission

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
@@ -53,11 +53,7 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
     public ResponseObject<CreditorsAfterOneYear> create(CreditorsAfterOneYear rest,
             Transaction transaction, String companyAccountId, HttpServletRequest request) throws DataException {
 
-        Errors errors = validator.validateIfEmptyResource(rest, request, companyAccountId);
-
-        if (!errors.hasErrors()) {
-            errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
-        }
+        Errors errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
 
         if (errors.hasErrors()) {
 
@@ -88,11 +84,7 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
     public ResponseObject<CreditorsAfterOneYear> update(CreditorsAfterOneYear rest,
             Transaction transaction, String companyAccountId, HttpServletRequest request) throws DataException {
 
-        Errors errors = validator.validateIfEmptyResource(rest, request, companyAccountId);
-
-        if (!errors.hasErrors()) {
-            errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
-        }
+        Errors errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
 
         if (errors.hasErrors()) {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
@@ -53,13 +53,17 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
     public ResponseObject<CreditorsAfterOneYear> create(CreditorsAfterOneYear rest,
             Transaction transaction, String companyAccountId, HttpServletRequest request) throws DataException {
 
-        Errors errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
+        Errors errors = validator.validateIfEmptyResource(rest, request, companyAccountId);
+
+        if (!errors.hasErrors()) {
+            errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
+        }
 
         if (errors.hasErrors()) {
 
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);
-        }
 
+        }
         setMetadataOnRestObject(rest, transaction, companyAccountId);
 
         CreditorsAfterOneYearEntity entity = transformer.transform(rest);
@@ -73,7 +77,8 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
             throw new DataException(e);
         }
 
-        smallFullService.addLink(companyAccountId, SmallFullLinkType.CREDITORS_AFTER_MORE_THAN_ONE_YEAR_NOTE,
+        smallFullService.addLink(companyAccountId,
+                SmallFullLinkType.CREDITORS_AFTER_MORE_THAN_ONE_YEAR_NOTE,
                 getSelfLinkFromCreditorsAfterOneYearEntity(entity), request);
 
         return new ResponseObject<>(ResponseStatus.CREATED, rest);
@@ -83,7 +88,11 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
     public ResponseObject<CreditorsAfterOneYear> update(CreditorsAfterOneYear rest,
             Transaction transaction, String companyAccountId, HttpServletRequest request) throws DataException {
 
-        Errors errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
+        Errors errors = validator.validateIfEmptyResource(rest, request, companyAccountId);
+
+        if (!errors.hasErrors()) {
+            errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
+        }
 
         if (errors.hasErrors()) {
 
@@ -133,7 +142,8 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
             if (repository.existsById(creditorsAfterOneYearId)) {
                 repository.deleteById(creditorsAfterOneYearId);
                 smallFullService
-                        .removeLink(companyAccountsId, SmallFullLinkType.CREDITORS_AFTER_MORE_THAN_ONE_YEAR_NOTE, request);
+                        .removeLink(companyAccountsId,
+                                SmallFullLinkType.CREDITORS_AFTER_MORE_THAN_ONE_YEAR_NOTE, request);
                 return new ResponseObject<>(ResponseStatus.UPDATED);
             } else {
                 return new ResponseObject<>(ResponseStatus.NOT_FOUND);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
@@ -53,13 +53,8 @@ public class CreditorsWithinOneYearService implements ResourceService<CreditorsW
             String companyAccountId,
             HttpServletRequest request) throws DataException {
 
+        Errors errors = validator.validateCreditorsWithinOneYear(rest, transaction, companyAccountId, request);
 
-        Errors errors = validator.validateIfEmptyResource(rest, request, companyAccountId);
-
-        if (!errors.hasErrors()) {
-
-            errors = validator.validateCreditorsWithinOneYear(rest, transaction, companyAccountId, request);
-        }
         if (errors.hasErrors()) {
 
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
@@ -53,8 +53,13 @@ public class CreditorsWithinOneYearService implements ResourceService<CreditorsW
             String companyAccountId,
             HttpServletRequest request) throws DataException {
 
-        Errors errors = validator.validateCreditorsWithinOneYear(rest, transaction, companyAccountId, request);
 
+        Errors errors = validator.validateIfEmptyResource(rest, request, companyAccountId);
+
+        if (!errors.hasErrors()) {
+
+            errors = validator.validateCreditorsWithinOneYear(rest, transaction, companyAccountId, request);
+        }
         if (errors.hasErrors()) {
 
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/BaseValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/BaseValidator.java
@@ -25,6 +25,9 @@ public class BaseValidator {
     @Value("${mandatory.element.missing}")
     protected String mandatoryElementMissing;
 
+    @Value("${empty.resource}")
+    protected String emptyResource;
+
     /**
      * Validate the given total is correctly aggregated
      *
@@ -34,12 +37,12 @@ public class BaseValidator {
      * @param errors
      */
     protected void validateAggregateTotal(Long total, Long expectedTotal, String location,
-        Errors errors) {
+            Errors errors) {
         if (expectedTotal == null) {
-            if (total != null && !total.equals(0L)) {
+            if (total != null && ! total.equals(0L)) {
                 addError(errors, incorrectTotal, location);
             }
-        } else if (total == null || !total.equals(expectedTotal)) {
+        } else if (total == null || ! total.equals(expectedTotal)) {
             addError(errors, incorrectTotal, location);
         }
     }
@@ -53,7 +56,19 @@ public class BaseValidator {
      */
     protected void addError(Errors errors, String messageKey, String location) {
         errors.addError(new Error(messageKey, location, LocationType.JSON_PATH.getValue(),
-            ErrorType.VALIDATION.getType()));
+                ErrorType.VALIDATION.getType()));
+    }
+
+    /**
+     * Add an empty resource error for the given location
+     *
+     * @param errors
+     * @param location
+     */
+    public Errors addEmptyResourceError(Errors errors, String location) {
+        addError(errors, emptyResource, location);
+
+        return errors;
     }
 }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
@@ -37,11 +37,32 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
     private PreviousPeriodService previousPeriodService;
 
     @Autowired
-    public CreditorsAfterOneYearValidator(CompanyService companyService, CurrentPeriodService currentPeriodService,
+    public CreditorsAfterOneYearValidator(CompanyService companyService,
+            CurrentPeriodService currentPeriodService,
             PreviousPeriodService previousPeriodService) {
         this.companyService = companyService;
         this.currentPeriodService = currentPeriodService;
         this.previousPeriodService = previousPeriodService;
+    }
+
+    public Errors validateIfEmptyResource(CreditorsAfterOneYear creditorsAfterOneYear,
+            HttpServletRequest request, String companyAccountsId) throws DataException {
+
+        Errors errors = new Errors();
+
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
+
+        if ((currentPeriodBalanceSheet == null && previousPeriodBalanceSheet == null) &&
+                (creditorsAfterOneYear.getCurrentPeriod() == null &&
+                        creditorsAfterOneYear.getPreviousPeriod() == null)) {
+
+            addEmptyResourceError(errors, CREDITORS_AFTER_PATH);
+        }
+
+        return errors;
     }
 
     public Errors validateCreditorsAfterOneYear(@Valid CreditorsAfterOneYear creditorsAfterOneYear,
@@ -53,8 +74,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
 
         boolean isMultipleYearFiler = getIsMultipleYearFiler(transaction);
 
-        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request, companyAccountsId);
-        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request, companyAccountsId);
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
 
         CurrentPeriod currentPeriodNote = creditorsAfterOneYear.getCurrentPeriod();
         PreviousPeriod previousPeriodNote = creditorsAfterOneYear.getPreviousPeriod();
@@ -70,26 +93,31 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
         return errors;
     }
 
-    private void validateCurrentPeriod(CurrentPeriod currentPeriodNote, BalanceSheet currentPeriodBalanceSheet, Errors errors) {
+    private void validateCurrentPeriod(CurrentPeriod currentPeriodNote,
+            BalanceSheet currentPeriodBalanceSheet, Errors errors) {
 
         boolean hasCurrentPeriodBalanceSheet = currentPeriodBalanceSheet != null;
-        boolean hasCurrentPeriodBalanceSheetNoteValue = !isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet);
+        boolean hasCurrentPeriodBalanceSheetNoteValue =
+                ! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet);
         boolean hasCurrentPeriodNoteData = currentPeriodNote != null;
 
-        if (!hasCurrentPeriodBalanceSheetNoteValue && hasCurrentPeriodNoteData) {
+        if (! hasCurrentPeriodBalanceSheetNoteValue && hasCurrentPeriodNoteData) {
 
-            if (validateNoUnexpectedDataPresent(hasCurrentPeriodBalanceSheet, CREDITORS_AFTER_CURRENT_PERIOD_PATH, errors)) {
+            if (validateNoUnexpectedDataPresent(hasCurrentPeriodBalanceSheet,
+                    CREDITORS_AFTER_CURRENT_PERIOD_PATH, errors)) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
             }
 
-        } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue, hasCurrentPeriodNoteData, errors)) {
+        } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue,
+                hasCurrentPeriodNoteData, errors)) {
 
             if (hasCurrentPeriodNoteData) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
             }
 
             if (hasCurrentPeriodNoteData && hasCurrentPeriodBalanceSheetNoteValue) {
-                crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet, errors);
+                crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet,
+                        errors);
             }
         }
     }
@@ -106,26 +134,31 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
         return true;
     }
 
-    private void validatePreviousPeriod(PreviousPeriod previousPeriodNote, BalanceSheet previousPeriodBalanceSheet, Errors errors) {
+    private void validatePreviousPeriod(PreviousPeriod previousPeriodNote,
+            BalanceSheet previousPeriodBalanceSheet, Errors errors) {
 
         boolean hasPreviousPeriodBalanceSheet = previousPeriodBalanceSheet != null;
-        boolean hasPreviousPeriodBalanceSheetNoteValue = !isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet);
+        boolean hasPreviousPeriodBalanceSheetNoteValue =
+                ! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet);
         boolean hasPreviousPeriodNoteData = previousPeriodNote != null;
 
-        if (!hasPreviousPeriodBalanceSheetNoteValue && hasPreviousPeriodNoteData) {
+        if (! hasPreviousPeriodBalanceSheetNoteValue && hasPreviousPeriodNoteData) {
 
-            if (validateNoUnexpectedDataPresent(hasPreviousPeriodBalanceSheet, CREDITORS_AFTER_PREVIOUS_PERIOD_PATH, errors)) {
+            if (validateNoUnexpectedDataPresent(hasPreviousPeriodBalanceSheet,
+                    CREDITORS_AFTER_PREVIOUS_PERIOD_PATH, errors)) {
                 validatePreviousPeriodFields(previousPeriodNote, errors);
             }
 
-        } else if (validatePreviousPeriodExists(hasPreviousPeriodBalanceSheetNoteValue, hasPreviousPeriodNoteData, errors)) {
+        } else if (validatePreviousPeriodExists(hasPreviousPeriodBalanceSheetNoteValue,
+                hasPreviousPeriodNoteData, errors)) {
 
             if (hasPreviousPeriodNoteData) {
                 validatePreviousPeriodFields(previousPeriodNote, errors);
             }
 
             if (hasPreviousPeriodNoteData && hasPreviousPeriodBalanceSheetNoteValue) {
-                crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet, errors);
+                crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet,
+                        errors);
             }
         }
     }
@@ -177,10 +210,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             boolean hasCurrentPeriodNoteData,
             Errors errors) {
 
-        if (hasCurrentPeriodBalanceSheetValue && !hasCurrentPeriodNoteData) {
+        if (hasCurrentPeriodBalanceSheetValue && ! hasCurrentPeriodNoteData) {
             addError(errors, mandatoryElementMissing, CREDITORS_AFTER_CURRENT_PERIOD_PATH);
             return false;
-        } else if (!hasCurrentPeriodBalanceSheetValue && hasCurrentPeriodNoteData) {
+        } else if (! hasCurrentPeriodBalanceSheetValue && hasCurrentPeriodNoteData) {
             addError(errors, unexpectedData, CREDITORS_AFTER_CURRENT_PERIOD_PATH);
             return false;
         }
@@ -192,10 +225,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             boolean hasPreviousPeriodNoteData,
             Errors errors) {
 
-        if (hasPreviousPeriodBalanceSheetValue && !hasPreviousPeriodNoteData) {
+        if (hasPreviousPeriodBalanceSheetValue && ! hasPreviousPeriodNoteData) {
             addError(errors, mandatoryElementMissing, CREDITORS_AFTER_PREVIOUS_PERIOD_PATH);
             return false;
-        } else if (!hasPreviousPeriodBalanceSheetValue && hasPreviousPeriodNoteData) {
+        } else if (! hasPreviousPeriodBalanceSheetValue && hasPreviousPeriodNoteData) {
             addError(errors, unexpectedData, CREDITORS_AFTER_PREVIOUS_PERIOD_PATH);
             return false;
         }
@@ -234,11 +267,15 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             String companyAccountsId,
             Errors errors) throws DataException {
 
-        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request, companyAccountsId);
-        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request, companyAccountsId);
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
 
-        crossValidateCurrentPeriodFields(creditorsAfterOneYear.getCurrentPeriod(), currentPeriodBalanceSheet, errors);
-        crossValidatePreviousPeriodFields(creditorsAfterOneYear.getPreviousPeriod(), previousPeriodBalanceSheet, errors);
+        crossValidateCurrentPeriodFields(creditorsAfterOneYear.getCurrentPeriod(),
+                currentPeriodBalanceSheet, errors);
+        crossValidatePreviousPeriodFields(creditorsAfterOneYear.getPreviousPeriod(),
+                previousPeriodBalanceSheet, errors);
 
         return errors;
     }
@@ -247,22 +284,26 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             BalanceSheet previousPeriodBalanceSheet,
             Errors errors) {
 
-        checkIfPreviousNoteIsNullAndBalanceNot(previousPeriodNote, previousPeriodBalanceSheet, errors);
-        checkIsPreviousBalanceNullAndNoteNot(previousPeriodNote, previousPeriodBalanceSheet, errors);
-        checkIfPreviousBalanceAndNoteValuesAreEqual(previousPeriodNote, previousPeriodBalanceSheet, errors);
+        checkIfPreviousNoteIsNullAndBalanceNot(previousPeriodNote, previousPeriodBalanceSheet,
+                errors);
+        checkIsPreviousBalanceNullAndNoteNot(previousPeriodNote, previousPeriodBalanceSheet,
+                errors);
+        checkIfPreviousBalanceAndNoteValuesAreEqual(previousPeriodNote,
+                previousPeriodBalanceSheet, errors);
     }
 
     private void checkIfPreviousBalanceAndNoteValuesAreEqual(PreviousPeriod previousPeriodNote,
             BalanceSheet previousPeriodBalanceSheet,
             Errors errors) {
 
-        if (!isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet) &&
-                (!isPreviousPeriodNoteDataNull(previousPeriodNote))
-                && (!previousPeriodNote.getTotal().equals(
+        if (! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet) &&
+                (! isPreviousPeriodNoteDataNull(previousPeriodNote))
+                && (! previousPeriodNote.getTotal().equals(
                 previousPeriodBalanceSheet.getOtherLiabilitiesOrAssets()
                         .getCreditorsAfterOneYear()))) {
 
-            addError(errors, previousBalanceSheetNotEqual, CREDITORS_AFTER_PREVIOUS_PERIOD_TOTAL_PATH);
+            addError(errors, previousBalanceSheetNotEqual,
+                    CREDITORS_AFTER_PREVIOUS_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -271,9 +312,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             Errors errors) {
 
         if (isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet) &&
-                (!isPreviousPeriodNoteDataNull(previousPeriodNote))) {
+                (! isPreviousPeriodNoteDataNull(previousPeriodNote))) {
 
-            addError(errors, previousBalanceSheetNotEqual, CREDITORS_AFTER_PREVIOUS_PERIOD_TOTAL_PATH);
+            addError(errors, previousBalanceSheetNotEqual,
+                    CREDITORS_AFTER_PREVIOUS_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -282,9 +324,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             Errors errors) {
 
         if (isPreviousPeriodNoteDataNull(previousPeriodNote) &&
-                (!isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet))) {
+                (! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet))) {
 
-            addError(errors, previousBalanceSheetNotEqual, CREDITORS_AFTER_PREVIOUS_PERIOD_TOTAL_PATH);
+            addError(errors, previousBalanceSheetNotEqual,
+                    CREDITORS_AFTER_PREVIOUS_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -307,21 +350,25 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             BalanceSheet currentPeriodBalanceSheet,
             Errors errors) {
 
-        checkIfCurrentNoteIsNullAndBalanceSheetNot(currentPeriodCreditors, currentPeriodBalanceSheet, errors);
-        checkIfCurrentBalanceSheetIsNullAndNoteNot(currentPeriodCreditors, currentPeriodBalanceSheet, errors);
-        checkIfCurrentBalanceAndNoteValuesAreEqual(currentPeriodCreditors, currentPeriodBalanceSheet, errors);
+        checkIfCurrentNoteIsNullAndBalanceSheetNot(currentPeriodCreditors,
+                currentPeriodBalanceSheet, errors);
+        checkIfCurrentBalanceSheetIsNullAndNoteNot(currentPeriodCreditors,
+                currentPeriodBalanceSheet, errors);
+        checkIfCurrentBalanceAndNoteValuesAreEqual(currentPeriodCreditors,
+                currentPeriodBalanceSheet, errors);
     }
 
     private void checkIfCurrentBalanceAndNoteValuesAreEqual(CurrentPeriod currentPeriodNote,
             BalanceSheet currentPeriodBalanceSheet,
             Errors errors) {
 
-        if (!isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)
-                && !isCurrentPeriodNoteDataNull(currentPeriodNote)
-                && !(currentPeriodNote.getTotal().equals(currentPeriodBalanceSheet.getOtherLiabilitiesOrAssets()
+        if (! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)
+                && ! isCurrentPeriodNoteDataNull(currentPeriodNote)
+                && ! (currentPeriodNote.getTotal().equals(currentPeriodBalanceSheet.getOtherLiabilitiesOrAssets()
                 .getCreditorsAfterOneYear()))) {
 
-            addError(errors, currentBalanceSheetNotEqual, CREDITORS_AFTER_CURRENT_PERIOD_TOTAL_PATH);
+            addError(errors, currentBalanceSheetNotEqual,
+                    CREDITORS_AFTER_CURRENT_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -330,9 +377,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             Errors errors) {
 
         if (isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet) &&
-                !isCurrentPeriodNoteDataNull(currentPeriodNote)) {
+                ! isCurrentPeriodNoteDataNull(currentPeriodNote)) {
 
-            addError(errors, currentBalanceSheetNotEqual, CREDITORS_AFTER_CURRENT_PERIOD_TOTAL_PATH);
+            addError(errors, currentBalanceSheetNotEqual,
+                    CREDITORS_AFTER_CURRENT_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -341,9 +389,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             Errors errors) {
 
         if (isCurrentPeriodNoteDataNull(currentPeriodNote) &&
-                !isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)) {
+                ! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)) {
 
-            addError(errors, currentBalanceSheetNotEqual, CREDITORS_AFTER_CURRENT_PERIOD_TOTAL_PATH);
+            addError(errors, currentBalanceSheetNotEqual,
+                    CREDITORS_AFTER_CURRENT_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -365,8 +414,8 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
 
     private boolean isCurrentPeriodNoteDataNull(CurrentPeriod currentPeriodCreditors) {
 
-        return !Optional.ofNullable(currentPeriodCreditors)
-                .map(CurrentPeriod::getTotal)
+        return ! Optional.ofNullable(currentPeriodCreditors)
+                .map(CurrentPeriod :: getTotal)
                 .isPresent();
 
     }
@@ -374,9 +423,9 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
     private boolean isCurrentPeriodBalanceSheetDataNull(
             BalanceSheet currentPeriodBalanceSheet) {
 
-        return !Optional.ofNullable(currentPeriodBalanceSheet)
-                .map(BalanceSheet::getOtherLiabilitiesOrAssets)
-                .map(OtherLiabilitiesOrAssets ::getCreditorsAfterOneYear)
+        return ! Optional.ofNullable(currentPeriodBalanceSheet)
+                .map(BalanceSheet :: getOtherLiabilitiesOrAssets)
+                .map(OtherLiabilitiesOrAssets :: getCreditorsAfterOneYear)
                 .isPresent();
 
     }
@@ -384,16 +433,16 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
     private boolean isPreviousPeriodBalanceSheetDataNull(
             BalanceSheet previousPeriodBalanceSheet) {
 
-        return !Optional.ofNullable(previousPeriodBalanceSheet)
-                .map(BalanceSheet::getOtherLiabilitiesOrAssets)
-                .map(OtherLiabilitiesOrAssets::getCreditorsAfterOneYear)
+        return ! Optional.ofNullable(previousPeriodBalanceSheet)
+                .map(BalanceSheet :: getOtherLiabilitiesOrAssets)
+                .map(OtherLiabilitiesOrAssets :: getCreditorsAfterOneYear)
                 .isPresent();
     }
 
     private boolean isPreviousPeriodNoteDataNull(PreviousPeriod previousPeriodNote) {
 
-        return !Optional.ofNullable(previousPeriodNote)
-                .map(PreviousPeriod::getTotal)
+        return ! Optional.ofNullable(previousPeriodNote)
+                .map(PreviousPeriod :: getTotal)
                 .isPresent();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
@@ -45,7 +45,7 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
         this.previousPeriodService = previousPeriodService;
     }
 
-    public Errors validateIfEmptyResource(CreditorsAfterOneYear creditorsAfterOneYear,
+    private Errors validateIfEmptyResource(CreditorsAfterOneYear creditorsAfterOneYear,
             HttpServletRequest request, String companyAccountsId) throws DataException {
 
         Errors errors = new Errors();
@@ -70,7 +70,11 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             String companyAccountsId,
             HttpServletRequest request) throws DataException {
 
-        Errors errors = new Errors();
+        Errors errors = validateIfEmptyResource( creditorsAfterOneYear, request,  companyAccountsId);
+
+        if (errors.hasErrors()) {
+            return errors;
+        }
 
         boolean isMultipleYearFiler = getIsMultipleYearFiler(transaction);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
@@ -70,7 +70,7 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             String companyAccountsId,
             HttpServletRequest request) throws DataException {
 
-        Errors errors = validateIfEmptyResource( creditorsAfterOneYear, request,  companyAccountsId);
+        Errors errors = validateIfEmptyResource(creditorsAfterOneYear, request, companyAccountsId);
 
         if (errors.hasErrors()) {
             return errors;
@@ -113,13 +113,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             }
 
         } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue,
-                hasCurrentPeriodNoteData, errors)) {
-
-            if (hasCurrentPeriodNoteData) {
-                validateCurrentPeriodFields(currentPeriodNote, errors);
-                crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet,
-                        errors);
-            }
+                hasCurrentPeriodNoteData, errors) && hasCurrentPeriodNoteData) {
+            validateCurrentPeriodFields(currentPeriodNote, errors);
+            crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet,
+                    errors);
         }
     }
 
@@ -151,13 +148,10 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
             }
 
         } else if (validatePreviousPeriodExists(hasPreviousPeriodBalanceSheetNoteValue,
-                hasPreviousPeriodNoteData, errors)) {
-
-            if (hasPreviousPeriodNoteData) {
-                validatePreviousPeriodFields(previousPeriodNote, errors);
-                crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet,
-                        errors);
-            }
+                hasPreviousPeriodNoteData, errors) && hasPreviousPeriodNoteData) {
+            validatePreviousPeriodFields(previousPeriodNote, errors);
+            crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet,
+                    errors);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -114,12 +114,9 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
             }
 
         } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue,
-                hasCurrentPeriodNoteData, errors)) {
-
-            if (hasCurrentPeriodNoteData) {
-                validateCurrentPeriodFields(currentPeriodNote, errors);
-                crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet, errors);
-            }
+                hasCurrentPeriodNoteData, errors) && hasCurrentPeriodNoteData) {
+            validateCurrentPeriodFields(currentPeriodNote, errors);
+            crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet, errors);
         }
     }
 
@@ -151,13 +148,10 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
             }
 
         } else if (validatePreviousPeriodExists(hasPreviousPeriodBalanceSheetNoteValue,
-                hasPreviousPeriodNoteData, errors)) {
-
-            if (hasPreviousPeriodNoteData) {
-                validatePreviousPeriodFields(previousPeriodNote, errors);
-                crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet,
-                        errors);
-            }
+                hasPreviousPeriodNoteData, errors) && hasPreviousPeriodNoteData) {
+            validatePreviousPeriodFields(previousPeriodNote, errors);
+            crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet,
+                    errors);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -45,6 +45,26 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
         this.previousPeriodService = previousPeriodService;
     }
 
+    public Errors validateIfEmptyResource(CreditorsWithinOneYear creditorsWithinOneYear,
+            HttpServletRequest request, String companyAccountsId) throws DataException {
+
+        Errors errors = new Errors();
+
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
+
+        if ((currentPeriodBalanceSheet == null && previousPeriodBalanceSheet == null) &&
+                (creditorsWithinOneYear.getCurrentPeriod() == null &&
+                        creditorsWithinOneYear.getPreviousPeriod() == null)) {
+
+            addEmptyResourceError(errors, CREDITORS_WITHIN_PATH);
+        }
+
+        return errors;
+    }
+
     public Errors validateCreditorsWithinOneYear(@Valid CreditorsWithinOneYear creditorsWithinOneYear,
                                                  Transaction transaction,
                                                  String companyAccountsId,

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -45,26 +45,6 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
         this.previousPeriodService = previousPeriodService;
     }
 
-    public Errors validateIfEmptyResource(CreditorsWithinOneYear creditorsWithinOneYear,
-            HttpServletRequest request, String companyAccountsId) throws DataException {
-
-        Errors errors = new Errors();
-
-        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
-                companyAccountsId);
-        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
-                companyAccountsId);
-
-        if ((currentPeriodBalanceSheet == null && previousPeriodBalanceSheet == null) &&
-                (creditorsWithinOneYear.getCurrentPeriod() == null &&
-                        creditorsWithinOneYear.getPreviousPeriod() == null)) {
-
-            addEmptyResourceError(errors, CREDITORS_WITHIN_PATH);
-        }
-
-        return errors;
-    }
-
     public Errors validateCreditorsWithinOneYear(@Valid CreditorsWithinOneYear creditorsWithinOneYear,
                                                  Transaction transaction,
                                                  String companyAccountsId,

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -38,24 +38,51 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
     private PreviousPeriodService previousPeriodService;
 
     @Autowired
-    public CreditorsWithinOneYearValidator(CompanyService companyService, CurrentPeriodService currentPeriodService,
-                                           PreviousPeriodService previousPeriodService) {
+    public CreditorsWithinOneYearValidator(CompanyService companyService,
+            CurrentPeriodService currentPeriodService,
+            PreviousPeriodService previousPeriodService) {
         this.companyService = companyService;
         this.currentPeriodService = currentPeriodService;
         this.previousPeriodService = previousPeriodService;
     }
 
-    public Errors validateCreditorsWithinOneYear(@Valid CreditorsWithinOneYear creditorsWithinOneYear,
-                                                 Transaction transaction,
-                                                 String companyAccountsId,
-                                                 HttpServletRequest request) throws DataException {
+    private Errors validateIfEmptyResource(CreditorsWithinOneYear creditorsWithinOneYear,
+            HttpServletRequest request, String companyAccountsId) throws DataException {
 
         Errors errors = new Errors();
 
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
+
+        if ((currentPeriodBalanceSheet == null && previousPeriodBalanceSheet == null) &&
+                (creditorsWithinOneYear.getCurrentPeriod() == null &&
+                        creditorsWithinOneYear.getPreviousPeriod() == null)) {
+
+            addEmptyResourceError(errors, CREDITORS_WITHIN_PATH);
+        }
+
+        return errors;
+    }
+
+    public Errors validateCreditorsWithinOneYear(@Valid CreditorsWithinOneYear creditorsWithinOneYear,
+            Transaction transaction,
+            String companyAccountsId,
+            HttpServletRequest request) throws DataException {
+
+        Errors errors = validateIfEmptyResource(creditorsWithinOneYear, request, companyAccountsId);
+
+        if (errors.hasErrors()) {
+            return errors;
+        }
+
         boolean isMultipleYearFiler = getIsMultipleYearFiler(transaction);
 
-        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request, companyAccountsId);
-        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request, companyAccountsId);
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
 
         CurrentPeriod currentPeriodNote = creditorsWithinOneYear.getCurrentPeriod();
         PreviousPeriod previousPeriodNote = creditorsWithinOneYear.getPreviousPeriod();
@@ -71,33 +98,38 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
         return errors;
     }
 
-    private void validateCurrentPeriod(CurrentPeriod currentPeriodNote, BalanceSheet currentPeriodBalanceSheet, Errors errors) {
+    private void validateCurrentPeriod(CurrentPeriod currentPeriodNote,
+            BalanceSheet currentPeriodBalanceSheet, Errors errors) {
 
         boolean hasCurrentPeriodBalanceSheet = currentPeriodBalanceSheet != null;
-        boolean hasCurrentPeriodBalanceSheetNoteValue = !isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet);
+        boolean hasCurrentPeriodBalanceSheetNoteValue =
+                ! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet);
         boolean hasCurrentPeriodNoteData = currentPeriodNote != null;
 
-        if (!hasCurrentPeriodBalanceSheetNoteValue && hasCurrentPeriodNoteData) {
+        if (! hasCurrentPeriodBalanceSheetNoteValue && hasCurrentPeriodNoteData) {
 
-            if (validateNoUnexpectedDataPresent(hasCurrentPeriodBalanceSheet, CREDITORS_WITHIN_CURRENT_PERIOD_PATH, errors)) {
+            if (validateNoUnexpectedDataPresent(hasCurrentPeriodBalanceSheet,
+                    CREDITORS_WITHIN_CURRENT_PERIOD_PATH, errors)) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
             }
 
-        } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue, hasCurrentPeriodNoteData, errors)) {
+        } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue,
+                hasCurrentPeriodNoteData, errors)) {
 
             if (hasCurrentPeriodNoteData) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
             }
 
             if (hasCurrentPeriodNoteData && hasCurrentPeriodBalanceSheetNoteValue) {
-                crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet, errors);
+                crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet,
+                        errors);
             }
         }
     }
 
     private boolean validateNoUnexpectedDataPresent(boolean hasCurrentPeriodBalanceSheet,
-                                                    String errorPath,
-                                                    Errors errors) {
+            String errorPath,
+            Errors errors) {
 
         if (hasCurrentPeriodBalanceSheet) {
             addError(errors, unexpectedData, errorPath);
@@ -107,32 +139,37 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
         return true;
     }
 
-    private void validatePreviousPeriod(PreviousPeriod previousPeriodNote, BalanceSheet previousPeriodBalanceSheet, Errors errors) {
+    private void validatePreviousPeriod(PreviousPeriod previousPeriodNote,
+            BalanceSheet previousPeriodBalanceSheet, Errors errors) {
 
         boolean hasPreviousPeriodBalanceSheet = previousPeriodBalanceSheet != null;
-        boolean hasPreviousPeriodBalanceSheetNoteValue = !isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet);
+        boolean hasPreviousPeriodBalanceSheetNoteValue =
+                ! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet);
         boolean hasPreviousPeriodNoteData = previousPeriodNote != null;
 
-        if (!hasPreviousPeriodBalanceSheetNoteValue && hasPreviousPeriodNoteData) {
+        if (! hasPreviousPeriodBalanceSheetNoteValue && hasPreviousPeriodNoteData) {
 
-            if (validateNoUnexpectedDataPresent(hasPreviousPeriodBalanceSheet, CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH, errors)) {
+            if (validateNoUnexpectedDataPresent(hasPreviousPeriodBalanceSheet,
+                    CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH, errors)) {
                 validatePreviousPeriodFields(previousPeriodNote, errors);
             }
 
-        } else if (validatePreviousPeriodExists(hasPreviousPeriodBalanceSheetNoteValue, hasPreviousPeriodNoteData, errors)) {
+        } else if (validatePreviousPeriodExists(hasPreviousPeriodBalanceSheetNoteValue,
+                hasPreviousPeriodNoteData, errors)) {
 
             if (hasPreviousPeriodNoteData) {
                 validatePreviousPeriodFields(previousPeriodNote, errors);
             }
 
             if (hasPreviousPeriodNoteData && hasPreviousPeriodBalanceSheetNoteValue) {
-                crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet, errors);
+                crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet,
+                        errors);
             }
         }
     }
 
     private void validatePreviousPeriodNotPresent(PreviousPeriod previousPeriodCreditors,
-                                                  Errors errors) {
+            Errors errors) {
 
         if (previousPeriodCreditors != null) {
             addError(errors, unexpectedData, CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH);
@@ -148,7 +185,7 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
     }
 
     private void validatePreviousPeriodFields(@Valid PreviousPeriod creditorsPreviousPeriod,
-                                              Errors errors) {
+            Errors errors) {
 
         if (creditorsPreviousPeriod.getTotal() == null) {
             addError(errors, mandatoryElementMissing, CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH);
@@ -181,13 +218,13 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
     }
 
     private boolean validateCurrentPeriodExists(boolean hasCurrentPeriodBalanceSheetValue,
-                                                boolean hasCurrentPeriodNoteData,
-                                                Errors errors) {
+            boolean hasCurrentPeriodNoteData,
+            Errors errors) {
 
-        if (hasCurrentPeriodBalanceSheetValue && !hasCurrentPeriodNoteData) {
+        if (hasCurrentPeriodBalanceSheetValue && ! hasCurrentPeriodNoteData) {
             addError(errors, mandatoryElementMissing, CREDITORS_WITHIN_CURRENT_PERIOD_PATH);
             return false;
-        } else if (!hasCurrentPeriodBalanceSheetValue && hasCurrentPeriodNoteData) {
+        } else if (! hasCurrentPeriodBalanceSheetValue && hasCurrentPeriodNoteData) {
             addError(errors, unexpectedData, CREDITORS_WITHIN_CURRENT_PERIOD_PATH);
             return false;
         }
@@ -196,13 +233,13 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
     }
 
     private boolean validatePreviousPeriodExists(boolean hasPreviousPeriodBalanceSheetValue,
-                                                 boolean hasPreviousPeriodNoteData,
-                                                 Errors errors) {
+            boolean hasPreviousPeriodNoteData,
+            Errors errors) {
 
-        if (hasPreviousPeriodBalanceSheetValue && !hasPreviousPeriodNoteData) {
+        if (hasPreviousPeriodBalanceSheetValue && ! hasPreviousPeriodNoteData) {
             addError(errors, mandatoryElementMissing, CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH);
             return false;
-        } else if (!hasPreviousPeriodBalanceSheetValue && hasPreviousPeriodNoteData) {
+        } else if (! hasPreviousPeriodBalanceSheetValue && hasPreviousPeriodNoteData) {
             addError(errors, unexpectedData, CREDITORS_WITHIN_PREVIOUS_PERIOD_PATH);
             return false;
         }
@@ -243,61 +280,71 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
 
     @Override
     public Errors crossValidate(CreditorsWithinOneYear creditorsWithinOneYear,
-                                HttpServletRequest request,
-                                String companyAccountsId,
-                                Errors errors) throws DataException {
+            HttpServletRequest request,
+            String companyAccountsId,
+            Errors errors) throws DataException {
 
-        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request, companyAccountsId);
-        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request, companyAccountsId);
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
 
-        crossValidateCurrentPeriodFields(creditorsWithinOneYear.getCurrentPeriod(), currentPeriodBalanceSheet, errors);
-        crossValidatePreviousPeriodFields(creditorsWithinOneYear.getPreviousPeriod(), previousPeriodBalanceSheet, errors);
+        crossValidateCurrentPeriodFields(creditorsWithinOneYear.getCurrentPeriod(),
+                currentPeriodBalanceSheet, errors);
+        crossValidatePreviousPeriodFields(creditorsWithinOneYear.getPreviousPeriod(),
+                previousPeriodBalanceSheet, errors);
 
         return errors;
     }
 
     private void crossValidatePreviousPeriodFields(PreviousPeriod previousPeriodNote,
-                                                   BalanceSheet previousPeriodBalanceSheet,
-                                                   Errors errors) {
+            BalanceSheet previousPeriodBalanceSheet,
+            Errors errors) {
 
-        checkIfPreviousNoteIsNullAndBalanceNot(previousPeriodNote, previousPeriodBalanceSheet, errors);
-        checkIsPreviousBalanceNullAndNoteNot(previousPeriodNote, previousPeriodBalanceSheet, errors);
-        checkIfPreviousBalanceAndNoteValuesAreEqual(previousPeriodNote, previousPeriodBalanceSheet, errors);
+        checkIfPreviousNoteIsNullAndBalanceNot(previousPeriodNote, previousPeriodBalanceSheet,
+                errors);
+        checkIsPreviousBalanceNullAndNoteNot(previousPeriodNote, previousPeriodBalanceSheet,
+                errors);
+        checkIfPreviousBalanceAndNoteValuesAreEqual(previousPeriodNote,
+                previousPeriodBalanceSheet, errors);
     }
 
     private void checkIfPreviousBalanceAndNoteValuesAreEqual(PreviousPeriod previousPeriodNote,
-                                                             BalanceSheet previousPeriodBalanceSheet,
-                                                             Errors errors) {
+            BalanceSheet previousPeriodBalanceSheet,
+            Errors errors) {
 
-        if (!isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet) &&
-                (!isPreviousPeriodNoteDataNull(previousPeriodNote))
-                && (!previousPeriodNote.getTotal().equals(
+        if (! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet) &&
+                (! isPreviousPeriodNoteDataNull(previousPeriodNote))
+                && (! previousPeriodNote.getTotal().equals(
                 previousPeriodBalanceSheet.getOtherLiabilitiesOrAssets()
                         .getCreditorsDueWithinOneYear()))) {
 
-            addError(errors, previousBalanceSheetNotEqual, CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH);
+            addError(errors, previousBalanceSheetNotEqual,
+                    CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH);
         }
     }
 
     private void checkIsPreviousBalanceNullAndNoteNot(PreviousPeriod previousPeriodNote,
-                                                      BalanceSheet previousPeriodBalanceSheet,
-                                                      Errors errors) {
+            BalanceSheet previousPeriodBalanceSheet,
+            Errors errors) {
 
         if (isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet) &&
-                (!isPreviousPeriodNoteDataNull(previousPeriodNote))) {
+                (! isPreviousPeriodNoteDataNull(previousPeriodNote))) {
 
-            addError(errors, previousBalanceSheetNotEqual, CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH);
+            addError(errors, previousBalanceSheetNotEqual,
+                    CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH);
         }
     }
 
     private void checkIfPreviousNoteIsNullAndBalanceNot(PreviousPeriod previousPeriodNote,
-                                                        BalanceSheet previousPeriodBalanceSheet,
-                                                        Errors errors) {
+            BalanceSheet previousPeriodBalanceSheet,
+            Errors errors) {
 
         if (isPreviousPeriodNoteDataNull(previousPeriodNote) &&
-                (!isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet))) {
+                (! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet))) {
 
-            addError(errors, previousBalanceSheetNotEqual, CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH);
+            addError(errors, previousBalanceSheetNotEqual,
+                    CREDITORS_WITHIN_PREVIOUS_PERIOD_TOTAL_PATH);
         }
     }
 
@@ -317,51 +364,57 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
     }
 
     private void crossValidateCurrentPeriodFields(CurrentPeriod currentPeriodCreditors,
-                                                  BalanceSheet currentPeriodBalanceSheet,
-                                                  Errors errors) {
+            BalanceSheet currentPeriodBalanceSheet,
+            Errors errors) {
 
-        checkIfCurrentNoteIsNullAndBalanceSheetNot(currentPeriodCreditors, currentPeriodBalanceSheet, errors);
-        checkIfCurrentBalanceSheetIsNullAndNoteNot(currentPeriodCreditors, currentPeriodBalanceSheet, errors);
-        checkIfCurrentBalanceAndNoteValuesAreEqual(currentPeriodCreditors, currentPeriodBalanceSheet, errors);
+        checkIfCurrentNoteIsNullAndBalanceSheetNot(currentPeriodCreditors,
+                currentPeriodBalanceSheet, errors);
+        checkIfCurrentBalanceSheetIsNullAndNoteNot(currentPeriodCreditors,
+                currentPeriodBalanceSheet, errors);
+        checkIfCurrentBalanceAndNoteValuesAreEqual(currentPeriodCreditors,
+                currentPeriodBalanceSheet, errors);
     }
 
     private void checkIfCurrentBalanceAndNoteValuesAreEqual(CurrentPeriod currentPeriodNote,
-                                                            BalanceSheet currentPeriodBalanceSheet,
-                                                            Errors errors) {
+            BalanceSheet currentPeriodBalanceSheet,
+            Errors errors) {
 
-        if (!isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)
-                && !isCurrentPeriodNoteDataNull(currentPeriodNote)
-                && !(currentPeriodNote.getTotal().equals(currentPeriodBalanceSheet.getOtherLiabilitiesOrAssets()
+        if (! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)
+                && ! isCurrentPeriodNoteDataNull(currentPeriodNote)
+                && ! (currentPeriodNote.getTotal().equals(currentPeriodBalanceSheet.getOtherLiabilitiesOrAssets()
                 .getCreditorsDueWithinOneYear()))) {
 
-            addError(errors, currentBalanceSheetNotEqual, CREDITORS_WITHIN_CURRENT_PERIOD_TOTAL_PATH);
+            addError(errors, currentBalanceSheetNotEqual,
+                    CREDITORS_WITHIN_CURRENT_PERIOD_TOTAL_PATH);
         }
     }
 
     private void checkIfCurrentBalanceSheetIsNullAndNoteNot(CurrentPeriod currentPeriodNote,
-                                                            BalanceSheet currentPeriodBalanceSheet,
-                                                            Errors errors) {
+            BalanceSheet currentPeriodBalanceSheet,
+            Errors errors) {
 
         if (isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet) &&
-                !isCurrentPeriodNoteDataNull(currentPeriodNote)) {
+                ! isCurrentPeriodNoteDataNull(currentPeriodNote)) {
 
-            addError(errors, currentBalanceSheetNotEqual, CREDITORS_WITHIN_CURRENT_PERIOD_TOTAL_PATH);
+            addError(errors, currentBalanceSheetNotEqual,
+                    CREDITORS_WITHIN_CURRENT_PERIOD_TOTAL_PATH);
         }
     }
 
     private void checkIfCurrentNoteIsNullAndBalanceSheetNot(CurrentPeriod currentPeriodNote,
-                                                            BalanceSheet currentPeriodBalanceSheet,
-                                                            Errors errors) {
+            BalanceSheet currentPeriodBalanceSheet,
+            Errors errors) {
 
         if (isCurrentPeriodNoteDataNull(currentPeriodNote) &&
-                !isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)) {
+                ! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)) {
 
-            addError(errors, currentBalanceSheetNotEqual, CREDITORS_WITHIN_CURRENT_PERIOD_TOTAL_PATH);
+            addError(errors, currentBalanceSheetNotEqual,
+                    CREDITORS_WITHIN_CURRENT_PERIOD_TOTAL_PATH);
         }
     }
 
     private BalanceSheet getCurrentPeriodBalanceSheet(HttpServletRequest request,
-                                                      String companyAccountsId) throws DataException {
+            String companyAccountsId) throws DataException {
 
         String currentPeriodId = currentPeriodService.generateID(companyAccountsId);
 
@@ -378,8 +431,8 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
 
     private boolean isCurrentPeriodNoteDataNull(CurrentPeriod currentPeriodCreditors) {
 
-        return !Optional.ofNullable(currentPeriodCreditors)
-                .map(CurrentPeriod::getTotal)
+        return ! Optional.ofNullable(currentPeriodCreditors)
+                .map(CurrentPeriod :: getTotal)
                 .isPresent();
 
     }
@@ -387,9 +440,9 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
     private boolean isCurrentPeriodBalanceSheetDataNull(
             BalanceSheet currentPeriodBalanceSheet) {
 
-        return !Optional.ofNullable(currentPeriodBalanceSheet)
-                .map(BalanceSheet::getOtherLiabilitiesOrAssets)
-                .map(OtherLiabilitiesOrAssets::getCreditorsDueWithinOneYear)
+        return ! Optional.ofNullable(currentPeriodBalanceSheet)
+                .map(BalanceSheet :: getOtherLiabilitiesOrAssets)
+                .map(OtherLiabilitiesOrAssets :: getCreditorsDueWithinOneYear)
                 .isPresent();
 
     }
@@ -397,16 +450,16 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
     private boolean isPreviousPeriodBalanceSheetDataNull(
             BalanceSheet previousPeriodBalanceSheet) {
 
-        return !Optional.ofNullable(previousPeriodBalanceSheet)
-                .map(BalanceSheet::getOtherLiabilitiesOrAssets)
-                .map(OtherLiabilitiesOrAssets::getCreditorsDueWithinOneYear)
+        return ! Optional.ofNullable(previousPeriodBalanceSheet)
+                .map(BalanceSheet :: getOtherLiabilitiesOrAssets)
+                .map(OtherLiabilitiesOrAssets :: getCreditorsDueWithinOneYear)
                 .isPresent();
     }
 
     private boolean isPreviousPeriodNoteDataNull(PreviousPeriod previousPeriodNote) {
 
-        return !Optional.ofNullable(previousPeriodNote)
-                .map(PreviousPeriod::getTotal)
+        return ! Optional.ofNullable(previousPeriodNote)
+                .map(PreviousPeriod :: getTotal)
                 .isPresent();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -50,8 +50,10 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
 
         boolean isMultipleYearFiler = getIsMultipleYearFiler(transaction);
 
-        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request, companyAccountsId);
-        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request, companyAccountsId);
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
 
         CurrentPeriod currentPeriodNote = debtors.getCurrentPeriod();
         PreviousPeriod previousPeriodNote = debtors.getPreviousPeriod();
@@ -67,50 +69,53 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         return errors;
     }
 
-    private void validateCurrentPeriod(CurrentPeriod currentPeriodNote, BalanceSheet currentPeriodBalanceSheet, Errors errors) {
+    private void validateCurrentPeriod(CurrentPeriod currentPeriodNote,
+            BalanceSheet currentPeriodBalanceSheet, Errors errors) {
 
         boolean hasCurrentPeriodBalanceSheet = currentPeriodBalanceSheet != null;
-        boolean hasCurrentPeriodBalanceSheetNoteValue = !isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet);
+        boolean hasCurrentPeriodBalanceSheetNoteValue =
+                ! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet);
         boolean hasCurrentPeriodNoteData = currentPeriodNote != null;
 
-        if (!hasCurrentPeriodBalanceSheetNoteValue && hasCurrentPeriodNoteData) {
+        if (! hasCurrentPeriodBalanceSheetNoteValue && hasCurrentPeriodNoteData) {
 
-            if (validateNoUnexpectedDataPresent(hasCurrentPeriodBalanceSheet, DEBTORS_PATH_CURRENT, errors)) {
+            if (validateNoUnexpectedDataPresent(hasCurrentPeriodBalanceSheet,
+                    DEBTORS_PATH_CURRENT, errors)) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
             }
 
-        } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue, hasCurrentPeriodNoteData, errors)) {
-
-            if (hasCurrentPeriodNoteData) {
-                validateCurrentPeriodFields(currentPeriodNote, errors);
-                crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet, errors);
-            }
+        } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue,
+                hasCurrentPeriodNoteData, errors) && hasCurrentPeriodNoteData) {
+            validateCurrentPeriodFields(currentPeriodNote, errors);
+            crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet, errors);
         }
     }
 
-    private void validatePreviousPeriod(PreviousPeriod previousPeriodNote, BalanceSheet previousPeriodBalanceSheet, Errors errors) {
+    private void validatePreviousPeriod(PreviousPeriod previousPeriodNote,
+            BalanceSheet previousPeriodBalanceSheet, Errors errors) {
 
         boolean hasPreviousPeriodBalanceSheet = previousPeriodBalanceSheet != null;
-        boolean hasPreviousPeriodBalanceSheetNoteValue = !isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet);
+        boolean hasPreviousPeriodBalanceSheetNoteValue =
+                ! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet);
         boolean hasPreviousPeriodNoteData = previousPeriodNote != null;
 
-        if (!hasPreviousPeriodBalanceSheetNoteValue && hasPreviousPeriodNoteData) {
+        if (! hasPreviousPeriodBalanceSheetNoteValue && hasPreviousPeriodNoteData) {
 
-            if (validateNoUnexpectedDataPresent(hasPreviousPeriodBalanceSheet, DEBTORS_PATH_PREVIOUS, errors)) {
+            if (validateNoUnexpectedDataPresent(hasPreviousPeriodBalanceSheet,
+                    DEBTORS_PATH_PREVIOUS, errors)) {
                 validatePreviousPeriodFields(previousPeriodNote, errors);
             }
 
-        } else if (validatePreviousPeriodExists(hasPreviousPeriodBalanceSheetNoteValue, hasPreviousPeriodNoteData, errors)) {
-
-            if (hasPreviousPeriodNoteData) {
-                validatePreviousPeriodFields(previousPeriodNote, errors);
-                crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet, errors);
-            }
+        } else if (validatePreviousPeriodExists(hasPreviousPeriodBalanceSheetNoteValue,
+                hasPreviousPeriodNoteData, errors) && hasPreviousPeriodNoteData) {
+            validatePreviousPeriodFields(previousPeriodNote, errors);
+            crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet,
+                    errors);
         }
     }
 
     private void validatePreviousPeriodNotPresent(PreviousPeriod previousPeriodDebtors,
-                                                  Errors errors) {
+            Errors errors) {
 
         if (previousPeriodDebtors != null) {
             addError(errors, unexpectedData, DEBTORS_PATH_PREVIOUS);
@@ -118,7 +123,7 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     }
 
     private boolean validateNoUnexpectedDataPresent(boolean hasCurrentPeriodBalanceSheet,
-       String errorPath, Errors errors) {
+            String errorPath, Errors errors) {
 
         if (hasCurrentPeriodBalanceSheet) {
             addError(errors, unexpectedData, errorPath);
@@ -136,7 +141,8 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         }
     }
 
-    private void validatePreviousPeriodFields(@Valid PreviousPeriod debtorsPreviousPeriod, Errors errors) {
+    private void validatePreviousPeriodFields(@Valid PreviousPeriod debtorsPreviousPeriod,
+            Errors errors) {
 
         if (debtorsPreviousPeriod.getTotal() == null) {
             addError(errors, mandatoryElementMissing, PREVIOUS_TOTAL_PATH);
@@ -146,13 +152,13 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     }
 
     private boolean validateCurrentPeriodExists(boolean hasCurrentPeriodBalanceSheetValue,
-                                                boolean hasCurrentPeriodNoteData,
-                                                Errors errors) {
+            boolean hasCurrentPeriodNoteData,
+            Errors errors) {
 
-        if (hasCurrentPeriodBalanceSheetValue && !hasCurrentPeriodNoteData) {
+        if (hasCurrentPeriodBalanceSheetValue && ! hasCurrentPeriodNoteData) {
             addError(errors, mandatoryElementMissing, DEBTORS_PATH_CURRENT);
             return false;
-        } else if (!hasCurrentPeriodBalanceSheetValue && hasCurrentPeriodNoteData) {
+        } else if (! hasCurrentPeriodBalanceSheetValue && hasCurrentPeriodNoteData) {
             addError(errors, unexpectedData, DEBTORS_PATH_CURRENT);
             return false;
         }
@@ -161,13 +167,13 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     }
 
     private boolean validatePreviousPeriodExists(boolean hasPreviousPeriodBalanceSheetValue,
-                                                 boolean hasPreviousPeriodNoteData,
-                                                 Errors errors) {
+            boolean hasPreviousPeriodNoteData,
+            Errors errors) {
 
-        if (hasPreviousPeriodBalanceSheetValue && !hasPreviousPeriodNoteData) {
+        if (hasPreviousPeriodBalanceSheetValue && ! hasPreviousPeriodNoteData) {
             addError(errors, mandatoryElementMissing, DEBTORS_PATH_PREVIOUS);
             return false;
-        } else if (!hasPreviousPeriodBalanceSheetValue && hasPreviousPeriodNoteData) {
+        } else if (! hasPreviousPeriodBalanceSheetValue && hasPreviousPeriodNoteData) {
             addError(errors, unexpectedData, DEBTORS_PATH_PREVIOUS);
             return false;
         }
@@ -175,18 +181,19 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         return true;
     }
 
-    private void validateCurrentPeriodTotalCalculation(@Valid CurrentPeriod debtorsCurrentPeriod, Errors errors) {
+    private void validateCurrentPeriodTotalCalculation(@Valid CurrentPeriod debtorsCurrentPeriod,
+            Errors errors) {
 
         Long tradeDebtors =
-            Optional.ofNullable(debtorsCurrentPeriod.getTradeDebtors()).orElse(0L);
+                Optional.ofNullable(debtorsCurrentPeriod.getTradeDebtors()).orElse(0L);
         Long prepaymentsAndAccruedIncome =
-            Optional.ofNullable(debtorsCurrentPeriod.getPrepaymentsAndAccruedIncome()).orElse(0L);
+                Optional.ofNullable(debtorsCurrentPeriod.getPrepaymentsAndAccruedIncome()).orElse(0L);
         Long otherDebtors =
-            Optional.ofNullable(debtorsCurrentPeriod.getOtherDebtors()).orElse(0L);
+                Optional.ofNullable(debtorsCurrentPeriod.getOtherDebtors()).orElse(0L);
 
         Long total = debtorsCurrentPeriod.getTotal();
         Long sum =
-            tradeDebtors + prepaymentsAndAccruedIncome + otherDebtors;
+                tradeDebtors + prepaymentsAndAccruedIncome + otherDebtors;
 
         validateAggregateTotal(total, sum, CURRENT_TOTAL_PATH, errors);
     }
@@ -194,21 +201,21 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     private void validatePreviousPeriodTotalCalculation(@Valid PreviousPeriod debtorsPreviousPeriod, Errors errors) {
 
         Long tradeDebtors =
-            Optional.ofNullable(debtorsPreviousPeriod.getTradeDebtors()).orElse(0L);
+                Optional.ofNullable(debtorsPreviousPeriod.getTradeDebtors()).orElse(0L);
         Long prepaymentsAndAccruedIncome =
-            Optional.ofNullable(debtorsPreviousPeriod.getPrepaymentsAndAccruedIncome()).orElse(0L);
+                Optional.ofNullable(debtorsPreviousPeriod.getPrepaymentsAndAccruedIncome()).orElse(0L);
         Long otherDebtors =
-            Optional.ofNullable(debtorsPreviousPeriod.getOtherDebtors()).orElse(0L);
+                Optional.ofNullable(debtorsPreviousPeriod.getOtherDebtors()).orElse(0L);
 
         Long total = debtorsPreviousPeriod.getTotal();
         Long sum =
-            tradeDebtors + prepaymentsAndAccruedIncome + otherDebtors;
+                tradeDebtors + prepaymentsAndAccruedIncome + otherDebtors;
 
         validateAggregateTotal(total, sum, PREVIOUS_TOTAL_PATH, errors);
     }
 
     private BalanceSheet getCurrentPeriodBalanceSheet(HttpServletRequest request,
-                                                      String companyAccountsId) throws DataException {
+            String companyAccountsId) throws DataException {
 
         String currentPeriodId = currentPeriodService.generateID(companyAccountsId);
 
@@ -224,7 +231,7 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     }
 
     private BalanceSheet getPreviousPeriodBalanceSheet(
-        HttpServletRequest request, String companyAccountsId) throws DataException {
+            HttpServletRequest request, String companyAccountsId) throws DataException {
         String previousPeriodId = previousPeriodService.generateID(companyAccountsId);
 
         ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject;
@@ -247,94 +254,105 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     }
 
     @Override
-    public Errors crossValidate(Debtors debtors, HttpServletRequest request, String companyAccountsId,
-        Errors errors) throws DataException {
+    public Errors crossValidate(Debtors debtors, HttpServletRequest request,
+            String companyAccountsId,
+            Errors errors) throws DataException {
 
-        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request, companyAccountsId);
-        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request, companyAccountsId);
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
 
-        crossValidateCurrentPeriodFields(debtors.getCurrentPeriod(), currentPeriodBalanceSheet, errors);
-        crossValidatePreviousPeriodFields(debtors.getPreviousPeriod(), previousPeriodBalanceSheet, errors);
+        crossValidateCurrentPeriodFields(debtors.getCurrentPeriod(), currentPeriodBalanceSheet,
+                errors);
+        crossValidatePreviousPeriodFields(debtors.getPreviousPeriod(), previousPeriodBalanceSheet
+                , errors);
 
         return errors;
     }
 
     private void crossValidateCurrentPeriodFields(CurrentPeriod currentPeriodDebtors,
-        BalanceSheet currentPeriodBalanceSheet, Errors errors) {
+            BalanceSheet currentPeriodBalanceSheet, Errors errors) {
 
-        checkIfCurrentNoteIsNullAndBalanceSheetNot(currentPeriodDebtors, currentPeriodBalanceSheet, errors);
-        checkIfCurrentBalanceSheetIsNullAndNoteNot(currentPeriodDebtors, currentPeriodBalanceSheet, errors);
-        checkIfCurrentBalanceAndNoteValuesAreEqual(currentPeriodDebtors, currentPeriodBalanceSheet, errors);
+        checkIfCurrentNoteIsNullAndBalanceSheetNot(currentPeriodDebtors,
+                currentPeriodBalanceSheet, errors);
+        checkIfCurrentBalanceSheetIsNullAndNoteNot(currentPeriodDebtors,
+                currentPeriodBalanceSheet, errors);
+        checkIfCurrentBalanceAndNoteValuesAreEqual(currentPeriodDebtors,
+                currentPeriodBalanceSheet, errors);
     }
 
     private void checkIfCurrentNoteIsNullAndBalanceSheetNot(CurrentPeriod currentPeriodNote,
-        BalanceSheet currentPeriodBalanceSheet, Errors errors) {
+            BalanceSheet currentPeriodBalanceSheet, Errors errors) {
 
         if (isCurrentPeriodNoteDataNull(currentPeriodNote) &&
-            !isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)) {
+                ! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)) {
 
             addError(errors, currentBalanceSheetNotEqual, CURRENT_TOTAL_PATH);
         }
     }
 
     private void checkIfCurrentBalanceSheetIsNullAndNoteNot(CurrentPeriod currentPeriodNote,
-        BalanceSheet currentPeriodBalanceSheet, Errors errors) {
+            BalanceSheet currentPeriodBalanceSheet, Errors errors) {
 
         if (isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet) &&
-            !isCurrentPeriodNoteDataNull(currentPeriodNote)) {
+                ! isCurrentPeriodNoteDataNull(currentPeriodNote)) {
 
             addError(errors, currentBalanceSheetNotEqual, CURRENT_TOTAL_PATH);
         }
     }
 
     private void checkIfCurrentBalanceAndNoteValuesAreEqual(CurrentPeriod currentPeriodNote,
-        BalanceSheet currentPeriodBalanceSheet, Errors errors) {
+            BalanceSheet currentPeriodBalanceSheet, Errors errors) {
 
-        if (!isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)
-            && !isCurrentPeriodNoteDataNull(currentPeriodNote)
-            && !(currentPeriodNote.getTotal().equals(currentPeriodBalanceSheet.getCurrentAssets()
-            .getDebtors()))) {
+        if (! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet)
+                && ! isCurrentPeriodNoteDataNull(currentPeriodNote)
+                && ! (currentPeriodNote.getTotal().equals(currentPeriodBalanceSheet.getCurrentAssets()
+                .getDebtors()))) {
 
             addError(errors, currentBalanceSheetNotEqual, CURRENT_TOTAL_PATH);
         }
     }
 
     private void crossValidatePreviousPeriodFields(PreviousPeriod previousPeriodNote,
-        BalanceSheet previousPeriodBalanceSheet, Errors errors) {
+            BalanceSheet previousPeriodBalanceSheet, Errors errors) {
 
-        checkIfPreviousNoteIsNullAndBalanceNot(previousPeriodNote, previousPeriodBalanceSheet, errors);
-        checkIsPreviousBalanceNullAndNoteNot(previousPeriodNote, previousPeriodBalanceSheet, errors);
-        checkIfPreviousBalanceAndNoteValuesAreEqual(previousPeriodNote, previousPeriodBalanceSheet, errors);
+        checkIfPreviousNoteIsNullAndBalanceNot(previousPeriodNote, previousPeriodBalanceSheet,
+                errors);
+        checkIsPreviousBalanceNullAndNoteNot(previousPeriodNote, previousPeriodBalanceSheet,
+                errors);
+        checkIfPreviousBalanceAndNoteValuesAreEqual(previousPeriodNote,
+                previousPeriodBalanceSheet, errors);
     }
 
     private void checkIfPreviousNoteIsNullAndBalanceNot(PreviousPeriod previousPeriodNote,
-        BalanceSheet previousPeriodBalanceSheet, Errors errors) {
+            BalanceSheet previousPeriodBalanceSheet, Errors errors) {
 
         if (isPreviousPeriodNoteDataNull(previousPeriodNote) &&
-            (!isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet))) {
+                (! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet))) {
 
             addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
         }
     }
 
     private void checkIsPreviousBalanceNullAndNoteNot(PreviousPeriod previousPeriodNote,
-        BalanceSheet previousPeriodBalanceSheet, Errors errors) {
+            BalanceSheet previousPeriodBalanceSheet, Errors errors) {
 
         if (isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet) &&
-            (!isPreviousPeriodNoteDataNull(previousPeriodNote))) {
+                (! isPreviousPeriodNoteDataNull(previousPeriodNote))) {
 
             addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
         }
     }
 
     private void checkIfPreviousBalanceAndNoteValuesAreEqual(PreviousPeriod previousPeriodNote,
-        BalanceSheet previousPeriodBalanceSheet, Errors errors) {
+            BalanceSheet previousPeriodBalanceSheet, Errors errors) {
 
-        if (!isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet) &&
-            (!isPreviousPeriodNoteDataNull(previousPeriodNote))
-            && (!previousPeriodNote.getTotal().equals(
-            previousPeriodBalanceSheet.getCurrentAssets()
-                .getDebtors()))) {
+        if (! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet) &&
+                (! isPreviousPeriodNoteDataNull(previousPeriodNote))
+                && (! previousPeriodNote.getTotal().equals(
+                previousPeriodBalanceSheet.getCurrentAssets()
+                        .getDebtors()))) {
 
             addError(errors, previousBalanceSheetNotEqual, PREVIOUS_TOTAL_PATH);
         }
@@ -342,33 +360,33 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
 
     private boolean isCurrentPeriodNoteDataNull(CurrentPeriod currentPeriodDebtors) {
 
-        return !Optional.ofNullable(currentPeriodDebtors)
-            .map(CurrentPeriod::getTotal)
-            .isPresent();
+        return ! Optional.ofNullable(currentPeriodDebtors)
+                .map(CurrentPeriod :: getTotal)
+                .isPresent();
     }
 
     private boolean isPreviousPeriodNoteDataNull(PreviousPeriod previousPeriodNote) {
 
-        return !Optional.ofNullable(previousPeriodNote)
-            .map(PreviousPeriod::getTotal)
-            .isPresent();
+        return ! Optional.ofNullable(previousPeriodNote)
+                .map(PreviousPeriod :: getTotal)
+                .isPresent();
     }
 
     private boolean isCurrentPeriodBalanceSheetDataNull(
-        BalanceSheet currentPeriodBalanceSheet) {
+            BalanceSheet currentPeriodBalanceSheet) {
 
-        return !Optional.ofNullable(currentPeriodBalanceSheet)
-            .map(BalanceSheet::getCurrentAssets)
-            .map(CurrentAssets::getDebtors)
-            .isPresent();
+        return ! Optional.ofNullable(currentPeriodBalanceSheet)
+                .map(BalanceSheet :: getCurrentAssets)
+                .map(CurrentAssets :: getDebtors)
+                .isPresent();
     }
 
     private boolean isPreviousPeriodBalanceSheetDataNull(
-        BalanceSheet previousPeriodBalanceSheet) {
+            BalanceSheet previousPeriodBalanceSheet) {
 
-        return !Optional.ofNullable(previousPeriodBalanceSheet)
-            .map(BalanceSheet::getCurrentAssets)
-            .map(CurrentAssets::getDebtors)
-            .isPresent();
+        return ! Optional.ofNullable(previousPeriodBalanceSheet)
+                .map(BalanceSheet :: getCurrentAssets)
+                .map(CurrentAssets :: getDebtors)
+                .isPresent();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -42,11 +42,35 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         this.previousPeriodService = previousPeriodService;
     }
 
+    private Errors validateIfEmptyResource(Debtors debtors,
+            HttpServletRequest request, String companyAccountsId) throws DataException {
+
+        Errors errors = new Errors();
+
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
+
+        if ((currentPeriodBalanceSheet == null && previousPeriodBalanceSheet == null) &&
+                (debtors.getCurrentPeriod() == null &&
+                        debtors.getPreviousPeriod() == null)) {
+
+            addEmptyResourceError(errors, DEBTORS_PATH);
+        }
+
+        return errors;
+    }
+
     public Errors validateDebtors(@Valid Debtors debtors, Transaction transaction,
             String companyAccountsId,
             HttpServletRequest request) throws DataException {
 
-        Errors errors = new Errors();
+        Errors errors = validateIfEmptyResource(debtors, request, companyAccountsId);
+
+        if (errors.hasErrors()) {
+            return errors;
+        }
 
         boolean isMultipleYearFiler = getIsMultipleYearFiler(transaction);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/EmployeesValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/EmployeesValidator.java
@@ -34,7 +34,7 @@ public class EmployeesValidator extends BaseValidator {
             addEmptyResourceError(errors, EMPLOYEES_PATH);
         }
 
-        if (! isMultipleYearFiler && employees.getPreviousPeriod() != null) {
+        if (!isMultipleYearFiler && employees.getPreviousPeriod().getAverageNumberOfEmployees() != null) {
             addError(errors, unexpectedData, EMPLOYEES_PREVIOUS_PERIOD_PATH);
         }
         return errors;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/EmployeesValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/EmployeesValidator.java
@@ -30,10 +30,13 @@ public class EmployeesValidator extends BaseValidator {
 
         boolean isMultipleYearFiler = getIsMultipleYearFiler(transaction);
 
+        if (employees.getCurrentPeriod() == null && employees.getPreviousPeriod() == null) {
+            addEmptyResourceError(errors, EMPLOYEES_PATH);
+        }
+
         if (! isMultipleYearFiler && employees.getPreviousPeriod() != null) {
             addError(errors, unexpectedData, EMPLOYEES_PREVIOUS_PERIOD_PATH);
         }
-
         return errors;
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/StocksValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/StocksValidator.java
@@ -107,14 +107,11 @@ public class StocksValidator extends BaseValidator implements CrossValidator<Sto
                 validateCurrentPeriodFields(currentPeriodNote, errors);
             }
 
-        } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue, hasCurrentPeriodNoteData, errors)) {
-
-            if (hasCurrentPeriodNoteData) {
+        } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue, hasCurrentPeriodNoteData, errors) && hasCurrentPeriodNoteData) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
                 crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet, errors);
             }
         }
-    }
 
     private boolean validateNoUnexpectedDataPresent(boolean hasCurrentPeriodBalanceSheet,
                                                     String errorPath,
@@ -140,14 +137,11 @@ public class StocksValidator extends BaseValidator implements CrossValidator<Sto
                 validatePreviousPeriodFields(previousPeriodNote, errors);
             }
 
-        } else if (validatePreviousPeriodExists(hasPreviousPeriodBalanceSheetNoteValue, hasPreviousPeriodNoteData, errors)) {
-
-            if (hasPreviousPeriodNoteData) {
+        } else if (validatePreviousPeriodExists(hasPreviousPeriodBalanceSheetNoteValue, hasPreviousPeriodNoteData, errors) && hasPreviousPeriodNoteData) {
                 validatePreviousPeriodFields(previousPeriodNote, errors);
                 crossValidatePreviousPeriodFields(previousPeriodNote, previousPeriodBalanceSheet, errors);
             }
         }
-    }
 
     private void validatePreviousPeriodNotPresent(PreviousPeriod previousPeriod,
                                                   Errors errors) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/StocksValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/StocksValidator.java
@@ -50,7 +50,11 @@ public class StocksValidator extends BaseValidator implements CrossValidator<Sto
                                  HttpServletRequest request) throws DataException {
 
 
-        Errors errors = new Errors();
+        Errors errors = validateIfEmptyResource(stocks, request, companyAccountsId);
+
+        if (errors.hasErrors()) {
+            return errors;
+        }
 
         boolean isMultipleYearFiler = getIsMultipleYearFiler(transaction);
 
@@ -66,6 +70,26 @@ public class StocksValidator extends BaseValidator implements CrossValidator<Sto
             validatePreviousPeriod(previousPeriodNote, previousPeriodBalanceSheet, errors);
         } else {
             validatePreviousPeriodNotPresent(stocks.getPreviousPeriod(), errors);
+        }
+
+        return errors;
+    }
+
+    private Errors validateIfEmptyResource(Stocks stocks,
+            HttpServletRequest request, String companyAccountsId) throws DataException {
+
+        Errors errors = new Errors();
+
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
+
+        if ((currentPeriodBalanceSheet == null && previousPeriodBalanceSheet == null) &&
+                (stocks.getCurrentPeriod() == null &&
+                        stocks.getPreviousPeriod() == null)) {
+
+            addEmptyResourceError(errors, STOCKS_PATH);
         }
 
         return errors;

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -17,3 +17,4 @@ current.balancesheet.not.equal=value_not_equal_to_current_period_on_balance_shee
 previous.balancesheet.not.equal=value_not_equal_to_previous_period_on_balance_sheet
 unexpected.data=unexpected_data
 value.required=value_required
+empty.resource=empty_resource

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearServiceTest.java
@@ -1,6 +1,24 @@
 package uk.gov.companieshouse.api.accounts.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.mongodb.MongoException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,33 +43,12 @@ import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.repository.CreditorsAfterOneYearRepository;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.CreditorsAfterOneYearTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
-
 import uk.gov.companieshouse.api.accounts.validation.CreditorsAfterOneYearValidator;
 import uk.gov.companieshouse.api.accounts.validation.ErrorType;
 import uk.gov.companieshouse.api.accounts.validation.LocationType;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 
 @ExtendWith(MockitoExtension.class)
@@ -121,6 +118,7 @@ public class CreditorsAfterOneYearServiceTest {
         Errors errors = new Errors();
         errors.addError(new Error("test.message.key", "location",
             LocationType.JSON_PATH.getValue(), ErrorType.VALIDATION.getType()));
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(new Errors());
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -133,11 +131,29 @@ public class CreditorsAfterOneYearServiceTest {
     }
 
     @Test
+    @DisplayName("Tests for validation error with empty note resource")
+    void validationErrorWhenEmptyresourceSubmitted() throws DataException {
+
+        Errors errors = new Errors();
+        errors.addError(new Error("test.message.key", "location",
+                LocationType.JSON_PATH.getValue(), ErrorType.VALIDATION.getType()));
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
+
+        ResponseObject<CreditorsAfterOneYear> result = mockCreditorsAfterOneYearService
+                .create(mockCreditorsAfterOneYear, mockTransaction, "", mockRequest);
+
+        assertEquals(ResponseStatus.VALIDATION_ERROR, result.getStatus());
+        verify(mockSmallFullService, times(0)).addLink(anyString(),
+                any(SmallFullLinkType.class), anyString(), any(HttpServletRequest.class));
+    }
+
+    @Test
     @DisplayName("Tests the successful creation of a creditors after one year resource")
     void canCreateCreditorsAfterOneYear() throws DataException {
 
         Errors errors = new Errors();
 
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -163,6 +179,7 @@ public class CreditorsAfterOneYearServiceTest {
 
         Errors errors = new Errors();
 
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -187,6 +204,8 @@ public class CreditorsAfterOneYearServiceTest {
     void createCreditorsAfterOneYearMongoExceptionFailure() throws DataException {
 
         Errors errors = new Errors();
+
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
 
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
@@ -250,6 +269,8 @@ public class CreditorsAfterOneYearServiceTest {
 
         Errors errors = new Errors();
 
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
+
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -270,6 +291,8 @@ public class CreditorsAfterOneYearServiceTest {
     void updateCreditorsAfterOneYearMongoExceptionFailure() throws DataException {
 
         Errors errors = new Errors();
+
+        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
 
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearServiceTest.java
@@ -118,7 +118,7 @@ public class CreditorsAfterOneYearServiceTest {
         Errors errors = new Errors();
         errors.addError(new Error("test.message.key", "location",
             LocationType.JSON_PATH.getValue(), ErrorType.VALIDATION.getType()));
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(new Errors());
+
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -131,29 +131,11 @@ public class CreditorsAfterOneYearServiceTest {
     }
 
     @Test
-    @DisplayName("Tests for validation error with empty note resource")
-    void validationErrorWhenEmptyresourceSubmitted() throws DataException {
-
-        Errors errors = new Errors();
-        errors.addError(new Error("test.message.key", "location",
-                LocationType.JSON_PATH.getValue(), ErrorType.VALIDATION.getType()));
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
-
-        ResponseObject<CreditorsAfterOneYear> result = mockCreditorsAfterOneYearService
-                .create(mockCreditorsAfterOneYear, mockTransaction, "", mockRequest);
-
-        assertEquals(ResponseStatus.VALIDATION_ERROR, result.getStatus());
-        verify(mockSmallFullService, times(0)).addLink(anyString(),
-                any(SmallFullLinkType.class), anyString(), any(HttpServletRequest.class));
-    }
-
-    @Test
     @DisplayName("Tests the successful creation of a creditors after one year resource")
     void canCreateCreditorsAfterOneYear() throws DataException {
 
         Errors errors = new Errors();
 
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -179,7 +161,6 @@ public class CreditorsAfterOneYearServiceTest {
 
         Errors errors = new Errors();
 
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -204,8 +185,6 @@ public class CreditorsAfterOneYearServiceTest {
     void createCreditorsAfterOneYearMongoExceptionFailure() throws DataException {
 
         Errors errors = new Errors();
-
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
 
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
@@ -269,8 +248,6 @@ public class CreditorsAfterOneYearServiceTest {
 
         Errors errors = new Errors();
 
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
-
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);
 
@@ -291,8 +268,6 @@ public class CreditorsAfterOneYearServiceTest {
     void updateCreditorsAfterOneYearMongoExceptionFailure() throws DataException {
 
         Errors errors = new Errors();
-
-        when(mockValidator.validateIfEmptyResource(mockCreditorsAfterOneYear, mockRequest, "")).thenReturn(errors);
 
         when(mockValidator.validateCreditorsAfterOneYear(
             mockCreditorsAfterOneYear, mockTransaction, "", mockRequest)).thenReturn(errors);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidatorTest.java
@@ -110,6 +110,21 @@ public class CreditorsAfterOneYearValidatorTest {
     }
 
     @Test
+    @DisplayName("Validation fails when empty periods and empty note resource")
+    void testValidationAgainstEmptyResource() throws DataException {
+
+        CreditorsAfterOneYear creditorsAfterOneYear = new CreditorsAfterOneYear();
+
+        ReflectionTestUtils.setField(validator, EMPTY_RESOURCE_NAME,
+                EMPTY_RESOURCE_VALUE);
+
+        errors = validator.validateCreditorsAfterOneYear(creditorsAfterOneYear, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
+
+        assertTrue(errors.containsError(createError(EMPTY_RESOURCE_VALUE,
+                CREDITORS_AFTER_PATH)));
+    }
+
+    @Test
     @DisplayName("Note validation and cross validation passes with valid note for multiple year filer")
     void testSuccessfulMultipleYearNoteValidationAndCrossValidation() throws ServiceException, DataException {
 
@@ -368,6 +383,11 @@ public class CreditorsAfterOneYearValidatorTest {
     @DisplayName("Data exception thrown when company service API call fails")
     void testDataExceptionThrown() throws ServiceException {
 
+        Errors errors = new Errors();
+
+        createValidNoteCurrentPeriod();
+        createValidNotePreviousPeriod();
+
         when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenThrow(mockServiceException);
 
         assertThrows(DataException.class,
@@ -406,28 +426,9 @@ public class CreditorsAfterOneYearValidatorTest {
                 COMPANY_ACCOUNTS_ID);
         when(mockPreviousPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
-        when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(true);
-
         assertThrows(DataException.class,
                 () -> validator.validateCreditorsAfterOneYear(creditorsAfterOneYear,
                         mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest));
-    }
-
-    @Test
-    @DisplayName("Empty resource error thrown when periods and note resources are empty")
-    void testErrorThrownWhenEmptyResourceSubmitted() throws DataException {
-
-        CreditorsAfterOneYear creditorsAfterOneYear = new CreditorsAfterOneYear();
-
-        ReflectionTestUtils.setField(validator, EMPTY_RESOURCE_NAME,
-                EMPTY_RESOURCE_VALUE);
-
-        errors = validator.validateIfEmptyResource(creditorsAfterOneYear, mockRequest, "");
-
-        assertTrue(errors.hasErrors());
-        assertTrue(errors.containsError(createError(EMPTY_RESOURCE_VALUE,
-                CREDITORS_AFTER_PATH)));
-
     }
 
     private void createValidNoteCurrentPeriod() {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidatorTest.java
@@ -55,6 +55,9 @@ public class CreditorsAfterOneYearValidatorTest {
     private static final String MANDATORY_ELEMENT_MISSING_NAME = "mandatoryElementMissing";
     private static final String MANDATORY_ELEMENT_MISSING_VALUE =
             "mandatory_element_missing";
+    private static final String EMPTY_RESOURCE_NAME = "emptyResource";
+    private static final String EMPTY_RESOURCE_VALUE =
+            "empty_resource";
     private static final String UNEXPECTED_DATA_NAME = "unexpectedData";
     private static final String UNEXPECTED_DATA_VALUE = "unexpected.data";
 
@@ -408,6 +411,23 @@ public class CreditorsAfterOneYearValidatorTest {
         assertThrows(DataException.class,
                 () -> validator.validateCreditorsAfterOneYear(creditorsAfterOneYear,
                         mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest));
+    }
+
+    @Test
+    @DisplayName("Empty resource error thrown when periods and note resources are empty")
+    void testErrorThrownWhenEmptyResourceSubmitted() throws DataException {
+
+        CreditorsAfterOneYear creditorsAfterOneYear = new CreditorsAfterOneYear();
+
+        ReflectionTestUtils.setField(validator, EMPTY_RESOURCE_NAME,
+                EMPTY_RESOURCE_VALUE);
+
+        errors = validator.validateIfEmptyResource(creditorsAfterOneYear, mockRequest, "");
+
+        assertTrue(errors.hasErrors());
+        assertTrue(errors.containsError(createError(EMPTY_RESOURCE_VALUE,
+                CREDITORS_AFTER_PATH)));
+
     }
 
     private void createValidNoteCurrentPeriod() {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidatorTests.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidatorTests.java
@@ -1,5 +1,13 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,15 +31,6 @@ import uk.gov.companieshouse.api.accounts.service.impl.PreviousPeriodService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
-
-import javax.servlet.http.HttpServletRequest;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -366,6 +365,11 @@ public class CreditorsWithinOneYearValidatorTests {
     @DisplayName("Data exception thrown when company service API call fails")
     void testDataExceptionThrown() throws ServiceException {
 
+        Errors errors = new Errors();
+
+        createValidNoteCurrentPeriod();
+        createValidNotePreviousPeriod();
+
         when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenThrow(mockServiceException);
 
         assertThrows(DataException.class,
@@ -403,8 +407,6 @@ public class CreditorsWithinOneYearValidatorTests {
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
                 COMPANY_ACCOUNTS_ID);
         when(mockPreviousPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
-
-        when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(true);
 
         assertThrows(DataException.class,
                 () -> validator.validateCreditorsWithinOneYear(creditorsWithinOneYear,

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -60,6 +60,9 @@ public class DebtorsValidatorTest {
             "mandatory_element_missing";
     private static final String UNEXPECTED_DATA_NAME = "unexpectedData";
     private static final String UNEXPECTED_DATA_VALUE = "unexpected.data";
+    private static final String EMPTY_RESOURCE_NAME = "emptyResource";
+    private static final String EMPTY_RESOURCE_VALUE =
+            "empty_resource";
 
     private static final long INVALID_TOTAL = 200L;
 
@@ -225,6 +228,21 @@ public class DebtorsValidatorTest {
     }
 
     @Test
+    @DisplayName("Validation fails when empty periods and empty note resource")
+    void testValidationAgainstEmptyResource() throws DataException {
+
+        Debtors debtors = new Debtors();
+
+        ReflectionTestUtils.setField(validator, EMPTY_RESOURCE_NAME,
+                EMPTY_RESOURCE_VALUE);
+
+        errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
+
+        assertTrue(errors.containsError(createError(EMPTY_RESOURCE_VALUE,
+                DEBTORS_PATH)));
+    }
+
+    @Test
     @DisplayName("Errors returned when total fields missing")
     void testErrorsReturnedWhenMandatoryFieldsMissing() throws ServiceException,
         DataException {
@@ -371,6 +389,11 @@ public class DebtorsValidatorTest {
     @DisplayName("Data exception thrown when company service API call fails")
     void testDataExceptionThrown() throws ServiceException {
 
+        Errors errors = new Errors();
+
+        createValidNoteCurrentPeriod();
+        createValidNotePreviousPeriod();
+
         when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenThrow(mockServiceException);
 
         assertThrows(DataException.class,
@@ -406,10 +429,8 @@ public class DebtorsValidatorTest {
         mockValidBalanceSheetCurrentPeriod();
 
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
+                COMPANY_ACCOUNTS_ID);
         when(mockPreviousPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
-
-        when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(true);
 
         assertThrows(DataException.class,
             () -> validator.validateDebtors(debtors,

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/EmployeesValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/EmployeesValidatorTest.java
@@ -34,6 +34,10 @@ public class EmployeesValidatorTest {
     private static final String UNEXPECTED_DATA_NAME = "unexpectedData";
     private static final String UNEXPECTED_DATA_VALUE = "unexpected.data";
 
+    private static final String EMPTY_RESOURCE_NAME = "emptyResource";
+    private static final String EMPTY_RESOURCE_VALUE =
+            "empty_resource";
+
     @Mock
     CompanyService mockCompanyService;
 
@@ -63,6 +67,22 @@ public class EmployeesValidatorTest {
         errors = validator.validateEmployees(employees, mockTransaction);
 
         assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    @DisplayName("Note validation when empty note submitted")
+    void testEmptyResourceValidation() throws DataException, ServiceException {
+        Employees employees = new Employees();
+
+        when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(true);
+
+        ReflectionTestUtils.setField(validator, EMPTY_RESOURCE_NAME,
+                EMPTY_RESOURCE_VALUE);
+
+        errors = validator.validateEmployees(employees, mockTransaction);
+
+        assertTrue(errors.containsError(createError(EMPTY_RESOURCE_VALUE,
+                EMPLOYEES_PATH)));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/EmployeesValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/EmployeesValidatorTest.java
@@ -60,10 +60,11 @@ public class EmployeesValidatorTest {
 
     @Test
     @DisplayName("Note validation with valid note for first year filer")
-    void testSuccessfulFirstYearNoteValidation() throws DataException {
+    void testSuccessfulFirstYearNoteValidation() throws DataException, ServiceException {
 
         createValidNoteCurrentPeriod();
 
+        when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(true);
         errors = validator.validateEmployees(employees, mockTransaction);
 
         assertFalse(errors.hasErrors());

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/StocksValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/StocksValidatorTest.java
@@ -1,6 +1,14 @@
 
 package uk.gov.companieshouse.api.accounts.validation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,15 +32,6 @@ import uk.gov.companieshouse.api.accounts.service.impl.PreviousPeriodService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
-
-import javax.servlet.http.HttpServletRequest;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -382,6 +381,10 @@ public class StocksValidatorTest {
     @DisplayName("Data exception thrown when company service API call fails")
     void testDataExceptionThrown() throws ServiceException {
 
+        Errors errors = new Errors();
+
+        createValidNoteCurrentPeriod();
+        createValidNotePreviousPeriod();
         when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenThrow(mockServiceException);
 
         assertThrows(DataException.class,
@@ -419,8 +422,6 @@ public class StocksValidatorTest {
         when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
             COMPANY_ACCOUNTS_ID);
         when(mockPreviousPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
-
-        when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(true);
 
         assertThrows(DataException.class,
             () -> validator.validateStocks(stocks,


### PR DESCRIPTION
Validate an empty note submission when there is no current or previous period.
Add 'empty-resource' error message when empty note submitted.

Added to Stocks, Debtors, employees and Creditors Within notes.

Unit tests updated

SFA-1194