### PR TITLE
Change Find Method Signature

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/AccountingPoliciesController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/AccountingPoliciesController.java
@@ -77,11 +77,9 @@ public class AccountingPoliciesController {
         Transaction transaction = (Transaction) request
                 .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        String accountingPoliciesId = accountingPoliciesService.generateID(companyAccountId);
-
         try {
             ResponseObject<AccountingPolicies> response = accountingPoliciesService
-                    .findById(accountingPoliciesId, request);
+                    .find(companyAccountId, request);
 
             return apiResponseMapper.mapGetResponse(response.getData(), request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/ApprovalController.java
@@ -75,13 +75,11 @@ public class ApprovalController {
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        String approvalId = approvalService.generateID(companyAccountId);
-
         final Map<String, Object> debugMap = new HashMap<>();
         debugMap.put("transaction_id", transaction.getId());
 
         try {
-            ResponseObject<Approval> response = approvalService.findById(approvalId, request);
+            ResponseObject<Approval> response = approvalService.find(companyAccountId, request);
 
             return apiResponseMapper.mapGetResponse(response.getData(), request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CreditorsAfterOneYearController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CreditorsAfterOneYearController.java
@@ -78,11 +78,9 @@ public class CreditorsAfterOneYearController {
         Transaction transaction = (Transaction) request
                 .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        String creditorsAfterOneYearId = creditorsAfterOneYearService.generateID(companyAccountId);
-
         try {
             ResponseObject<CreditorsAfterOneYear> response = creditorsAfterOneYearService
-                    .findById(creditorsAfterOneYearId, request);
+                    .find(companyAccountId, request);
 
             return apiResponseMapper.mapGetResponse(response.getData(), request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CreditorsWithinOneYearController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CreditorsWithinOneYearController.java
@@ -112,11 +112,9 @@ public class CreditorsWithinOneYearController {
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        String creditorsWithinOneYearId = creditorsWithinOneYearService.generateID(companyAccountId);
-
         try {
             ResponseObject<CreditorsWithinOneYear> response = creditorsWithinOneYearService
-                .findById(creditorsWithinOneYearId, request);
+                .find(companyAccountId, request);
 
             return apiResponseMapper.mapGetResponse(response.getData(), request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodController.java
@@ -109,11 +109,9 @@ public class CurrentPeriodController {
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        String currentPeriodId = currentPeriodService.generateID(companyAccountId);
-
         try {
             ResponseObject<CurrentPeriod> response =
-                    currentPeriodService.findById(currentPeriodId, request);
+                    currentPeriodService.find(companyAccountId, request);
 
             return apiResponseMapper.mapGetResponse(response.getData(), request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/DebtorsController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/DebtorsController.java
@@ -76,11 +76,9 @@ public class DebtorsController {
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        String debtorsId = debtorsService.generateID(companyAccountId);
-
         try {
             ResponseObject<Debtors> response = debtorsService
-                .findById(debtorsId, request);
+                .find(companyAccountId, request);
 
             return apiResponseMapper.mapGetResponse(response.getData(), request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/EmployeesController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/EmployeesController.java
@@ -111,11 +111,9 @@ public class EmployeesController {
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        String employeesId = employeesService.generateID(companyAccountId);
-
         try {
             ResponseObject<Employees> response = employeesService
-                .findById(employeesId, request);
+                .find(companyAccountId, request);
 
             return apiResponseMapper.mapGetResponse(response.getData(), request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/FixedAssetsInvestmentsController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/FixedAssetsInvestmentsController.java
@@ -111,11 +111,9 @@ public class FixedAssetsInvestmentsController {
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        String fixedAssetsInvestmentsId = fixedAssetsInvestmentsService.generateID(companyAccountId);
-
         try {
             ResponseObject<FixedAssetsInvestments> response = fixedAssetsInvestmentsService
-                .findById(fixedAssetsInvestmentsId, request);
+                .find(companyAccountId, request);
 
             return apiResponseMapper.mapGetResponse(response.getData(), request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodController.java
@@ -75,11 +75,9 @@ public class PreviousPeriodController {
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        String previousPeriodId = previousPeriodService.generateID(companyAccountId);
-
         try {
             ResponseObject<PreviousPeriod> response =
-                    previousPeriodService.findById(previousPeriodId, request);
+                    previousPeriodService.find(companyAccountId, request);
 
             return apiResponseMapper.mapGetResponse(response.getData(), request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/StatementsController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/StatementsController.java
@@ -85,11 +85,9 @@ public class StatementsController {
         Transaction transaction =
                 (Transaction) request.getAttribute(AttributeName.TRANSACTION.getValue());
 
-        String statementId = statementService.generateID(companyAccountId);
-
         try {
             ResponseObject<Statement> responseObject =
-                statementService.findById(statementId, request);
+                statementService.find(companyAccountId, request);
 
             return apiResponseMapper.mapGetResponse(responseObject.getData(), request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/StocksController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/StocksController.java
@@ -110,11 +110,9 @@ public class StocksController {
         Transaction transaction = (Transaction) request
                 .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        String stocksId = stocksService.generateID(companyAccountId);
-
         try {
             ResponseObject<Stocks> response = stocksService
-                    .findById(stocksId, request);
+                    .find(companyAccountId, request);
 
             return apiResponseMapper.mapGetResponse(response.getData(), request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/TangibleAssetsController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/TangibleAssetsController.java
@@ -78,12 +78,10 @@ public class TangibleAssetsController {
         Transaction transaction = (Transaction) request
                 .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        String tangibleAssetsId = tangibleAssetsService.generateID(companyAccountId);
-
         try {
             ResponseObject<TangibleAssets> response =
                     tangibleAssetsService
-                        .findById(tangibleAssetsId, request);
+                        .find(companyAccountId, request);
 
             return apiResponseMapper.mapGetResponse(response.getData(), request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptor.java
@@ -97,10 +97,9 @@ public class SmallFullInterceptor extends HandlerInterceptorAdapter {
             return false;
         }
 
-        String smallFullId = smallFullService.generateID(companyAccountId);
         ResponseObject<SmallFull> responseObject;
         try {
-            responseObject = smallFullService.findById(smallFullId, request);
+            responseObject = smallFullService.find(companyAccountId, request);
         } catch (DataException de) {
             LOGGER.errorRequest(request, de, debugMap);
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/ResourceService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/ResourceService.java
@@ -16,12 +16,10 @@ public interface ResourceService<T extends RestObject> {
         HttpServletRequest request)
         throws DataException;
 
-    ResponseObject<T> findById(String id, HttpServletRequest request)
+    ResponseObject<T> find(String companyAccountsId, HttpServletRequest request)
         throws DataException;
 
     ResponseObject<T> delete(String companyAccountsId, HttpServletRequest request)
         throws DataException;
-
-    String generateID(String companyAccountId);
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/AccountingPoliciesService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/AccountingPoliciesService.java
@@ -97,13 +97,13 @@ public class AccountingPoliciesService implements ResourceService<AccountingPoli
     }
 
     @Override
-    public ResponseObject<AccountingPolicies> findById(String id, HttpServletRequest request) throws DataException {
+    public ResponseObject<AccountingPolicies> find(String companyAccountsId, HttpServletRequest request) throws DataException {
 
         AccountingPoliciesEntity entity;
 
         try {
 
-            entity = repository.findById(id).orElse(null);
+            entity = repository.findById(generateID(companyAccountsId)).orElse(null);
         } catch (MongoException e) {
 
             throw new DataException(e);
@@ -122,8 +122,7 @@ public class AccountingPoliciesService implements ResourceService<AccountingPoli
         return null;
     }
 
-    @Override
-    public String generateID(String companyAccountId) {
+    private String generateID(String companyAccountId) {
 
         return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.ACCOUNTING_POLICIES.getName());
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/ApprovalService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/ApprovalService.java
@@ -96,13 +96,13 @@ public class ApprovalService implements ResourceService<Approval> {
     }
 
     @Override
-    public ResponseObject<Approval> findById(String id, HttpServletRequest request) throws DataException {
+    public ResponseObject<Approval> find(String companyAccountsId, HttpServletRequest request) throws DataException {
 
         ApprovalEntity approvalEntity;
 
         try {
 
-            approvalEntity = approvalRepository.findById(id).orElse(null);
+            approvalEntity = approvalRepository.findById(generateID(companyAccountsId)).orElse(null);
         } catch (MongoException e) {
 
             throw new DataException(e);
@@ -121,8 +121,7 @@ public class ApprovalService implements ResourceService<Approval> {
         return null;
     }
 
-    @Override
-    public String generateID(String companyAccountId) {
+    private String generateID(String companyAccountId) {
         return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.APPROVAL.getName());
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
@@ -107,11 +107,11 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
     }
 
     @Override
-    public ResponseObject<CreditorsAfterOneYear> findById(String id, HttpServletRequest request) throws DataException {
+    public ResponseObject<CreditorsAfterOneYear> find(String companyAccountsId, HttpServletRequest request) throws DataException {
         CreditorsAfterOneYearEntity entity;
 
         try {
-            entity = repository.findById(id).orElse(null);
+            entity = repository.findById(generateID(companyAccountsId)).orElse(null);
         } catch (MongoException e) {
             throw new DataException(e);
         }
@@ -146,8 +146,7 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
         }
     }
 
-    @Override
-    public String generateID(String companyAccountId) {
+    private String generateID(String companyAccountId) {
         return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.CREDITORS_AFTER_ONE_YEAR.getName());
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
@@ -107,13 +107,13 @@ public class CreditorsWithinOneYearService implements ResourceService<CreditorsW
     }
 
     @Override
-    public ResponseObject<CreditorsWithinOneYear> findById(String id,
+    public ResponseObject<CreditorsWithinOneYear> find(String companyAccountsId,
             HttpServletRequest request) throws DataException {
 
         CreditorsWithinOneYearEntity entity;
 
         try {
-            entity = repository.findById(id).orElse(null);
+            entity = repository.findById(generateID(companyAccountsId)).orElse(null);
         } catch (MongoException e) {
             throw new DataException(e);
         }
@@ -146,8 +146,7 @@ public class CreditorsWithinOneYearService implements ResourceService<CreditorsW
         }
     }
 
-    @Override
-    public String generateID(String companyAccountId) {
+    private String generateID(String companyAccountId) {
         return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.CREDITORS_WITHIN_ONE_YEAR.getName());
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodService.java
@@ -108,12 +108,12 @@ public class CurrentPeriodService implements
     }
 
     @Override
-    public ResponseObject<CurrentPeriod> findById(String id, HttpServletRequest request)
+    public ResponseObject<CurrentPeriod> find(String companyAccountsId, HttpServletRequest request)
         throws DataException {
 
         CurrentPeriodEntity currentPeriodEntity;
         try {
-            currentPeriodEntity = currentPeriodRepository.findById(id).orElse(null);
+            currentPeriodEntity = currentPeriodRepository.findById(generateID(companyAccountsId)).orElse(null);
         } catch (MongoException e) {
             throw new DataException(e);
         }
@@ -130,8 +130,7 @@ public class CurrentPeriodService implements
         return null;
     }
 
-    @Override
-    public String generateID(String value) {
+    private String generateID(String value) {
         return keyIdGenerator.generate(value + "-" + ResourceName.CURRENT_PERIOD.getName());
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
@@ -105,11 +105,11 @@ public class DebtorsService implements ResourceService<Debtors> {
     }
 
     @Override
-    public ResponseObject<Debtors> findById (String id, HttpServletRequest request) throws DataException {
+    public ResponseObject<Debtors> find(String companyAccountsId, HttpServletRequest request) throws DataException {
         DebtorsEntity entity;
 
         try {
-            entity = repository.findById(id).orElse(null);
+            entity = repository.findById(generateID(companyAccountsId)).orElse(null);
         } catch (MongoException e) {
             throw new DataException(e);
         }
@@ -140,8 +140,8 @@ public class DebtorsService implements ResourceService<Debtors> {
             throw new DataException(e);
         }
     }
-    @Override
-    public String generateID(String companyAccountId) {
+
+    private String generateID(String companyAccountId) {
         return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.DEBTORS.getName());
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/EmployeesService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/EmployeesService.java
@@ -111,13 +111,13 @@ public class EmployeesService implements ResourceService<Employees> {
     }
 
     @Override
-    public ResponseObject<Employees> findById(String id,
+    public ResponseObject<Employees> find(String companyAccountsId,
             HttpServletRequest request) throws DataException {
 
         EmployeesEntity entity;
 
         try {
-            entity = repository.findById(id).orElse(null);
+            entity = repository.findById(generateID(companyAccountsId)).orElse(null);
         } catch (MongoException e) {
 
             throw new DataException(e);
@@ -152,8 +152,7 @@ public class EmployeesService implements ResourceService<Employees> {
         }
     }
 
-    @Override
-    public String generateID(String companyAccountId) {
+    private String generateID(String companyAccountId) {
         return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.EMPLOYEES.getName());
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FixedAssetsInvestmentsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FixedAssetsInvestmentsService.java
@@ -89,13 +89,13 @@ public class FixedAssetsInvestmentsService implements ResourceService<FixedAsset
     }
 
     @Override
-    public ResponseObject<FixedAssetsInvestments> findById(String id,
+    public ResponseObject<FixedAssetsInvestments> find(String companyAccountsId,
             HttpServletRequest request) throws DataException {
 
         FixedAssetsInvestmentsEntity entity;
 
         try {
-            entity = repository.findById(id).orElse(null);
+            entity = repository.findById(generateID(companyAccountsId)).orElse(null);
         } catch (MongoException e) {
             throw new DataException(e);
         }
@@ -128,8 +128,7 @@ public class FixedAssetsInvestmentsService implements ResourceService<FixedAsset
         }
     }
 
-    @Override
-    public String generateID(String companyAccountId) {
+    private String generateID(String companyAccountId) {
         return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.FIXED_ASSETS_INVESTMENTS.getName());
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodService.java
@@ -87,13 +87,13 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
     }
 
     @Override
-    public ResponseObject<PreviousPeriod> findById(String id, HttpServletRequest request)
+    public ResponseObject<PreviousPeriod> find(String companyAccountsId, HttpServletRequest request)
         throws DataException {
 
         PreviousPeriodEntity previousPeriodEntity;
 
         try {
-            previousPeriodEntity = previousPeriodRepository.findById(id).orElse(null);
+            previousPeriodEntity = previousPeriodRepository.findById(generateID(companyAccountsId)).orElse(null);
         } catch (MongoException e) {
             throw new DataException(e);
         }
@@ -133,8 +133,7 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod> {
         return new ResponseObject<>(ResponseStatus.UPDATED, rest);
     }
 
-    @Override
-    public String generateID(String value) {
+    private String generateID(String value) {
         return keyIdGenerator.generate(value + "-" + ResourceName.PREVIOUS_PERIOD.getName());
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullService.java
@@ -81,11 +81,11 @@ public class SmallFullService implements
     }
 
     @Override
-    public ResponseObject<SmallFull> findById(String id, HttpServletRequest request) throws DataException {
+    public ResponseObject<SmallFull> find(String companyAccountsId, HttpServletRequest request) throws DataException {
 
         SmallFullEntity smallFullEntity;
         try {
-            smallFullEntity = smallFullRepository.findById(id).orElse(null);
+            smallFullEntity = smallFullRepository.findById(generateID(companyAccountsId)).orElse(null);
         } catch (MongoException e) {
             throw new DataException(e);
         }
@@ -136,8 +136,7 @@ public class SmallFullService implements
         }
     }
 
-    @Override
-    public String generateID(String value) {
+    private String generateID(String value) {
         return keyIdGenerator.generate(value + "-" + ResourceName.SMALL_FULL.getName());
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
@@ -113,13 +113,13 @@ public class StatementService implements ResourceService<Statement> {
     }
 
     @Override
-    public ResponseObject<Statement> findById(String id, HttpServletRequest request)
+    public ResponseObject<Statement> find(String companyAccountsId, HttpServletRequest request)
         throws DataException {
 
         StatementEntity statementEntity;
 
         try {
-            statementEntity = statementRepository.findById(id).orElse(null);
+            statementEntity = statementRepository.findById(generateID(companyAccountsId)).orElse(null);
 
         } catch (MongoException ex) {
 
@@ -138,8 +138,7 @@ public class StatementService implements ResourceService<Statement> {
         return null;
     }
 
-    @Override
-    public String generateID(String companyAccountId) {
+    private String generateID(String companyAccountId) {
         return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.STATEMENTS.getName());
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StocksService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StocksService.java
@@ -102,12 +102,12 @@ public class StocksService implements ResourceService<Stocks> {
     }
 
     @Override
-    public ResponseObject<Stocks> findById(String id, HttpServletRequest request) throws DataException {
+    public ResponseObject<Stocks> find(String companyAccountsId, HttpServletRequest request) throws DataException {
 
         StocksEntity entity;
 
         try {
-            entity = repository.findById(id).orElse(null);
+            entity = repository.findById(generateID(companyAccountsId)).orElse(null);
         } catch (MongoException e) {
             throw new DataException(e);
         }
@@ -138,8 +138,7 @@ public class StocksService implements ResourceService<Stocks> {
         }
     }
 
-    @Override
-    public String generateID(String companyAccountId) {
+    private String generateID(String companyAccountId) {
         return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.STOCKS.getName());
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TangibleAssetsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TangibleAssetsService.java
@@ -101,14 +101,14 @@ public class TangibleAssetsService implements ResourceService<TangibleAssets> {
     }
 
     @Override
-    public ResponseObject<TangibleAssets> findById(String id, HttpServletRequest request)
+    public ResponseObject<TangibleAssets> find(String companyAccountsId, HttpServletRequest request)
             throws DataException {
 
         TangibleAssetsEntity entity;
 
         try {
 
-            entity = repository.findById(id).orElse(null);
+            entity = repository.findById(generateID(companyAccountsId)).orElse(null);
         } catch (MongoException e) {
 
             throw new DataException(e);
@@ -145,8 +145,7 @@ public class TangibleAssetsService implements ResourceService<TangibleAssets> {
         }
     }
 
-    @Override
-    public String generateID(String companyAccountId) {
+    private String generateID(String companyAccountId) {
 
         return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.TANGIBLE_ASSETS.getName());
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
@@ -325,11 +325,9 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
 
     private BalanceSheet getPreviousPeriodBalanceSheet(
             HttpServletRequest request, String companyAccountsId) throws DataException {
-        String previousPeriodId = previousPeriodService.generateID(companyAccountsId);
 
-        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject;
-
-        previousPeriodResponseObject = previousPeriodService.findById(previousPeriodId, request);
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject
+                = previousPeriodService.find(companyAccountsId, request);
 
         if (previousPeriodResponseObject != null && previousPeriodResponseObject.getData() != null) {
             return previousPeriodResponseObject.getData().getBalanceSheet();
@@ -391,11 +389,8 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
     private BalanceSheet getCurrentPeriodBalanceSheet(HttpServletRequest request,
             String companyAccountsId) throws DataException {
 
-        String currentPeriodId = currentPeriodService.generateID(companyAccountsId);
-
-        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject;
-
-        currentPeriodResponseObject = currentPeriodService.findById(currentPeriodId, request);
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject
+                = currentPeriodService.find(companyAccountsId, request);
 
         if (currentPeriodResponseObject != null && currentPeriodResponseObject.getData() != null) {
             return currentPeriodResponseObject.getData().getBalanceSheet();

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -337,11 +337,9 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
 
     private BalanceSheet getPreviousPeriodBalanceSheet(
             HttpServletRequest request, String companyAccountsId) throws DataException {
-        String previousPeriodId = previousPeriodService.generateID(companyAccountsId);
 
-        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject;
-
-        previousPeriodResponseObject = previousPeriodService.findById(previousPeriodId, request);
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject
+                = previousPeriodService.find(companyAccountsId, request);
 
         if (previousPeriodResponseObject != null && previousPeriodResponseObject.getData() != null) {
             return previousPeriodResponseObject.getData().getBalanceSheet();
@@ -403,11 +401,8 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
     private BalanceSheet getCurrentPeriodBalanceSheet(HttpServletRequest request,
             String companyAccountsId) throws DataException {
 
-        String currentPeriodId = currentPeriodService.generateID(companyAccountsId);
-
-        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject;
-
-        currentPeriodResponseObject = currentPeriodService.findById(currentPeriodId, request);
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject
+                = currentPeriodService.find(companyAccountsId, request);
 
         if (currentPeriodResponseObject != null && currentPeriodResponseObject.getData() != null) {
             return currentPeriodResponseObject.getData().getBalanceSheet();

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -241,11 +241,8 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     private BalanceSheet getCurrentPeriodBalanceSheet(HttpServletRequest request,
             String companyAccountsId) throws DataException {
 
-        String currentPeriodId = currentPeriodService.generateID(companyAccountsId);
-
-        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject;
-
-        currentPeriodResponseObject = currentPeriodService.findById(currentPeriodId, request);
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject
+                = currentPeriodService.find(companyAccountsId, request);
 
         if (currentPeriodResponseObject != null && currentPeriodResponseObject.getData() != null) {
             return currentPeriodResponseObject.getData().getBalanceSheet();
@@ -256,11 +253,9 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
 
     private BalanceSheet getPreviousPeriodBalanceSheet(
             HttpServletRequest request, String companyAccountsId) throws DataException {
-        String previousPeriodId = previousPeriodService.generateID(companyAccountsId);
 
-        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject;
-
-        previousPeriodResponseObject = previousPeriodService.findById(previousPeriodId, request);
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject
+                = previousPeriodService.find(companyAccountsId, request);
 
         if (previousPeriodResponseObject != null && previousPeriodResponseObject.getData() != null) {
             return previousPeriodResponseObject.getData().getBalanceSheet();

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/StocksValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/StocksValidator.java
@@ -291,11 +291,9 @@ public class StocksValidator extends BaseValidator implements CrossValidator<Sto
 
     private BalanceSheet getPreviousPeriodBalanceSheet(
         HttpServletRequest request, String companyAccountsId) throws DataException {
-        String previousPeriodId = previousPeriodService.generateID(companyAccountsId);
 
-        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject;
-
-        previousPeriodResponseObject = previousPeriodService.findById(previousPeriodId, request);
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject
+                = previousPeriodService.find(companyAccountsId, request);
 
         if (previousPeriodResponseObject != null && previousPeriodResponseObject.getData() != null) {
             return previousPeriodResponseObject.getData().getBalanceSheet();
@@ -351,11 +349,8 @@ public class StocksValidator extends BaseValidator implements CrossValidator<Sto
     private BalanceSheet getCurrentPeriodBalanceSheet(HttpServletRequest request,
                                                       String companyAccountsId) throws DataException {
 
-        String currentPeriodId = currentPeriodService.generateID(companyAccountsId);
-
-        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject;
-
-        currentPeriodResponseObject = currentPeriodService.findById(currentPeriodId, request);
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject
+                = currentPeriodService.find(companyAccountsId, request);
 
         if (currentPeriodResponseObject != null && currentPeriodResponseObject.getData() != null) {
             return currentPeriodResponseObject.getData().getBalanceSheet();

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/TangibleAssetsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/TangibleAssetsValidator.java
@@ -929,10 +929,8 @@ public class TangibleAssetsValidator extends BaseValidator implements CrossValid
     private void crossValidateCurrentPeriod(Errors errors, HttpServletRequest request, String companyAccountsId,
                                             TangibleAssets tangibleAssets) throws DataException {
 
-        String currentPeriodId = currentPeriodService.generateID(companyAccountsId);
-
         ResponseObject<CurrentPeriod> currentPeriodResponseObject =
-                currentPeriodService.findById(currentPeriodId, request);
+                currentPeriodService.find(companyAccountsId, request);
         CurrentPeriod currentPeriod = currentPeriodResponseObject.getData();
 
         Long currentPeriodTangible =
@@ -960,10 +958,8 @@ public class TangibleAssetsValidator extends BaseValidator implements CrossValid
     private void crossValidatePreviousPeriod(Errors errors, HttpServletRequest request, String companyAccountsId,
             TangibleAssets tangibleAssets) throws DataException {
 
-        String previousPeriodId = previousPeriodService.generateID(companyAccountsId);
-
         ResponseObject<PreviousPeriod> previousPeriodResponseObject =
-                previousPeriodService.findById(previousPeriodId, request);
+                previousPeriodService.find(companyAccountsId, request);
         PreviousPeriod previousPeriod = previousPeriodResponseObject.getData();
 
         Long previousPeriodTangible =

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/AccountingPoliciesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/AccountingPoliciesControllerTest.java
@@ -68,8 +68,6 @@ public class AccountingPoliciesControllerTest {
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
 
-    private static final String ACCOUNTING_POLICIES_ID = "accountingPoliciesId";
-
     @Test
     @DisplayName("Create accounting policies - has binding errors")
     void createAccountingPoliciesBindingErrors() {
@@ -136,11 +134,10 @@ public class AccountingPoliciesControllerTest {
     void getAccountingPoliciesSuccess() throws DataException {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
-        when(accountingPoliciesService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(ACCOUNTING_POLICIES_ID);
 
         ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND,
                 accountingPolicies);
-        when(accountingPoliciesService.findById(ACCOUNTING_POLICIES_ID, request))
+        when(accountingPoliciesService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(responseObject);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.FOUND)
@@ -161,9 +158,8 @@ public class AccountingPoliciesControllerTest {
     void getAccountingPoliciesDataException() throws DataException {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
-        when(accountingPoliciesService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(ACCOUNTING_POLICIES_ID);
 
-        when(accountingPoliciesService.findById(ACCOUNTING_POLICIES_ID, request))
+        when(accountingPoliciesService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/ApprovalControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/ApprovalControllerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.security.NoSuchAlgorithmException;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -57,13 +56,13 @@ public class ApprovalControllerTest {
     private ApprovalController approvalController;
 
     @BeforeEach
-    public void setUp() throws NoSuchAlgorithmException, DataException {
+    public void setUp() {
         when(request.getAttribute("transaction")).thenReturn(transaction);
     }
 
     @Test
     @DisplayName("Tests the successful creation of a approval resource")
-    public void canCreateApproval() throws NoSuchAlgorithmException, DataException {
+    public void canCreateApproval() throws DataException {
         ResponseObject successCreateResponse = new ResponseObject(ResponseStatus.CREATED,
             approval);
         doReturn(successCreateResponse).when(approvalService)
@@ -102,11 +101,11 @@ public class ApprovalControllerTest {
 
     @Test
     @DisplayName("Test the retreval of a approval resource")
-    public void canRetrieveApproval() throws NoSuchAlgorithmException, DataException {
+    public void canRetrieveApproval() throws DataException {
         ResponseObject successFindResponse = new ResponseObject(ResponseStatus.FOUND,
             approval);
-        doReturn(successFindResponse).when(approvalService).findById("find", request);
-        doReturn("find").when(approvalService).generateID("123456");
+        doReturn(successFindResponse).when(approvalService).find("123456", request);
+
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.OK).body(approval);
         when(apiResponseMapper.mapGetResponse(approval,
             request)).thenReturn(responseEntity);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CreditorsAfterOneYearControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CreditorsAfterOneYearControllerTest.java
@@ -36,7 +36,6 @@ import uk.gov.companieshouse.api.accounts.utility.ErrorMapper;
 public class CreditorsAfterOneYearControllerTest {
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
-    private static final String CREDITORS_AFTER_ONE_YEAR_ID = "creditorsAfterOneYearId";
 
     @Mock
     private BindingResult mockBindingResult;
@@ -236,11 +235,10 @@ public class CreditorsAfterOneYearControllerTest {
     void getCreditorsAfterOneYearSuccess() throws DataException {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
-        when(mockCreditorsAfterOneYearService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(CREDITORS_AFTER_ONE_YEAR_ID);
 
         ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND,
                 mockCreditorsAfterOneYear);
-        when(mockCreditorsAfterOneYearService.findById(CREDITORS_AFTER_ONE_YEAR_ID, mockRequest))
+        when(mockCreditorsAfterOneYearService.find(COMPANY_ACCOUNTS_ID, mockRequest))
                 .thenReturn(responseObject);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.FOUND)
@@ -261,9 +259,8 @@ public class CreditorsAfterOneYearControllerTest {
     void getCreditorsAfterOneYearDataException() throws DataException {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
-        when(mockCreditorsAfterOneYearService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(CREDITORS_AFTER_ONE_YEAR_ID);
 
-        when(mockCreditorsAfterOneYearService.findById(CREDITORS_AFTER_ONE_YEAR_ID, mockRequest))
+        when(mockCreditorsAfterOneYearService.find(COMPANY_ACCOUNTS_ID, mockRequest))
                 .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity =

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CreditorsWithinOneYearControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CreditorsWithinOneYearControllerTest.java
@@ -36,7 +36,6 @@ import uk.gov.companieshouse.api.accounts.utility.ErrorMapper;
 public class CreditorsWithinOneYearControllerTest {
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
-    private static final String CREDITORS_WITHIN_ONE_YEAR_ID = "creditorsWithinOneYearId";
 
     @Mock
     private BindingResult mockBindingResult;
@@ -223,11 +222,10 @@ public class CreditorsWithinOneYearControllerTest {
     void getCreditorsWithinOneYearSuccess() throws DataException {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
-        when(mockCreditorsWithinOneYearService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(CREDITORS_WITHIN_ONE_YEAR_ID);
 
         ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND,
                 mockCreditorsWithinOneYear);
-        when(mockCreditorsWithinOneYearService.findById(CREDITORS_WITHIN_ONE_YEAR_ID, mockRequest))
+        when(mockCreditorsWithinOneYearService.find(COMPANY_ACCOUNTS_ID, mockRequest))
                 .thenReturn(responseObject);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.FOUND)
@@ -248,9 +246,8 @@ public class CreditorsWithinOneYearControllerTest {
     void getDebtorsDataException() throws DataException {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
-        when(mockCreditorsWithinOneYearService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(CREDITORS_WITHIN_ONE_YEAR_ID);
 
-        when(mockCreditorsWithinOneYearService.findById(CREDITORS_WITHIN_ONE_YEAR_ID, mockRequest))
+        when(mockCreditorsWithinOneYearService.find(COMPANY_ACCOUNTS_ID, mockRequest))
                 .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity =

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
@@ -25,7 +25,6 @@ import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
-import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.service.impl.CurrentPeriodService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
@@ -50,9 +49,6 @@ public class CurrentPeriodControllerTest {
 
     @Mock
     private BindingResult bindingResult;
-
-    @Mock
-    private Errors errors;
 
     @Mock
     private CurrentPeriodService currentPeriodService;
@@ -91,10 +87,9 @@ public class CurrentPeriodControllerTest {
     @DisplayName("Test the retreval of a current period resource")
     public void canRetrieveCurrentPeriod() throws DataException {
         when(request.getAttribute("transaction")).thenReturn(transaction);
-        doReturn("find").when(currentPeriodService).generateID("123456");
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.OK).body(currentPeriod);
         doReturn(new ResponseObject(ResponseStatus.FOUND,
-            currentPeriod)).when(currentPeriodService).findById("find", request);
+            currentPeriod)).when(currentPeriodService).find("123456", request);
         when(apiResponseMapper.mapGetResponse(currentPeriod,
             request)).thenReturn(responseEntity);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/DebtorsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/DebtorsControllerTest.java
@@ -36,7 +36,6 @@ import uk.gov.companieshouse.api.accounts.utility.ErrorMapper;
 public class DebtorsControllerTest {
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
-    private static final String DEBTORS_ID = "debtorsId";
 
     @Mock
     private BindingResult mockBindingResult;
@@ -54,7 +53,7 @@ public class DebtorsControllerTest {
     private ApiResponseMapper mockApiResponseMapper;
 
     @Mock
-    DebtorsService mockDebtorsService;
+    private DebtorsService mockDebtorsService;
 
     @Mock
     private SmallFull mockSmallFull;
@@ -135,11 +134,10 @@ public class DebtorsControllerTest {
     void getDebtorsSuccess() throws DataException {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
-        when(mockDebtorsService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(DEBTORS_ID);
 
         ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND,
             mockDebtors);
-        when(mockDebtorsService.findById(DEBTORS_ID, mockRequest))
+        when(mockDebtorsService.find(COMPANY_ACCOUNTS_ID, mockRequest))
             .thenReturn(responseObject);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.FOUND)
@@ -160,9 +158,8 @@ public class DebtorsControllerTest {
     void getDebtorsDataException() throws DataException {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
-        when(mockDebtorsService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(DEBTORS_ID);
 
-        when(mockDebtorsService.findById(DEBTORS_ID, mockRequest))
+        when(mockDebtorsService.find(COMPANY_ACCOUNTS_ID, mockRequest))
             .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/EmployeesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/EmployeesControllerTest.java
@@ -36,7 +36,6 @@ import uk.gov.companieshouse.api.accounts.utility.ErrorMapper;
 public class EmployeesControllerTest {
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
-    private static final String EMPLOYEES_ID = "employeesId";
 
     @Mock
     private BindingResult mockBindingResult;
@@ -240,11 +239,10 @@ public class EmployeesControllerTest {
     void getEmployeesSuccess() throws DataException {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
-        when(mockEmployeesService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(EMPLOYEES_ID);
 
         ResponseObject mockResponseObject = new ResponseObject(ResponseStatus.FOUND,
                 mockEmployees);
-        when(mockEmployeesService.findById(EMPLOYEES_ID, mockRequest))
+        when(mockEmployeesService.find(COMPANY_ACCOUNTS_ID, mockRequest))
                 .thenReturn(mockResponseObject);
 
         ResponseEntity mockResponseEntity = ResponseEntity.status(HttpStatus.FOUND)
@@ -265,10 +263,9 @@ public class EmployeesControllerTest {
     void getEmployeesDataException() throws DataException {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
-        when(mockEmployeesService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(EMPLOYEES_ID);
 
         DataException dataException = new DataException("");
-        when(mockEmployeesService.findById(EMPLOYEES_ID, mockRequest))
+        when(mockEmployeesService.find(COMPANY_ACCOUNTS_ID, mockRequest))
                 .thenThrow(dataException);
 
         ResponseEntity mockResponseEntity =

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/FixedAssetsInvestmentsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/FixedAssetsInvestmentsControllerTest.java
@@ -36,7 +36,6 @@ import uk.gov.companieshouse.api.accounts.utility.ErrorMapper;
 public class FixedAssetsInvestmentsControllerTest {
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
-    private static final String FIXED_ASSETS_INVESTMENTS_ID = "fixedAssetsInvestmentsId";
 
     @Mock
     private BindingResult mockBindingResult;
@@ -225,11 +224,10 @@ public class FixedAssetsInvestmentsControllerTest {
     void getFixedAssetsInvestmentsSuccess() throws DataException {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
-        when(mockFixedAssetsInvestmentsService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(FIXED_ASSETS_INVESTMENTS_ID);
 
         ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND,
                 mockFixedAssetsInvestments);
-        when(mockFixedAssetsInvestmentsService.findById(FIXED_ASSETS_INVESTMENTS_ID, mockRequest))
+        when(mockFixedAssetsInvestmentsService.find(COMPANY_ACCOUNTS_ID, mockRequest))
                 .thenReturn(responseObject);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.FOUND)
@@ -250,10 +248,9 @@ public class FixedAssetsInvestmentsControllerTest {
     void getFixedAssetsInvestmentsDataException() throws DataException {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
-        when(mockFixedAssetsInvestmentsService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(FIXED_ASSETS_INVESTMENTS_ID);
 
         DataException dataException = new DataException("");
-        when(mockFixedAssetsInvestmentsService.findById(FIXED_ASSETS_INVESTMENTS_ID, mockRequest))
+        when(mockFixedAssetsInvestmentsService.find(COMPANY_ACCOUNTS_ID, mockRequest))
                 .thenThrow(dataException);
 
         ResponseEntity responseEntity =

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodControllerTest.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.api.accounts.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -12,7 +11,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
-import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +25,6 @@ import org.springframework.validation.BindingResult;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
-import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
@@ -37,32 +34,21 @@ import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.utility.ApiResponseMapper;
 import uk.gov.companieshouse.api.accounts.utility.ErrorMapper;
+
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PreviousPeriodControllerTest {
 
-    public static final String X_REQUEST_ID = "X-Request-Id";
-    public static final String TRANSACTION_STRING = "transaction";
-    public static final String TEST = "test";
-    public static final String CREATE = "create";
-    public static final String FIND = "find";
-    public static final String SELF = "self";
     public static final String COMPANY_ACCOUNT_ID = "12345";
 
     @Mock
     private HttpServletRequest request;
 
     @Mock
-    private BindingResult result;
-
-    @Mock
     private PreviousPeriod previousPeriod;
 
     @Mock
     private Transaction transaction;
-
-    @Mock
-    private CompanyAccountEntity companyAccountEntity;
 
     @Mock
     private PreviousPeriodService previousPeriodService;
@@ -81,9 +67,6 @@ public class PreviousPeriodControllerTest {
 
     @Mock
     private BindingResult bindingResult;
-
-    @Mock
-    private Map<String, String> links;
 
     @InjectMocks
     private PreviousPeriodController previousPeriodController;
@@ -148,12 +131,11 @@ public class PreviousPeriodControllerTest {
     @Test
     @DisplayName("Test the successful retrieval of a previous period resource")
     public void canRetrievePreviousPeriod() throws DataException {
-        doReturn("find").when(previousPeriodService).generateID("123456");
         doReturn(transaction).when(request).getAttribute(AttributeName.TRANSACTION.getValue());
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.OK).body(previousPeriod);
 
-        when(previousPeriodService.findById(anyString(), any(HttpServletRequest.class)))
+        when(previousPeriodService.find(anyString(), any(HttpServletRequest.class)))
             .thenReturn(new ResponseObject(ResponseStatus.FOUND, previousPeriod));
         when(apiResponseMapper.mapGetResponse(previousPeriod, request)).thenReturn(responseEntity);
 
@@ -206,12 +188,11 @@ public class PreviousPeriodControllerTest {
     @Test
     @DisplayName("Test the unsuccessful retrieval of a previous period resource")
     public void canRetrievePreviousPeriodFailed() throws DataException {
-        doReturn("find").when(previousPeriodService).generateID("123456");
         doReturn(transaction).when(request).getAttribute(AttributeName.TRANSACTION.getValue());
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(null);
-        when(previousPeriodService.findById(anyString(), any(HttpServletRequest.class)))
+        when(previousPeriodService.find(anyString(), any(HttpServletRequest.class)))
             .thenThrow(new DataException(""));
         when(apiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/StatementsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/StatementsControllerTest.java
@@ -32,17 +32,20 @@ import uk.gov.companieshouse.api.accounts.utility.ApiResponseMapper;
 @TestInstance(Lifecycle.PER_CLASS)
 public class StatementsControllerTest {
 
-    private static final String STATEMENT_ID = "abcdef";
     private static final String COMPANY_ACCOUNTS_ID = "123123";
 
     @Mock
     private Statement statementMock;
+
     @Mock
     private StatementService statementServiceMock;
+
     @Mock
     private Transaction transactionMock;
+
     @Mock
     private HttpServletRequest requestMock;
+
     @Mock
     private ApiResponseMapper apiResponseMapperMock;
 
@@ -139,11 +142,10 @@ public class StatementsControllerTest {
     @Test
     @DisplayName("Tests the successful request to get Statements")
     void shouldGetStatements() throws DataException {
-        when(statementServiceMock.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(STATEMENT_ID);
 
         ResponseObject restObjectFound = createResponseObject(ResponseStatus.FOUND);
 
-        when(statementServiceMock.findById(STATEMENT_ID, requestMock))
+        when(statementServiceMock.find(COMPANY_ACCOUNTS_ID, requestMock))
             .thenReturn(restObjectFound);
 
         when(apiResponseMapperMock.mapGetResponse(restObjectFound.getData(), requestMock))
@@ -153,18 +155,17 @@ public class StatementsControllerTest {
             statementsController.get(COMPANY_ACCOUNTS_ID, requestMock);
 
         assertStatementControllerResponse(response, HttpStatus.OK, true);
-        verifyStatementServiceGenerateAndFind(STATEMENT_ID);
+        verifyStatementServiceFind();
         verifyApiResponseMapperMapGetResponseCall(restObjectFound);
     }
 
     @Test
     @DisplayName("Tests the unsuccessful request to get Statements as statement id not found")
     void shouldNotGetStatementsStatementIdNotFound() throws DataException {
-        when(statementServiceMock.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(STATEMENT_ID);
 
         ResponseObject restObjectNotFound = createResponseObject(ResponseStatus.NOT_FOUND);
 
-        when(statementServiceMock.findById(STATEMENT_ID, requestMock))
+        when(statementServiceMock.find(COMPANY_ACCOUNTS_ID, requestMock))
             .thenReturn(restObjectNotFound);
 
         when(apiResponseMapperMock.mapGetResponse(restObjectNotFound.getData(), requestMock))
@@ -174,7 +175,7 @@ public class StatementsControllerTest {
             statementsController.get(COMPANY_ACCOUNTS_ID, requestMock);
 
         assertStatementControllerResponse(response, HttpStatus.NOT_FOUND, true);
-        verifyStatementServiceGenerateAndFind(STATEMENT_ID);
+        verifyStatementServiceFind();
         verifyApiResponseMapperMapGetResponseCall(restObjectNotFound);
     }
 
@@ -183,9 +184,7 @@ public class StatementsControllerTest {
     void shouldNotGetStatementsStatementAsExceptionOccurs() throws DataException {
         when(requestMock.getAttribute(anyString())).thenReturn(transactionMock);
 
-        when(statementServiceMock.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(STATEMENT_ID);
-
-        when(statementServiceMock.findById(STATEMENT_ID, requestMock))
+        when(statementServiceMock.find(COMPANY_ACCOUNTS_ID, requestMock))
             .thenThrow(new DataException(""));
 
         when(apiResponseMapperMock.getErrorResponse())
@@ -195,7 +194,7 @@ public class StatementsControllerTest {
             statementsController.get(COMPANY_ACCOUNTS_ID, requestMock);
 
         assertStatementControllerResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, false);
-        verifyStatementServiceGenerateAndFind(STATEMENT_ID);
+        verifyStatementServiceFind();
         verify(apiResponseMapperMock, times(1)).getErrorResponse();
     }
 
@@ -266,13 +265,10 @@ public class StatementsControllerTest {
      *
      * @throws DataException
      */
-    private void verifyStatementServiceGenerateAndFind(String a) throws DataException {
+    private void verifyStatementServiceFind() throws DataException {
 
         verify(statementServiceMock, times(1))
-            .generateID(COMPANY_ACCOUNTS_ID);
-
-        verify(statementServiceMock, times(1))
-            .findById(STATEMENT_ID, requestMock);
+            .find(COMPANY_ACCOUNTS_ID, requestMock);
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/StocksControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/StocksControllerTest.java
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.when;
 public class StocksControllerTest {
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
-    private static final String STOCKS_ID = "stocksId";
 
     @Mock
     private BindingResult mockBindingResult;
@@ -214,11 +213,10 @@ public class StocksControllerTest {
     void getStocksSuccess() throws DataException {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
-        when(mockStocksService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(STOCKS_ID);
 
         ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND,
                 mockStocks);
-        when(mockStocksService.findById(STOCKS_ID, mockRequest))
+        when(mockStocksService.find(COMPANY_ACCOUNTS_ID, mockRequest))
                 .thenReturn(responseObject);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.FOUND)
@@ -239,9 +237,8 @@ public class StocksControllerTest {
     void getStocksDataException() throws DataException {
 
         when(mockRequest.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(mockTransaction);
-        when(mockStocksService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(STOCKS_ID);
 
-        when(mockStocksService.findById(STOCKS_ID, mockRequest))
+        when(mockStocksService.find(COMPANY_ACCOUNTS_ID, mockRequest))
                 .thenThrow(new DataException(""));
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/TangibleAssetsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/TangibleAssetsControllerTest.java
@@ -75,7 +75,6 @@ public class TangibleAssetsControllerTest {
     private TangibleAssetsController controller;
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
-    private static final String GENERATED_ID = "generatedId";
     private static final String TANGIBLE_ASSETS_LINK = "tangibleAssetsLink";
 
     @Test
@@ -158,10 +157,9 @@ public class TangibleAssetsControllerTest {
     void getTangibleAssetsSuccess() throws DataException {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
-        when(tangibleAssetsService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(GENERATED_ID);
 
         ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND, tangibleAssets);
-        when(tangibleAssetsService.findById(GENERATED_ID, request))
+        when(tangibleAssetsService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(responseObject);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.FOUND).body(responseObject.getData());
@@ -175,7 +173,7 @@ public class TangibleAssetsControllerTest {
         assertEquals(tangibleAssets, response.getBody());
 
         verify(tangibleAssetsService, times(1))
-                .findById(GENERATED_ID, request);
+                .find(COMPANY_ACCOUNTS_ID, request);
         verify(apiResponseMapper, times(1))
                 .mapGetResponse(responseObject.getData(), request);
     }
@@ -185,9 +183,8 @@ public class TangibleAssetsControllerTest {
     void getTangibleAssetsServiceThrowsDataException() throws DataException {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
-        when(tangibleAssetsService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(GENERATED_ID);
 
-        doThrow(new DataException("")).when(tangibleAssetsService).findById(GENERATED_ID, request);
+        doThrow(new DataException("")).when(tangibleAssetsService).find(COMPANY_ACCOUNTS_ID, request);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         when(apiResponseMapper.getErrorResponse()).thenReturn(responseEntity);
@@ -199,7 +196,7 @@ public class TangibleAssetsControllerTest {
         assertNull(response.getBody());
 
         verify(tangibleAssetsService, times(1))
-                .findById(GENERATED_ID, request);
+                .find(COMPANY_ACCOUNTS_ID, request);
         verify(apiResponseMapper, never()).mapGetResponse(any(), any());
         verify(apiResponseMapper, times(1)).getErrorResponse();
     }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptorTest.java
@@ -28,7 +28,6 @@ import org.springframework.web.servlet.HandlerMapping;
 import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountDataEntity;
-import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
 import uk.gov.companieshouse.api.accounts.service.impl.SmallFullService;
@@ -85,14 +84,13 @@ public class SmallFullInterceptorTest {
         doReturn(companyAccount).when(httpServletRequest).getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
         doReturn(pathVariables).when(httpServletRequest).getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
 
-        when(smallFullService.generateID(anyString())).thenReturn("test");
         when(httpServletRequest.getMethod()).thenReturn("GET");
     }
 
     @Test
     @DisplayName("Tests the interceptor returns correctly when all is valid")
     public void testReturnsCorrectlyOnValidConditions() throws NoSuchAlgorithmException, DataException {
-        when(smallFullService.findById(anyString(), any(HttpServletRequest.class))).thenReturn(responseObject);
+        when(smallFullService.find(anyString(), any(HttpServletRequest.class))).thenReturn(responseObject);
         when(responseObject.getStatus()).thenReturn(ResponseStatus.FOUND);
         when(responseObject.getData()).thenReturn(smallFull);
         when(companyAccount.getLinks()).thenReturn(companyAccountLinks);
@@ -102,14 +100,14 @@ public class SmallFullInterceptorTest {
 
         smallFullInterceptor.preHandle(httpServletRequest, httpServletResponse,
                 new Object());
-        verify(smallFullService, times(1)).findById(anyString(), any(HttpServletRequest.class));
+        verify(smallFullService, times(1)).find(anyString(), any(HttpServletRequest.class));
         verify(httpServletRequest, times(1)).setAttribute(anyString(), any(SmallFull.class));
     }
 
     @Test
     @DisplayName("Tests the interceptor returns false on a failed SmallFullEntity lookup")
     public void testReturnsFalseForAFailedLookup() throws NoSuchAlgorithmException, DataException {
-        doThrow(mock(DataException.class)).when(smallFullService).findById(anyString(), any(HttpServletRequest.class));
+        doThrow(mock(DataException.class)).when(smallFullService).find(anyString(), any(HttpServletRequest.class));
         assertFalse(smallFullInterceptor.preHandle(httpServletRequest, httpServletResponse,
                 new Object()));
     }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/AccountingPoliciesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/AccountingPoliciesServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DuplicateKeyException;
+import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.AccountingPoliciesDataEntity;
@@ -76,6 +77,8 @@ public class AccountingPoliciesServiceTest {
     private AccountingPoliciesEntity accountingPoliciesEntity;
 
     private static final String SELF_LINK = "self_link";
+    private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
+    private static final String RESOURCE_ID = "resourceId";
 
     @BeforeEach
     void setUp() {
@@ -88,6 +91,10 @@ public class AccountingPoliciesServiceTest {
 
         accountingPoliciesEntity = new AccountingPoliciesEntity();
         accountingPoliciesEntity.setData(dataEntity);
+
+        when(keyIdGenerator
+                .generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.ACCOUNTING_POLICIES.getName()))
+                        .thenReturn(RESOURCE_ID);
     }
 
     @Test
@@ -100,7 +107,7 @@ public class AccountingPoliciesServiceTest {
         when(transactionLinks.getSelf()).thenReturn(SELF_LINK);
 
         ResponseObject<AccountingPolicies> result = service.create(accountingPolicies, transaction,
-                                                "", request);
+                                                COMPANY_ACCOUNTS_ID, request);
 
         assertNotNull(result);
         assertEquals(accountingPolicies, result.getData());
@@ -117,7 +124,7 @@ public class AccountingPoliciesServiceTest {
         when(transaction.getLinks()).thenReturn(transactionLinks);
         when(transactionLinks.getSelf()).thenReturn(SELF_LINK);
 
-        ResponseObject response = service.create(accountingPolicies, transaction, "", request);
+        ResponseObject response = service.create(accountingPolicies, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertNotNull(response);
         assertEquals(response.getStatus(), ResponseStatus.DUPLICATE_KEY_ERROR);
@@ -136,7 +143,7 @@ public class AccountingPoliciesServiceTest {
         when(transactionLinks.getSelf()).thenReturn(SELF_LINK);
 
         assertThrows(DataException.class,
-                () -> service.create(accountingPolicies, transaction, "", request));
+                () -> service.create(accountingPolicies, transaction, COMPANY_ACCOUNTS_ID, request));
     }
 
     @Test
@@ -149,7 +156,7 @@ public class AccountingPoliciesServiceTest {
         when(transactionLinks.getSelf()).thenReturn(SELF_LINK);
 
         ResponseObject<AccountingPolicies> result = service.update(accountingPolicies, transaction,
-                "", request);
+                COMPANY_ACCOUNTS_ID, request);
 
         assertNotNull(result);
         assertEquals(accountingPolicies, result.getData());
@@ -167,18 +174,18 @@ public class AccountingPoliciesServiceTest {
         when(transactionLinks.getSelf()).thenReturn(SELF_LINK);
 
         assertThrows(DataException.class,
-                () -> service.update(accountingPolicies, transaction, "", request));
+                () -> service.update(accountingPolicies, transaction, COMPANY_ACCOUNTS_ID, request));
     }
 
     @Test
     @DisplayName("Tests the successful find of an AccountingPolicies resource")
     void findAccountingPolicies() throws DataException {
 
-        when(repository.findById(""))
+        when(repository.findById(RESOURCE_ID))
                 .thenReturn(Optional.ofNullable(accountingPoliciesEntity));
         when(transformer.transform(accountingPoliciesEntity)).thenReturn(accountingPolicies);
 
-        ResponseObject<AccountingPolicies> result = service.findById("", request);
+        ResponseObject<AccountingPolicies> result = service.find(COMPANY_ACCOUNTS_ID, request);
 
         assertNotNull(result);
         assertEquals(accountingPolicies, result.getData());
@@ -187,8 +194,8 @@ public class AccountingPoliciesServiceTest {
     @Test
     @DisplayName("Tests mongo exception thrown on find of an AccountingPolicies resource")
     void findAccountingPoliciesMongoException() {
-        when(repository.findById("")).thenThrow(mongoException);
+        when(repository.findById(RESOURCE_ID)).thenThrow(mongoException);
 
-        assertThrows(DataException.class, () -> service.findById("", request));
+        assertThrows(DataException.class, () -> service.find(COMPANY_ACCOUNTS_ID, request));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearServiceTest.java
@@ -287,11 +287,14 @@ public class CreditorsAfterOneYearServiceTest {
     @DisplayName("Tests the successful find of a creditors after one year resource")
     void findCreditorsAfterOneYear() throws DataException {
 
-        when(mockRepository.findById(""))
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.CREDITORS_AFTER_ONE_YEAR.getName()))
+                .thenReturn(CREDITORS_AFTER_ID);
+
+        when(mockRepository.findById(CREDITORS_AFTER_ID))
                 .thenReturn(Optional.ofNullable(creditorsAfterOneYearEntity));
         when(mockTransformer.transform(creditorsAfterOneYearEntity)).thenReturn(mockCreditorsAfterOneYear);
 
-        ResponseObject<CreditorsAfterOneYear> result = mockCreditorsAfterOneYearService.findById("", mockRequest);
+        ResponseObject<CreditorsAfterOneYear> result = mockCreditorsAfterOneYearService.find(COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertNotNull(result);
         assertEquals(mockCreditorsAfterOneYear, result.getData());
@@ -303,10 +306,13 @@ public class CreditorsAfterOneYearServiceTest {
 
         creditorsAfterOneYearEntity = null;
 
-        when(mockRepository.findById(""))
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.CREDITORS_AFTER_ONE_YEAR.getName()))
+                .thenReturn(CREDITORS_AFTER_ID);
+
+        when(mockRepository.findById(CREDITORS_AFTER_ID))
                 .thenReturn(Optional.ofNullable(creditorsAfterOneYearEntity));
 
-        ResponseObject<CreditorsAfterOneYear> result = mockCreditorsAfterOneYearService.findById("", mockRequest);
+        ResponseObject<CreditorsAfterOneYear> result = mockCreditorsAfterOneYearService.find(COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertNotNull(result);
         assertEquals(responseStatusNotFound(), result.getStatus());
@@ -316,8 +322,11 @@ public class CreditorsAfterOneYearServiceTest {
     @DisplayName("Tests mongo exception thrown on find of a creditors after one year resource")
     void findCreditorsMongoException() {
 
-        when(mockRepository.findById("")).thenThrow(mockMongoException);
-        assertThrows(DataException.class, () -> mockCreditorsAfterOneYearService.findById("", mockRequest));
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.CREDITORS_AFTER_ONE_YEAR.getName()))
+                .thenReturn(CREDITORS_AFTER_ID);
+
+        when(mockRepository.findById(CREDITORS_AFTER_ID)).thenThrow(mockMongoException);
+        assertThrows(DataException.class, () -> mockCreditorsAfterOneYearService.find(COMPANY_ACCOUNTS_ID, mockRequest));
     }
 
     private ResponseStatus responseStatusNotFound() {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearServiceTest.java
@@ -246,11 +246,14 @@ public class CreditorsWithinOneYearServiceTest {
     @DisplayName("Tests the successful find of a creditors within one year resource")
     void findCreditorsWithinOneYear() throws DataException {
 
-        when(mockRepository.findById(""))
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.CREDITORS_WITHIN_ONE_YEAR.getName()))
+                .thenReturn(GENERATED_ID);
+
+        when(mockRepository.findById(GENERATED_ID))
             .thenReturn(Optional.ofNullable(creditorsWithinOneYearEntity));
         when(mockTransformer.transform(creditorsWithinOneYearEntity)).thenReturn(mockCreditorsWithinOneYear);
 
-        ResponseObject<CreditorsWithinOneYear> result = service.findById("", mockRequest);
+        ResponseObject<CreditorsWithinOneYear> result = service.find(COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertNotNull(result);
         assertEquals(mockCreditorsWithinOneYear, result.getData());
@@ -262,10 +265,13 @@ public class CreditorsWithinOneYearServiceTest {
 
         creditorsWithinOneYearEntity = null;
 
-        when(mockRepository.findById(""))
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.CREDITORS_WITHIN_ONE_YEAR.getName()))
+                .thenReturn(GENERATED_ID);
+
+        when(mockRepository.findById(GENERATED_ID))
             .thenReturn(Optional.ofNullable(creditorsWithinOneYearEntity));
 
-        ResponseObject<CreditorsWithinOneYear> result = service.findById("", mockRequest);
+        ResponseObject<CreditorsWithinOneYear> result = service.find(COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertNotNull(result);
         assertEquals(responseStatusNotFound(), result.getStatus());
@@ -275,8 +281,11 @@ public class CreditorsWithinOneYearServiceTest {
     @DisplayName("Tests mongo exception thrown on find of a creditors within one year resource")
     void findCreditorsMongoException() {
 
-        when(mockRepository.findById("")).thenThrow(mockMongoException);
-        assertThrows(DataException.class, () -> service.findById("", mockRequest));
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.CREDITORS_WITHIN_ONE_YEAR.getName()))
+                .thenReturn(GENERATED_ID);
+
+        when(mockRepository.findById(GENERATED_ID)).thenThrow(mockMongoException);
+        assertThrows(DataException.class, () -> service.find(COMPANY_ACCOUNTS_ID, mockRequest));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsServiceTest.java
@@ -198,11 +198,13 @@ public class DebtorsServiceTest {
     @DisplayName("Tests the successful find of a debtors resource")
     void findDebtors() throws DataException {
 
-        when(mockRepository.findById(""))
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.DEBTORS.getName()))
+                .thenReturn(DEBTORS_ID);
+        when(mockRepository.findById(DEBTORS_ID))
             .thenReturn(Optional.ofNullable(debtorsEntity));
         when(mockTransformer.transform(debtorsEntity)).thenReturn(mockDebtors);
 
-        ResponseObject<Debtors> result = service.findById("", mockRequest);
+        ResponseObject<Debtors> result = service.find(COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertNotNull(result);
         assertEquals(mockDebtors, result.getData());
@@ -212,10 +214,12 @@ public class DebtorsServiceTest {
     @DisplayName("Tests debtors response not found")
     void findDebtorsResponseNotFound() throws DataException {
         debtorsEntity = null;
-        when(mockRepository.findById(""))
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.DEBTORS.getName()))
+                .thenReturn(DEBTORS_ID);
+        when(mockRepository.findById(DEBTORS_ID))
             .thenReturn(Optional.ofNullable(debtorsEntity));
 
-        ResponseObject<Debtors> result = service.findById("", mockRequest);
+        ResponseObject<Debtors> result = service.find(COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertNotNull(result);
         assertEquals(responseStatusNotFound(), result.getStatus());
@@ -224,9 +228,11 @@ public class DebtorsServiceTest {
     @Test
     @DisplayName("Tests mongo exception thrown on find of a debtors resource")
     void findDebtorsMongoException() {
-        when(mockRepository.findById("")).thenThrow(mockMongoException);
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.DEBTORS.getName()))
+                .thenReturn(DEBTORS_ID);
+        when(mockRepository.findById(DEBTORS_ID)).thenThrow(mockMongoException);
 
-        assertThrows(DataException.class, () -> service.findById("", mockRequest));
+        assertThrows(DataException.class, () -> service.find(COMPANY_ACCOUNTS_ID, mockRequest));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/EmployeesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/EmployeesServiceTest.java
@@ -249,11 +249,13 @@ public class EmployeesServiceTest {
     @DisplayName("Tests the successful find of an employees resource")
     void findEmployees() throws DataException {
 
-        when(mockRepository.findById(""))
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.EMPLOYEES.getName()))
+                .thenReturn(EMPLOYEES_ID);
+        when(mockRepository.findById(EMPLOYEES_ID))
                 .thenReturn(Optional.ofNullable(employeesEntity));
         when(mockTransformer.transform(employeesEntity)).thenReturn(mockEmployees);
 
-        ResponseObject<Employees> result = mockEmployeesService.findById("", mockRequest);
+        ResponseObject<Employees> result = mockEmployeesService.find(COMPANY_ACCOUNTS_ID, mockRequest);
         assertNotNull(result);
     }
 
@@ -261,10 +263,12 @@ public class EmployeesServiceTest {
     @DisplayName("Tests when employees resource not found")
     void findEmployeesResponseNotFound() throws DataException {
 
-        when(mockRepository.findById(""))
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.EMPLOYEES.getName()))
+                .thenReturn(EMPLOYEES_ID);
+        when(mockRepository.findById(EMPLOYEES_ID))
                 .thenReturn(Optional.ofNullable(null));
 
-        ResponseObject<Employees> result = mockEmployeesService.findById("", mockRequest);
+        ResponseObject<Employees> result = mockEmployeesService.find(COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertNotNull(result);
         assertEquals(responseStatusNotFound(), result.getStatus());
@@ -274,8 +278,10 @@ public class EmployeesServiceTest {
     @DisplayName("Tests mongo exception thrown on find of an employees resource")
     void findEmployeesMongoException() {
 
-        when(mockRepository.findById("")).thenThrow(mockMongoException);
-        assertThrows(DataException.class, () -> mockEmployeesService.findById("", mockRequest));
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.EMPLOYEES.getName()))
+                .thenReturn(EMPLOYEES_ID);
+        when(mockRepository.findById(EMPLOYEES_ID)).thenThrow(mockMongoException);
+        assertThrows(DataException.class, () -> mockEmployeesService.find(COMPANY_ACCOUNTS_ID, mockRequest));
     }
 
     private ResponseStatus responseStatusNotFound() {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FixedAssetsInvestmentsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FixedAssetsInvestmentsServiceTest.java
@@ -194,11 +194,14 @@ public class FixedAssetsInvestmentsServiceTest {
     @DisplayName("Tests the successful find of a fixed assets investments resource")
     void findFixedAssetsInvestments() throws DataException {
 
-        when(mockRepository.findById(""))
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.FIXED_ASSETS_INVESTMENTS.getName()))
+                .thenReturn(GENERATED_ID);
+
+        when(mockRepository.findById(GENERATED_ID))
             .thenReturn(Optional.ofNullable(fixedAssetsInvestmentsEntity));
         when(mockTransformer.transform(fixedAssetsInvestmentsEntity)).thenReturn(mockFixedAssetsInvestments);
 
-        ResponseObject<FixedAssetsInvestments> result = service.findById("", mockRequest);
+        ResponseObject<FixedAssetsInvestments> result = service.find(COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertNotNull(result);
         assertEquals(mockFixedAssetsInvestments, result.getData());
@@ -210,10 +213,13 @@ public class FixedAssetsInvestmentsServiceTest {
 
         fixedAssetsInvestmentsEntity = null;
 
-        when(mockRepository.findById(""))
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.FIXED_ASSETS_INVESTMENTS.getName()))
+                .thenReturn(GENERATED_ID);
+
+        when(mockRepository.findById(GENERATED_ID))
             .thenReturn(Optional.ofNullable(fixedAssetsInvestmentsEntity));
 
-        ResponseObject<FixedAssetsInvestments> result = service.findById("", mockRequest);
+        ResponseObject<FixedAssetsInvestments> result = service.find(COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertNotNull(result);
         assertEquals(responseStatusNotFound(), result.getStatus());
@@ -223,8 +229,11 @@ public class FixedAssetsInvestmentsServiceTest {
     @DisplayName("Tests mongo exception thrown on find of a fixed assets investments resource")
     void findFixedAssetsInvestmentsMongoException() {
 
-        when(mockRepository.findById("")).thenThrow(mockMongoException);
-        assertThrows(DataException.class, () -> service.findById("", mockRequest));
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.FIXED_ASSETS_INVESTMENTS.getName()))
+                .thenReturn(GENERATED_ID);
+
+        when(mockRepository.findById(GENERATED_ID)).thenThrow(mockMongoException);
+        assertThrows(DataException.class, () -> service.find(COMPANY_ACCOUNTS_ID, mockRequest));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StatementServiceTest.java
@@ -80,7 +80,7 @@ public class StatementServiceTest {
     @Mock
     private StatementRepository statementRepositoryMock;
     @Mock
-    private KeyIdGenerator KeyIdGeneratorMock;
+    private KeyIdGenerator keyIdGeneratorMock;
     @Mock
     private SmallFullService smallFullServiceMock;
     @Mock
@@ -92,6 +92,7 @@ public class StatementServiceTest {
     private StatementService statementService;
 
     private static final String SELF_LINK = "self_link";
+    private static final String RESOURCE_ID = "resourceId";
 
     @BeforeAll
     void setUpBeforeAll() {
@@ -186,13 +187,15 @@ public class StatementServiceTest {
     @Test
     @DisplayName("Tests the successful find of an an Statement resource")
     void shouldFindStatementResource() throws DataException {
-        when(statementRepositoryMock.findById(anyString()))
+        when(keyIdGeneratorMock.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.STATEMENTS.getName()))
+                .thenReturn(RESOURCE_ID);
+        when(statementRepositoryMock.findById(RESOURCE_ID))
             .thenReturn(Optional.ofNullable(statementEntity));
 
         Statement statement = createStatement();
         when(statementTransformerMock.transform(any(StatementEntity.class))).thenReturn(statement);
 
-        ResponseObject<Statement> result = statementService.findById(anyString(), requestMock);
+        ResponseObject<Statement> result = statementService.find(COMPANY_ACCOUNTS_ID, requestMock);
 
         assertNotNull(result);
         assertEquals(statement, result.getData());
@@ -202,10 +205,12 @@ public class StatementServiceTest {
     @Test
     @DisplayName("Tests the unsuccessful find of an an Statement resource")
     void shouldNotFindStatementResource() throws DataException {
-        when(statementRepositoryMock.findById(anyString()))
+        when(keyIdGeneratorMock.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.STATEMENTS.getName()))
+                .thenReturn(RESOURCE_ID);
+        when(statementRepositoryMock.findById(RESOURCE_ID))
             .thenReturn(Optional.ofNullable(null));
 
-        ResponseObject<Statement> result = statementService.findById(anyString(), requestMock);
+        ResponseObject<Statement> result = statementService.find(COMPANY_ACCOUNTS_ID, requestMock);
 
         assertNotNull(result);
         assertNull(result.getData());
@@ -214,12 +219,14 @@ public class StatementServiceTest {
 
     @Test
     @DisplayName("Tests the mongo exception thrown on find a Statement resource")
-    void shouldThrowMongoExceptionWhenFindingById() throws DataException {
-        when(statementRepositoryMock.findById(anyString()))
+    void shouldThrowMongoExceptionWhenFindingById() {
+        when(keyIdGeneratorMock.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.STATEMENTS.getName()))
+                .thenReturn(RESOURCE_ID);
+        when(statementRepositoryMock.findById(RESOURCE_ID))
             .thenThrow(MongoException.class);
 
         assertThrows(DataException.class,
-            () -> statementService.findById(anyString(), requestMock));
+            () -> statementService.find(COMPANY_ACCOUNTS_ID, requestMock));
     }
 
     private StatementEntity createStatementEntity() {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StocksServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StocksServiceTest.java
@@ -201,11 +201,13 @@ public class StocksServiceTest {
     @DisplayName("Tests the successful find of a stocks resource")
     void findStocks() throws DataException {
 
-        when(mockRepository.findById(""))
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.STOCKS.getName()))
+                .thenReturn(GENERATED_ID);
+        when(mockRepository.findById(GENERATED_ID))
                 .thenReturn(Optional.ofNullable(stocksEntity));
         when(mockTransformer.transform(stocksEntity)).thenReturn(mockStocks);
 
-        ResponseObject<Stocks> result = service.findById("", mockRequest);
+        ResponseObject<Stocks> result = service.find(COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertNotNull(result);
         assertEquals(mockStocks, result.getData());
@@ -217,10 +219,12 @@ public class StocksServiceTest {
 
         stocksEntity = null;
 
-        when(mockRepository.findById(""))
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.STOCKS.getName()))
+                .thenReturn(GENERATED_ID);
+        when(mockRepository.findById(GENERATED_ID))
                 .thenReturn(Optional.ofNullable(stocksEntity));
 
-        ResponseObject<Stocks> result = service.findById("", mockRequest);
+        ResponseObject<Stocks> result = service.find(COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertNotNull(result);
         assertEquals(responseStatusNotFound(), result.getStatus());
@@ -230,8 +234,10 @@ public class StocksServiceTest {
     @DisplayName("Tests mongo exception thrown on find of a stocks resource")
     void findStocksMongoException() {
 
-        when(mockRepository.findById("")).thenThrow(mockMongoException);
-        assertThrows(DataException.class, () -> service.findById("", mockRequest));
+        when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.STOCKS.getName()))
+                .thenReturn(GENERATED_ID);
+        when(mockRepository.findById(GENERATED_ID)).thenThrow(mockMongoException);
+        assertThrows(DataException.class, () -> service.find(COMPANY_ACCOUNTS_ID, mockRequest));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/TangibleAssetsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/TangibleAssetsServiceTest.java
@@ -253,11 +253,14 @@ public class TangibleAssetsServiceTest {
     @DisplayName("Tests the successful retrieval of a Tangible Assets resource")
     void getTangibleAssetsSuccess() throws DataException {
 
+        when(keyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.TANGIBLE_ASSETS.getName()))
+                .thenReturn(GENERATED_ID);
+
         when(repository.findById(GENERATED_ID)).thenReturn(Optional.of(tangibleAssetsEntity));
         when(transformer.transform(tangibleAssetsEntity)).thenReturn(tangibleAssets);
 
         ResponseObject<TangibleAssets> response =
-                tangibleAssetsService.findById(GENERATED_ID, request);
+                tangibleAssetsService.find(COMPANY_ACCOUNTS_ID, request);
 
         assertRepositoryFindByIdCalled();
         assertEquals(ResponseStatus.FOUND, response.getStatus());
@@ -268,11 +271,14 @@ public class TangibleAssetsServiceTest {
     @DisplayName("Tests the retrieval of a non-existent Tangible Assets resource")
     void getTangibleAssetsNotFound() throws DataException {
 
+        when(keyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.TANGIBLE_ASSETS.getName()))
+                .thenReturn(GENERATED_ID);
+
         TangibleAssetsEntity tangibleAssetsEntity = null;
         when(repository.findById(GENERATED_ID)).thenReturn(Optional.ofNullable(tangibleAssetsEntity));
 
         ResponseObject<TangibleAssets> response =
-                tangibleAssetsService.findById(GENERATED_ID, request);
+                tangibleAssetsService.find(COMPANY_ACCOUNTS_ID, request);
 
         assertRepositoryFindByIdCalled();
         assertEquals(ResponseStatus.NOT_FOUND, response.getStatus());
@@ -283,10 +289,13 @@ public class TangibleAssetsServiceTest {
     @DisplayName("Tests the retrieval of a Tangible Assets resource where the repository throws a Mongo exception")
     void getTangibleAssetsMongoException() {
 
+        when(keyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.TANGIBLE_ASSETS.getName()))
+                .thenReturn(GENERATED_ID);
+
         when(repository.findById(GENERATED_ID)).thenThrow(MongoException.class);
 
         assertThrows(DataException.class, () ->
-                tangibleAssetsService.findById(GENERATED_ID, request));
+                tangibleAssetsService.find(COMPANY_ACCOUNTS_ID, request));
 
         assertRepositoryFindByIdCalled();
     }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidatorTest.java
@@ -403,9 +403,7 @@ public class CreditorsAfterOneYearValidatorTest {
         createValidNoteCurrentPeriod();
         createValidNotePreviousPeriod();
 
-        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        when(mockCurrentPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
+        when(mockCurrentPeriodService.find(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         assertThrows(DataException.class,
                 () -> validator.validateCreditorsAfterOneYear(creditorsAfterOneYear,
@@ -422,9 +420,7 @@ public class CreditorsAfterOneYearValidatorTest {
 
         mockValidBalanceSheetCurrentPeriod();
 
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        when(mockPreviousPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
+        when(mockPreviousPeriodService.find(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         assertThrows(DataException.class,
                 () -> validator.validateCreditorsAfterOneYear(creditorsAfterOneYear,
@@ -501,30 +497,22 @@ public class CreditorsAfterOneYearValidatorTest {
     }
 
     private void mockValidBalanceSheetCurrentPeriod() throws DataException {
-        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidCurrentPeriodResponseObject(true)).when(mockCurrentPeriodService).findById(
+        doReturn(generateValidCurrentPeriodResponseObject(true)).when(mockCurrentPeriodService).find(
                 COMPANY_ACCOUNTS_ID, mockRequest);
     }
 
     private void mockValidBalanceSheetPreviousPeriod() throws DataException {
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidPreviousPeriodResponseObject(true)).when(mockPreviousPeriodService).findById(
+        doReturn(generateValidPreviousPeriodResponseObject(true)).when(mockPreviousPeriodService).find(
                 COMPANY_ACCOUNTS_ID, mockRequest);
     }
 
     private void mockBalanceSheetCurrentPeriodWithoutNoteValue() throws DataException {
-        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidCurrentPeriodResponseObject(false)).when(mockCurrentPeriodService).findById(
+        doReturn(generateValidCurrentPeriodResponseObject(false)).when(mockCurrentPeriodService).find(
                 COMPANY_ACCOUNTS_ID, mockRequest);
     }
 
     private void mockBalanceSheetPreviousPeriodWithoutNoteValue() throws DataException {
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidPreviousPeriodResponseObject(false)).when(mockPreviousPeriodService).findById(
+        doReturn(generateValidPreviousPeriodResponseObject(false)).when(mockPreviousPeriodService).find(
                 COMPANY_ACCOUNTS_ID, mockRequest);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidatorTests.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidatorTests.java
@@ -385,9 +385,7 @@ public class CreditorsWithinOneYearValidatorTests {
         createValidNoteCurrentPeriod();
         createValidNotePreviousPeriod();
 
-        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        when(mockCurrentPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
+        when(mockCurrentPeriodService.find(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         assertThrows(DataException.class,
                 () -> validator.validateCreditorsWithinOneYear(creditorsWithinOneYear,
@@ -404,9 +402,7 @@ public class CreditorsWithinOneYearValidatorTests {
 
         mockValidBalanceSheetCurrentPeriod();
 
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        when(mockPreviousPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
+        when(mockPreviousPeriodService.find(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         assertThrows(DataException.class,
                 () -> validator.validateCreditorsWithinOneYear(creditorsWithinOneYear,
@@ -489,30 +485,22 @@ public class CreditorsWithinOneYearValidatorTests {
     }
 
     private void mockValidBalanceSheetCurrentPeriod() throws DataException {
-        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidCurrentPeriodResponseObject(true)).when(mockCurrentPeriodService).findById(
+        doReturn(generateValidCurrentPeriodResponseObject(true)).when(mockCurrentPeriodService).find(
                 COMPANY_ACCOUNTS_ID, mockRequest);
     }
 
     private void mockValidBalanceSheetPreviousPeriod() throws DataException {
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidPreviousPeriodResponseObject(true)).when(mockPreviousPeriodService).findById(
+        doReturn(generateValidPreviousPeriodResponseObject(true)).when(mockPreviousPeriodService).find(
                 COMPANY_ACCOUNTS_ID, mockRequest);
     }
 
     private void mockBalanceSheetCurrentPeriodWithoutNoteValue() throws DataException {
-        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidCurrentPeriodResponseObject(false)).when(mockCurrentPeriodService).findById(
+        doReturn(generateValidCurrentPeriodResponseObject(false)).when(mockCurrentPeriodService).find(
                 COMPANY_ACCOUNTS_ID, mockRequest);
     }
 
     private void mockBalanceSheetPreviousPeriodWithoutNoteValue() throws DataException {
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidPreviousPeriodResponseObject(false)).when(mockPreviousPeriodService).findById(
+        doReturn(generateValidPreviousPeriodResponseObject(false)).when(mockPreviousPeriodService).find(
                 COMPANY_ACCOUNTS_ID, mockRequest);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -409,9 +409,7 @@ public class DebtorsValidatorTest {
         createValidNoteCurrentPeriod();
         createValidNotePreviousPeriod();
 
-        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
-        when(mockCurrentPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
+        when(mockCurrentPeriodService.find(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         assertThrows(DataException.class,
             () -> validator.validateDebtors(debtors,
@@ -428,9 +426,7 @@ public class DebtorsValidatorTest {
 
         mockValidBalanceSheetCurrentPeriod();
 
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-                COMPANY_ACCOUNTS_ID);
-        when(mockPreviousPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
+        when(mockPreviousPeriodService.find(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         assertThrows(DataException.class,
             () -> validator.validateDebtors(debtors,
@@ -462,30 +458,22 @@ public class DebtorsValidatorTest {
     }
 
     private void mockValidBalanceSheetCurrentPeriod() throws DataException {
-        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidCurrentPeriodResponseObject(true)).when(mockCurrentPeriodService).findById(
+        doReturn(generateValidCurrentPeriodResponseObject(true)).when(mockCurrentPeriodService).find(
             COMPANY_ACCOUNTS_ID, mockRequest);
     }
 
     private void mockValidBalanceSheetPreviousPeriod() throws DataException {
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidPreviousPeriodResponseObject(true)).when(mockPreviousPeriodService).findById(
+        doReturn(generateValidPreviousPeriodResponseObject(true)).when(mockPreviousPeriodService).find(
             COMPANY_ACCOUNTS_ID, mockRequest);
     }
 
     private void mockBalanceSheetCurrentPeriodWithoutNoteValue() throws DataException {
-        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidCurrentPeriodResponseObject(false)).when(mockCurrentPeriodService).findById(
+        doReturn(generateValidCurrentPeriodResponseObject(false)).when(mockCurrentPeriodService).find(
             COMPANY_ACCOUNTS_ID, mockRequest);
     }
 
     private void mockBalanceSheetPreviousPeriodWithoutNoteValue() throws DataException {
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidPreviousPeriodResponseObject(false)).when(mockPreviousPeriodService).findById(
+        doReturn(generateValidPreviousPeriodResponseObject(false)).when(mockPreviousPeriodService).find(
             COMPANY_ACCOUNTS_ID, mockRequest);
     }
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/StocksValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/StocksValidatorTest.java
@@ -400,9 +400,7 @@ public class StocksValidatorTest {
         createValidNoteCurrentPeriod();
         createValidNotePreviousPeriod();
 
-        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
-        when(mockCurrentPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
+        when(mockCurrentPeriodService.find(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         assertThrows(DataException.class,
             () -> validator.validateStocks(stocks,
@@ -419,9 +417,7 @@ public class StocksValidatorTest {
 
         mockValidBalanceSheetCurrentPeriod();
 
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
-        when(mockPreviousPeriodService.findById(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
+        when(mockPreviousPeriodService.find(COMPANY_ACCOUNTS_ID, mockRequest)).thenThrow(new DataException(""));
 
         assertThrows(DataException.class,
             () -> validator.validateStocks(stocks,
@@ -496,30 +492,22 @@ public class StocksValidatorTest {
     }
 
     private void mockValidBalanceSheetCurrentPeriod() throws DataException {
-        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidCurrentPeriodResponseObject(true)).when(mockCurrentPeriodService).findById(
+        doReturn(generateValidCurrentPeriodResponseObject(true)).when(mockCurrentPeriodService).find(
             COMPANY_ACCOUNTS_ID, mockRequest);
     }
 
     private void mockValidBalanceSheetPreviousPeriod() throws DataException {
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidPreviousPeriodResponseObject(true)).when(mockPreviousPeriodService).findById(
+        doReturn(generateValidPreviousPeriodResponseObject(true)).when(mockPreviousPeriodService).find(
             COMPANY_ACCOUNTS_ID, mockRequest);
     }
 
     private void mockBalanceSheetCurrentPeriodWithoutNoteValue() throws DataException {
-        when(mockCurrentPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidCurrentPeriodResponseObject(false)).when(mockCurrentPeriodService).findById(
+        doReturn(generateValidCurrentPeriodResponseObject(false)).when(mockCurrentPeriodService).find(
             COMPANY_ACCOUNTS_ID, mockRequest);
     }
 
     private void mockBalanceSheetPreviousPeriodWithoutNoteValue() throws DataException {
-        when(mockPreviousPeriodService.generateID(COMPANY_ACCOUNTS_ID)).thenReturn(
-            COMPANY_ACCOUNTS_ID);
-        doReturn(generateValidPreviousPeriodResponseObject(false)).when(mockPreviousPeriodService).findById(
+        doReturn(generateValidPreviousPeriodResponseObject(false)).when(mockPreviousPeriodService).find(
             COMPANY_ACCOUNTS_ID, mockRequest);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/TangibleAssetsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/TangibleAssetsValidatorTest.java
@@ -71,8 +71,7 @@ public class TangibleAssetsValidatorTest {
     private static final String PREVIOUS_BALANCE_SHEET_NOT_EQUAL_KEY = "previousBalanceSheetNotEqual";
     private static final String PREVIOUS_BALANCE_SHEET_NOT_EQUAL = "value_not_equal_to_previous_period_on_balance_sheet";
 
-    private static final String CURRENT_PERIOD_ID = "currentPeriodId";
-    private static final String PREVIOUS_PERIOD_ID = "previousPeriodId";
+    private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
 
     @Test
     @DisplayName("First year filer - provides only additional info in note")
@@ -85,7 +84,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.total.net_book_value_at_end_of_current_period")));
@@ -102,7 +101,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(2, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.total.net_book_value_at_end_of_current_period")));
@@ -127,7 +126,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, UNEXPECTED_DATA_KEY, UNEXPECTED_DATA);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(UNEXPECTED_DATA, "$.tangible_assets.fixtures_and_fittings.cost.at_period_start")));
@@ -151,7 +150,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, UNEXPECTED_DATA_KEY, UNEXPECTED_DATA);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(UNEXPECTED_DATA, "$.tangible_assets.fixtures_and_fittings.depreciation.at_period_start")));
@@ -172,7 +171,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, UNEXPECTED_DATA_KEY, UNEXPECTED_DATA);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(UNEXPECTED_DATA, "$.tangible_assets.fixtures_and_fittings.net_book_value_at_end_of_previous_period")));
@@ -196,7 +195,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.fixtures_and_fittings.net_book_value_at_end_of_current_period")));
@@ -220,7 +219,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.fixtures_and_fittings.net_book_value_at_end_of_current_period")));
@@ -241,7 +240,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.fixtures_and_fittings.cost.at_period_end")));
@@ -263,7 +262,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.fixtures_and_fittings.cost.at_period_end")));
@@ -289,7 +288,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.fixtures_and_fittings.net_book_value_at_end_of_previous_period")));
@@ -315,7 +314,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.fixtures_and_fittings.net_book_value_at_end_of_current_period")));
@@ -336,7 +335,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(2, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.fixtures_and_fittings.cost.at_period_start")));
@@ -362,7 +361,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.fixtures_and_fittings.cost.at_period_start")));
@@ -387,7 +386,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.fixtures_and_fittings.cost.at_period_end")));
@@ -417,7 +416,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(2, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.fixtures_and_fittings.depreciation.at_period_start")));
@@ -441,7 +440,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(2, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.fixtures_and_fittings.net_book_value_at_end_of_current_period")));
@@ -465,7 +464,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, VALUE_REQUIRED_KEY, VALUE_REQUIRED);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(2, errors.getErrorCount());
         assertTrue(errors.containsError(createError(VALUE_REQUIRED, "$.tangible_assets.fixtures_and_fittings.net_book_value_at_end_of_current_period")));
@@ -491,7 +490,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_KEY, INCORRECT_TOTAL);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL, "$.tangible_assets.fixtures_and_fittings.cost.at_period_end")));
@@ -522,7 +521,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_KEY, INCORRECT_TOTAL);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL, "$.tangible_assets.fixtures_and_fittings.depreciation.at_period_end")));
@@ -548,7 +547,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_KEY, INCORRECT_TOTAL);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL, "$.tangible_assets.fixtures_and_fittings.net_book_value_at_end_of_current_period")));
@@ -575,7 +574,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_KEY, INCORRECT_TOTAL);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL, "$.tangible_assets.fixtures_and_fittings.cost.at_period_end")));
@@ -609,7 +608,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_KEY, INCORRECT_TOTAL);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL, "$.tangible_assets.fixtures_and_fittings.depreciation.at_period_end")));
@@ -637,7 +636,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_KEY, INCORRECT_TOTAL);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL, "$.tangible_assets.fixtures_and_fittings.net_book_value_at_end_of_current_period")));
@@ -665,7 +664,7 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_KEY, INCORRECT_TOTAL);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL, "$.tangible_assets.fixtures_and_fittings.net_book_value_at_end_of_previous_period")));
@@ -721,13 +720,13 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_KEY, INCORRECT_TOTAL);
 
-        when(currentPeriodService.find("", request))
+        when(currentPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(createCurrentPeriodResponseObject(2L));
 
-        when(previousPeriodService.find("", request))
+        when(previousPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(10, errors.getErrorCount());
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL, "$.tangible_assets.total.cost.additions")));
@@ -798,13 +797,13 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_KEY, INCORRECT_TOTAL);
 
-        when(currentPeriodService.find("", request))
+        when(currentPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(createCurrentPeriodResponseObject(3L));
 
-        when(previousPeriodService.find("", request))
+        when(previousPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(createPreviousPeriodResponseObject(1L));
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(13, errors.getErrorCount());
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL, "$.tangible_assets.total.cost.at_period_start")));
@@ -856,15 +855,15 @@ public class TangibleAssetsValidatorTest {
 
         tangibleAssets.setTotal(total);
 
-        when(currentPeriodService.find("", request))
+        when(currentPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
-        when(previousPeriodService.find("", request))
+        when(previousPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_KEY, CURRENT_BALANCE_SHEET_NOT_EQUAL);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(CURRENT_BALANCE_SHEET_NOT_EQUAL, "$.tangible_assets.total.net_book_value_at_end_of_current_period")));
@@ -904,15 +903,15 @@ public class TangibleAssetsValidatorTest {
 
         tangibleAssets.setTotal(total);
 
-        when(currentPeriodService.find("", request))
+        when(currentPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(createCurrentPeriodResponseObject(100L));
 
-        when(previousPeriodService.find("", request))
+        when(previousPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_KEY, CURRENT_BALANCE_SHEET_NOT_EQUAL);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(CURRENT_BALANCE_SHEET_NOT_EQUAL, "$.tangible_assets.total.net_book_value_at_end_of_current_period")));
@@ -955,16 +954,16 @@ public class TangibleAssetsValidatorTest {
 
         tangibleAssets.setTotal(total);
 
-        when(currentPeriodService.find("", request))
+        when(currentPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
-        when(previousPeriodService.find("", request))
+        when(previousPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_KEY, CURRENT_BALANCE_SHEET_NOT_EQUAL);
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_KEY, PREVIOUS_BALANCE_SHEET_NOT_EQUAL);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(2, errors.getErrorCount());
         assertTrue(errors.containsError(createError(CURRENT_BALANCE_SHEET_NOT_EQUAL, "$.tangible_assets.total.net_book_value_at_end_of_current_period")));
@@ -1008,16 +1007,16 @@ public class TangibleAssetsValidatorTest {
 
         tangibleAssets.setTotal(total);
 
-        when(currentPeriodService.find("", request))
+        when(currentPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(createCurrentPeriodResponseObject(100L));
 
-        when(previousPeriodService.find("", request))
+        when(previousPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(createPreviousPeriodResponseObject(100L));
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_KEY, CURRENT_BALANCE_SHEET_NOT_EQUAL);
         ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_KEY, PREVIOUS_BALANCE_SHEET_NOT_EQUAL);
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertEquals(2, errors.getErrorCount());
         assertTrue(errors.containsError(createError(CURRENT_BALANCE_SHEET_NOT_EQUAL, "$.tangible_assets.total.net_book_value_at_end_of_current_period")));
@@ -1058,13 +1057,13 @@ public class TangibleAssetsValidatorTest {
 
         tangibleAssets.setTotal(total);
 
-        when(currentPeriodService.find("", request))
+        when(currentPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(createCurrentPeriodResponseObject(5L));
 
-        when(previousPeriodService.find("", request))
+        when(previousPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertFalse(errors.hasErrors());
     }
@@ -1106,13 +1105,13 @@ public class TangibleAssetsValidatorTest {
 
         tangibleAssets.setTotal(total);
 
-        when(currentPeriodService.find("", request))
+        when(currentPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(createCurrentPeriodResponseObject(5L));
 
-        when(previousPeriodService.find("", request))
+        when(previousPeriodService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(createPreviousPeriodResponseObject(0L));
 
-        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
+        Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertFalse(errors.hasErrors());
     }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/TangibleAssetsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/TangibleAssetsValidatorTest.java
@@ -721,12 +721,10 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_KEY, INCORRECT_TOTAL);
 
-        when(currentPeriodService.generateID("")).thenReturn(CURRENT_PERIOD_ID);
-        when(currentPeriodService.findById(CURRENT_PERIOD_ID, request))
+        when(currentPeriodService.find("", request))
                 .thenReturn(createCurrentPeriodResponseObject(2L));
 
-        when(previousPeriodService.generateID("")).thenReturn(PREVIOUS_PERIOD_ID);
-        when(previousPeriodService.findById(PREVIOUS_PERIOD_ID, request))
+        when(previousPeriodService.find("", request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
         Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
@@ -800,12 +798,10 @@ public class TangibleAssetsValidatorTest {
 
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_KEY, INCORRECT_TOTAL);
 
-        when(currentPeriodService.generateID("")).thenReturn(CURRENT_PERIOD_ID);
-        when(currentPeriodService.findById(CURRENT_PERIOD_ID, request))
+        when(currentPeriodService.find("", request))
                 .thenReturn(createCurrentPeriodResponseObject(3L));
 
-        when(previousPeriodService.generateID("")).thenReturn(PREVIOUS_PERIOD_ID);
-        when(previousPeriodService.findById(PREVIOUS_PERIOD_ID, request))
+        when(previousPeriodService.find("", request))
                 .thenReturn(createPreviousPeriodResponseObject(1L));
 
         Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
@@ -860,12 +856,10 @@ public class TangibleAssetsValidatorTest {
 
         tangibleAssets.setTotal(total);
 
-        when(currentPeriodService.generateID("")).thenReturn(CURRENT_PERIOD_ID);
-        when(currentPeriodService.findById(CURRENT_PERIOD_ID, request))
+        when(currentPeriodService.find("", request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
-        when(previousPeriodService.generateID("")).thenReturn(PREVIOUS_PERIOD_ID);
-        when(previousPeriodService.findById(PREVIOUS_PERIOD_ID, request))
+        when(previousPeriodService.find("", request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_KEY, CURRENT_BALANCE_SHEET_NOT_EQUAL);
@@ -910,12 +904,10 @@ public class TangibleAssetsValidatorTest {
 
         tangibleAssets.setTotal(total);
 
-        when(currentPeriodService.generateID("")).thenReturn(CURRENT_PERIOD_ID);
-        when(currentPeriodService.findById(CURRENT_PERIOD_ID, request))
+        when(currentPeriodService.find("", request))
                 .thenReturn(createCurrentPeriodResponseObject(100L));
 
-        when(previousPeriodService.generateID("")).thenReturn(PREVIOUS_PERIOD_ID);
-        when(previousPeriodService.findById(PREVIOUS_PERIOD_ID, request))
+        when(previousPeriodService.find("", request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_KEY, CURRENT_BALANCE_SHEET_NOT_EQUAL);
@@ -963,12 +955,10 @@ public class TangibleAssetsValidatorTest {
 
         tangibleAssets.setTotal(total);
 
-        when(currentPeriodService.generateID("")).thenReturn(CURRENT_PERIOD_ID);
-        when(currentPeriodService.findById(CURRENT_PERIOD_ID, request))
+        when(currentPeriodService.find("", request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
-        when(previousPeriodService.generateID("")).thenReturn(PREVIOUS_PERIOD_ID);
-        when(previousPeriodService.findById(PREVIOUS_PERIOD_ID, request))
+        when(previousPeriodService.find("", request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_KEY, CURRENT_BALANCE_SHEET_NOT_EQUAL);
@@ -1018,12 +1008,10 @@ public class TangibleAssetsValidatorTest {
 
         tangibleAssets.setTotal(total);
 
-        when(currentPeriodService.generateID("")).thenReturn(CURRENT_PERIOD_ID);
-        when(currentPeriodService.findById(CURRENT_PERIOD_ID, request))
+        when(currentPeriodService.find("", request))
                 .thenReturn(createCurrentPeriodResponseObject(100L));
 
-        when(previousPeriodService.generateID("")).thenReturn(PREVIOUS_PERIOD_ID);
-        when(previousPeriodService.findById(PREVIOUS_PERIOD_ID, request))
+        when(previousPeriodService.find("", request))
                 .thenReturn(createPreviousPeriodResponseObject(100L));
 
         ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_KEY, CURRENT_BALANCE_SHEET_NOT_EQUAL);
@@ -1070,12 +1058,10 @@ public class TangibleAssetsValidatorTest {
 
         tangibleAssets.setTotal(total);
 
-        when(currentPeriodService.generateID("")).thenReturn(CURRENT_PERIOD_ID);
-        when(currentPeriodService.findById(CURRENT_PERIOD_ID, request))
+        when(currentPeriodService.find("", request))
                 .thenReturn(createCurrentPeriodResponseObject(5L));
 
-        when(previousPeriodService.generateID("")).thenReturn(PREVIOUS_PERIOD_ID);
-        when(previousPeriodService.findById(PREVIOUS_PERIOD_ID, request))
+        when(previousPeriodService.find("", request))
                 .thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
 
         Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);
@@ -1120,12 +1106,10 @@ public class TangibleAssetsValidatorTest {
 
         tangibleAssets.setTotal(total);
 
-        when(currentPeriodService.generateID("")).thenReturn(CURRENT_PERIOD_ID);
-        when(currentPeriodService.findById(CURRENT_PERIOD_ID, request))
+        when(currentPeriodService.find("", request))
                 .thenReturn(createCurrentPeriodResponseObject(5L));
 
-        when(previousPeriodService.generateID("")).thenReturn(PREVIOUS_PERIOD_ID);
-        when(previousPeriodService.findById(PREVIOUS_PERIOD_ID, request))
+        when(previousPeriodService.find("", request))
                 .thenReturn(createPreviousPeriodResponseObject(0L));
 
         Errors errors = validator.validateTangibleAssets(tangibleAssets, transaction, "", request);


### PR DESCRIPTION
Refactor the resource service method signature 'findById' to 'find', taking a company accounts id variable, rather than a resource id. Resource id's are calculated within each service to delegate all business logic to the service layer.

Resolves SFA-1206