### PR TITLE
Add 'Investments' field to balance sheet api

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/FixedAssetsEntity.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/FixedAssetsEntity.java
@@ -7,6 +7,9 @@ public class FixedAssetsEntity {
     @Field("tangible")
     private Long tangible;
 
+    @Field("investments")
+    private Long investments;
+
     @Field("total")
     private Long total;
 
@@ -16,6 +19,14 @@ public class FixedAssetsEntity {
 
     public void setTangible(Long tangible) {
         this.tangible = tangible;
+    }
+
+    public Long getInvestments() {
+        return investments;
+    }
+
+    public void setInvestments(Long investments) {
+        this.investments = investments;
     }
 
     public Long getTotal() {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/FixedAssets.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/FixedAssets.java
@@ -14,6 +14,10 @@ public class FixedAssets {
     @JsonProperty("tangible")
     private Long tangible;
 
+    @Range(min=MIN_RANGE,max=MAX_RANGE, message = "value.outside.range")
+    @JsonProperty("investments")
+    private Long investments;
+
     @JsonProperty("total")
     private Long total;
 
@@ -23,6 +27,14 @@ public class FixedAssets {
 
     public void setTangible(Long tangible) {
         this.tangible = tangible;
+    }
+
+    public Long getInvestments() {
+        return investments;
+    }
+
+    public void setInvestments(Long investments) {
+        this.investments = investments;
     }
 
     public Long getTotal() {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FixedAssetsInvestmentsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FixedAssetsInvestmentsService.java
@@ -53,7 +53,7 @@ public class FixedAssetsInvestmentsService implements ResourceService<FixedAsset
             String companyAccountId,
             HttpServletRequest request) throws DataException {
 
-        Errors errors = validator.validateFixedAssetsInvestments(request, rest, transaction,
+        Errors errors = validator.validateFixedAssetsInvestments(request, rest,
                 companyAccountId);
 
         if (errors.hasErrors()) {
@@ -86,7 +86,7 @@ public class FixedAssetsInvestmentsService implements ResourceService<FixedAsset
             String companyAccountId,
             HttpServletRequest request) throws DataException {
 
-        Errors errors = validator.validateFixedAssetsInvestments(request, rest, transaction,
+        Errors errors = validator.validateFixedAssetsInvestments(request, rest,
                 companyAccountId);
 
         if (errors.hasErrors()) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidator.java
@@ -93,11 +93,11 @@ public class CurrentPeriodValidator extends BaseValidator {
         FixedAssets fixedAssets = currentPeriod.getBalanceSheet().getFixedAssets();
         if (fixedAssets != null) {
 
-            Long tangible = fixedAssets.getTangible();
+            Long tangible = Optional.ofNullable(fixedAssets.getTangible()).orElse(0L);
+            Long investments = Optional.ofNullable(fixedAssets.getInvestments()).orElse(0L);
             Long fixedAssetsTotal = fixedAssets.getTotal();
 
-            // Will calculate the total of all fixedassets fields as they are added to the balance sheet
-            Long calculatedTotal = tangible;
+            Long calculatedTotal = tangible + investments;
 
             validateAggregateTotal(fixedAssetsTotal, calculatedTotal, FIXED_ASSETS_TOTAL_PATH, errors);
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
@@ -39,16 +39,22 @@ public class FixedAssetsInvestmentsValidator extends BaseValidator {
         BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
                 companyAccountsId);
 
-        if ((hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) ||
-            hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet)) &&
+        if ((!hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) &&
+            !hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet)) &&
                 fixedAssetsNote.getDetails() == null) {
-            addError(errors, mandatoryElementMissing, FIXED_ASSETS_DETAILS_PATH);
+            addEmptyResourceError(errors, FIXED_ASSETS_DETAILS_PATH);
         }
 
         if ((!hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) &&
                 !hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet)) &&
                 fixedAssetsNote.getDetails() != null) {
             addError(errors, unexpectedData, FIXED_ASSETS_DETAILS_PATH);
+        }
+
+        if ((hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) ||
+                hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet)) &&
+                fixedAssetsNote.getDetails() == null) {
+            addError(errors, mandatoryElementMissing, FIXED_ASSETS_DETAILS_PATH);
         }
         return errors;
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
@@ -13,6 +11,9 @@ import uk.gov.companieshouse.api.accounts.service.impl.CurrentPeriodService;
 import uk.gov.companieshouse.api.accounts.service.impl.PreviousPeriodService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 
 @Component
 public class FixedAssetsInvestmentsValidator extends BaseValidator {
@@ -59,11 +60,9 @@ public class FixedAssetsInvestmentsValidator extends BaseValidator {
     private BalanceSheet getCurrentPeriodBalanceSheet(HttpServletRequest request,
             String companyAccountsId) throws DataException {
 
-        String currentPeriodId = currentPeriodService.generateID(companyAccountsId);
-
         ResponseObject<CurrentPeriod> currentPeriodResponseObject;
 
-        currentPeriodResponseObject = currentPeriodService.findById(currentPeriodId, request);
+        currentPeriodResponseObject = currentPeriodService.find(companyAccountsId, request);
 
         if (currentPeriodResponseObject != null && currentPeriodResponseObject.getData() != null) {
             return currentPeriodResponseObject.getData().getBalanceSheet();
@@ -74,11 +73,10 @@ public class FixedAssetsInvestmentsValidator extends BaseValidator {
 
     private BalanceSheet getPreviousPeriodBalanceSheet(
             HttpServletRequest request, String companyAccountsId) throws DataException {
-        String previousPeriodId = previousPeriodService.generateID(companyAccountsId);
 
         ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject;
 
-        previousPeriodResponseObject = previousPeriodService.findById(previousPeriodId, request);
+        previousPeriodResponseObject = previousPeriodService.find(companyAccountsId, request);
 
         if (previousPeriodResponseObject != null && previousPeriodResponseObject.getData() != null) {
             return previousPeriodResponseObject.getData().getBalanceSheet();

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
@@ -41,8 +41,8 @@ public class FixedAssetsInvestmentsValidator extends BaseValidator {
         BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
                 companyAccountsId);
 
-        if (hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) ||
-                hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet) &&
+        if ((hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) ||
+            hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet)) &&
                 fixedAssetsNote.getDetails() == null) {
             addError(errors, mandatoryElementMissing, FIXED_ASSETS_DETAILS_PATH);
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
@@ -31,7 +31,7 @@ public class FixedAssetsInvestmentsValidator extends BaseValidator {
     }
 
     public Errors validateFixedAssetsInvestments(@Valid HttpServletRequest request,
-            FixedAssetsInvestments fixedAssetsNote, Transaction transaction,
+            FixedAssetsInvestments fixedAssetsNote,
             String companyAccountsId) throws DataException {
 
         Errors errors = new Errors();

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
@@ -10,10 +12,6 @@ import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.service.impl.CurrentPeriodService;
 import uk.gov.companieshouse.api.accounts.service.impl.PreviousPeriodService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
 
 @Component
 public class FixedAssetsInvestmentsValidator extends BaseValidator {
@@ -45,6 +43,12 @@ public class FixedAssetsInvestmentsValidator extends BaseValidator {
             hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet)) &&
                 fixedAssetsNote.getDetails() == null) {
             addError(errors, mandatoryElementMissing, FIXED_ASSETS_DETAILS_PATH);
+        }
+
+        if ((!hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) &&
+                !hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet)) &&
+                fixedAssetsNote.getDetails() != null) {
+            addError(errors, unexpectedData, FIXED_ASSETS_DETAILS_PATH);
         }
         return errors;
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
@@ -1,0 +1,89 @@
+package uk.gov.companieshouse.api.accounts.validation;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.model.rest.BalanceSheet;
+import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.fixedassetsinvestments.FixedAssetsInvestments;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.service.impl.CurrentPeriodService;
+import uk.gov.companieshouse.api.accounts.service.impl.PreviousPeriodService;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+@Component
+public class FixedAssetsInvestmentsValidator extends BaseValidator {
+
+    private static final String FIXED_ASSETS_DETAILS_PATH = "$.fixed_assets_investments.details";
+
+    private CurrentPeriodService currentPeriodService;
+    private PreviousPeriodService previousPeriodService;
+
+    @Autowired
+    public FixedAssetsInvestmentsValidator(CurrentPeriodService currentPeriodService,
+            PreviousPeriodService previousPeriodService) {
+        this.currentPeriodService = currentPeriodService;
+        this.previousPeriodService = previousPeriodService;
+    }
+
+    public Errors validateFixedAssetsInvestments(@Valid HttpServletRequest request,
+            FixedAssetsInvestments fixedAssetsNote, Transaction transaction,
+            String companyAccountsId) throws DataException {
+
+        Errors errors = new Errors();
+
+        BalanceSheet currentPeriodBalanceSheet = getCurrentPeriodBalanceSheet(request,
+                companyAccountsId);
+        BalanceSheet previousPeriodBalanceSheet = getPreviousPeriodBalanceSheet(request,
+                companyAccountsId);
+
+        if (hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) ||
+                hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet) &&
+                fixedAssetsNote.getDetails() == null) {
+            addError(errors, mandatoryElementMissing, FIXED_ASSETS_DETAILS_PATH);
+        }
+        return errors;
+    }
+
+    private boolean hasPreviousBalanceSheetInvestmentsValue(BalanceSheet previousPeriodBalanceSheet) {
+        return previousPeriodBalanceSheet != null && previousPeriodBalanceSheet.getFixedAssets() != null && previousPeriodBalanceSheet.getFixedAssets().getInvestments() != null;
+    }
+
+    private boolean hasCurrentBalanceSheetInvestmentsValue(BalanceSheet currentPeriodBalanceSheet) {
+        return currentPeriodBalanceSheet !=null && currentPeriodBalanceSheet.getFixedAssets()!= null && currentPeriodBalanceSheet.getFixedAssets().getInvestments() !=null;
+    }
+
+    private BalanceSheet getCurrentPeriodBalanceSheet(HttpServletRequest request,
+            String companyAccountsId) throws DataException {
+
+        String currentPeriodId = currentPeriodService.generateID(companyAccountsId);
+
+        ResponseObject<CurrentPeriod> currentPeriodResponseObject;
+
+        currentPeriodResponseObject = currentPeriodService.findById(currentPeriodId, request);
+
+        if (currentPeriodResponseObject != null && currentPeriodResponseObject.getData() != null) {
+            return currentPeriodResponseObject.getData().getBalanceSheet();
+        } else {
+            return null;
+        }
+    }
+
+    private BalanceSheet getPreviousPeriodBalanceSheet(
+            HttpServletRequest request, String companyAccountsId) throws DataException {
+        String previousPeriodId = previousPeriodService.generateID(companyAccountsId);
+
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.PreviousPeriod> previousPeriodResponseObject;
+
+        previousPeriodResponseObject = previousPeriodService.findById(previousPeriodId, request);
+
+        if (previousPeriodResponseObject != null && previousPeriodResponseObject.getData() != null) {
+            return previousPeriodResponseObject.getData().getBalanceSheet();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidator.java
@@ -142,12 +142,11 @@ public class PreviousPeriodValidator extends BaseValidator {
         FixedAssets fixedAssets = previousPeriod.getBalanceSheet().getFixedAssets();
         if (fixedAssets != null) {
 
-            Long tangible = fixedAssets.getTangible();
+            Long tangible = Optional.ofNullable(fixedAssets.getTangible()).orElse(0L);
+            Long investments = Optional.ofNullable(fixedAssets.getInvestments()).orElse(0L);
             Long fixedAssetsTotal = fixedAssets.getTotal();
 
-            // Will calculate the total of all fixedassets fields as they are added to the
-            // balance sheet
-            Long calculatedTotal = tangible;
+            Long calculatedTotal = tangible + investments;
 
             validateAggregateTotal(fixedAssetsTotal, calculatedTotal, FIXED_ASSETS_TOTAL_PATH,
                     errors);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FixedAssetsInvestmentsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FixedAssetsInvestmentsServiceTest.java
@@ -114,7 +114,7 @@ public class FixedAssetsInvestmentsServiceTest {
     void canCreateFixedAssetsInvestments() throws DataException {
 
         when(mockTransformer.transform(mockFixedAssetsInvestments)).thenReturn(fixedAssetsInvestmentsEntity);
-        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, "")).thenReturn(mockErrors);
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
         
@@ -134,7 +134,7 @@ public class FixedAssetsInvestmentsServiceTest {
         doReturn(fixedAssetsInvestmentsEntity).when(mockTransformer).transform(ArgumentMatchers
             .any(FixedAssetsInvestments.class));
         when(mockRepository.insert(fixedAssetsInvestmentsEntity)).thenThrow(mockDuplicateKeyException);
-        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, "")).thenReturn(mockErrors);
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
         
@@ -152,7 +152,7 @@ public class FixedAssetsInvestmentsServiceTest {
         doReturn(fixedAssetsInvestmentsEntity).when(mockTransformer).transform(ArgumentMatchers
             .any(FixedAssetsInvestments.class));
         when(mockRepository.insert(fixedAssetsInvestmentsEntity)).thenThrow(mockMongoException);
-        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, "")).thenReturn(mockErrors);
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
         
@@ -165,7 +165,7 @@ public class FixedAssetsInvestmentsServiceTest {
     void canUpdateAFixedAssetsInvestments() throws DataException {
 
         when(mockTransformer.transform(mockFixedAssetsInvestments)).thenReturn(fixedAssetsInvestmentsEntity);
-        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, "")).thenReturn(mockErrors);
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
         
@@ -182,7 +182,7 @@ public class FixedAssetsInvestmentsServiceTest {
 
         doReturn(fixedAssetsInvestmentsEntity).when(mockTransformer).transform(ArgumentMatchers
             .any(FixedAssetsInvestments.class));
-        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, "")).thenReturn(mockErrors);
         when(mockRepository.save(fixedAssetsInvestmentsEntity)).thenThrow(mockMongoException);
 
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
@@ -282,7 +282,7 @@ public class FixedAssetsInvestmentsServiceTest {
     @DisplayName("Test correct response when validation fails on create")
     void validationFailsOnCreate() throws DataException {
 
-        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, "")).thenReturn(mockErrors);
         when(mockErrors.hasErrors()).thenReturn(true);
 
         ResponseObject<FixedAssetsInvestments> responseObject = service.create(mockFixedAssetsInvestments, mockTransaction,
@@ -295,7 +295,7 @@ public class FixedAssetsInvestmentsServiceTest {
     @DisplayName("Test correct response when validation fails on update")
     void validationFailsOnUpdate() throws DataException {
 
-        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, "")).thenReturn(mockErrors);
         when(mockErrors.hasErrors()).thenReturn(true);
 
         ResponseObject<FixedAssetsInvestments> responseObject = service.update(mockFixedAssetsInvestments, mockTransaction,

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FixedAssetsInvestmentsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/FixedAssetsInvestmentsServiceTest.java
@@ -6,22 +6,19 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.mongodb.MongoException;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-
 import javax.servlet.http.HttpServletRequest;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +29,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DuplicateKeyException;
-
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
@@ -45,10 +41,11 @@ import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.repository.FixedAssetsInvestmentsRepository;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
-import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 import uk.gov.companieshouse.api.accounts.transformer.FixedAssetsInvestmentsTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
+import uk.gov.companieshouse.api.accounts.validation.FixedAssetsInvestmentsValidator;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -88,6 +85,9 @@ public class FixedAssetsInvestmentsServiceTest {
     private SmallFullService mockSmallFullService;
 
     @Mock
+    private FixedAssetsInvestmentsValidator mockValidator;
+
+    @Mock
     private KeyIdGenerator mockKeyIdGenerator;
 
     private FixedAssetsInvestmentsEntity fixedAssetsInvestmentsEntity;
@@ -114,7 +114,7 @@ public class FixedAssetsInvestmentsServiceTest {
     void canCreateFixedAssetsInvestments() throws DataException {
 
         when(mockTransformer.transform(mockFixedAssetsInvestments)).thenReturn(fixedAssetsInvestmentsEntity);
-
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
         
@@ -134,7 +134,7 @@ public class FixedAssetsInvestmentsServiceTest {
         doReturn(fixedAssetsInvestmentsEntity).when(mockTransformer).transform(ArgumentMatchers
             .any(FixedAssetsInvestments.class));
         when(mockRepository.insert(fixedAssetsInvestmentsEntity)).thenThrow(mockDuplicateKeyException);
-
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
         
@@ -152,7 +152,7 @@ public class FixedAssetsInvestmentsServiceTest {
         doReturn(fixedAssetsInvestmentsEntity).when(mockTransformer).transform(ArgumentMatchers
             .any(FixedAssetsInvestments.class));
         when(mockRepository.insert(fixedAssetsInvestmentsEntity)).thenThrow(mockMongoException);
-
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
         
@@ -165,6 +165,7 @@ public class FixedAssetsInvestmentsServiceTest {
     void canUpdateAFixedAssetsInvestments() throws DataException {
 
         when(mockTransformer.transform(mockFixedAssetsInvestments)).thenReturn(fixedAssetsInvestmentsEntity);
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
         
@@ -181,6 +182,7 @@ public class FixedAssetsInvestmentsServiceTest {
 
         doReturn(fixedAssetsInvestmentsEntity).when(mockTransformer).transform(ArgumentMatchers
             .any(FixedAssetsInvestments.class));
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
         when(mockRepository.save(fixedAssetsInvestmentsEntity)).thenThrow(mockMongoException);
 
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
@@ -267,9 +269,35 @@ public class FixedAssetsInvestmentsServiceTest {
 
         assertThrows(DataException.class, () -> service.delete(COMPANY_ACCOUNTS_ID, mockRequest));
     }
+    @Test
+    @DisplayName("Test correct response when validation fails on create")
+    void validationFailsOnCreate() throws DataException {
+
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
+        when(mockErrors.hasErrors()).thenReturn(true);
+
+        ResponseObject<FixedAssetsInvestments> responseObject = service.create(mockFixedAssetsInvestments, mockTransaction,
+                "", mockRequest);
+
+        assertEquals(responseObject.getStatus(), ResponseStatus.VALIDATION_ERROR);
+    }
+
+    @Test
+    @DisplayName("Test correct response when validation fails on update")
+    void validationFailsOnUpdate() throws DataException {
+
+        when(mockValidator.validateFixedAssetsInvestments(mockRequest, mockFixedAssetsInvestments, mockTransaction, "")).thenReturn(mockErrors);
+        when(mockErrors.hasErrors()).thenReturn(true);
+
+        ResponseObject<FixedAssetsInvestments> responseObject = service.update(mockFixedAssetsInvestments, mockTransaction,
+                "", mockRequest);
+
+        assertEquals(responseObject.getStatus(), ResponseStatus.VALIDATION_ERROR);
+    }
 
     private ResponseStatus responseStatusNotFound() {
         ResponseObject<RestObject> responseObject = new ResponseObject<>(ResponseStatus.NOT_FOUND);
         return responseObject.getStatus();
     }
+
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
@@ -1,21 +1,20 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.accounts.model.rest.BalanceSheet;
+import uk.gov.companieshouse.api.accounts.model.rest.CapitalAndReserves;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
-import uk.gov.companieshouse.api.accounts.model.rest.CapitalAndReserves;
 import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CurrentPeriodValidatorTest {
 
@@ -57,24 +56,25 @@ public class CurrentPeriodValidatorTest {
         otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
         otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(5L);
         otherLiabilitiesOrAssets.setNetCurrentAssets(2L);
-        otherLiabilitiesOrAssets.setTotalAssetsLessCurrentLiabilities(4L);
+        otherLiabilitiesOrAssets.setTotalAssetsLessCurrentLiabilities(5L);
         otherLiabilitiesOrAssets.setCreditorsAfterOneYear(1L);
         otherLiabilitiesOrAssets.setProvisionForLiabilities(1L);
         otherLiabilitiesOrAssets.setAccrualsAndDeferredIncome(1L);
-        otherLiabilitiesOrAssets.setTotalNetAssets(1L);
+        otherLiabilitiesOrAssets.setTotalNetAssets(2L);
         balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
 
         CapitalAndReserves capitalAndReserves = new CapitalAndReserves();
         capitalAndReserves.setCalledUpShareCapital(1L);
-        capitalAndReserves.setOtherReserves(0L);
+        capitalAndReserves.setOtherReserves(1L);
         capitalAndReserves.setProfitAndLoss(0L);
         capitalAndReserves.setSharePremiumAccount(0L);
-        capitalAndReserves.setTotalShareholdersFunds(1L);
+        capitalAndReserves.setTotalShareholdersFunds(2L);
         balanceSheet.setCapitalAndReserves(capitalAndReserves);
 
         FixedAssets fixedAssets = new FixedAssets();
         fixedAssets.setTangible(1L);
-        fixedAssets.setTotal(1L);
+        fixedAssets.setInvestments(1L);
+        fixedAssets.setTotal(2L);
         balanceSheet.setFixedAssets(fixedAssets);
 
         balanceSheet.setCalledUpShareCapitalNotPaid(1L);
@@ -122,7 +122,8 @@ public class CurrentPeriodValidatorTest {
         balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
 
         FixedAssets fixedAssets = new FixedAssets();
-        fixedAssets.setTangible(2L);
+        fixedAssets.setTangible(1L);
+        fixedAssets.setInvestments(1L);
         fixedAssets.setTotal(2L);
         balanceSheet.setFixedAssets(fixedAssets);
 
@@ -233,6 +234,7 @@ public class CurrentPeriodValidatorTest {
     private void addInvalidFixedAssetsToBalanceSheet() {
         FixedAssets fixedAssets = new FixedAssets();
         fixedAssets.setTangible(5L);
+        fixedAssets.setInvestments(2L);
         fixedAssets.setTotal(10L);
 
         balanceSheet.setFixedAssets(fixedAssets);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/FixedInvestmentsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/FixedInvestmentsValidatorTest.java
@@ -156,10 +156,4 @@ public class FixedInvestmentsValidatorTest {
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).find(
                 "", mockRequest);
     }
-
-
-
-    // empty note when balance sheet not
-
-    // note when balance sheet null
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/FixedInvestmentsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/FixedInvestmentsValidatorTest.java
@@ -1,0 +1,147 @@
+package uk.gov.companieshouse.api.accounts.validation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.exception.ServiceException;
+import uk.gov.companieshouse.api.accounts.model.rest.BalanceSheet;
+import uk.gov.companieshouse.api.accounts.model.rest.FixedAssets;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.fixedassetsinvestments.FixedAssetsInvestments;
+import uk.gov.companieshouse.api.accounts.model.validation.Error;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.service.impl.CurrentPeriodService;
+import uk.gov.companieshouse.api.accounts.service.impl.PreviousPeriodService;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class FixedInvestmentsValidatorTest {
+
+    private static final String UNEXPECTED_DATA_NAME = "unexpectedData";
+    private static final String UNEXPECTED_DATA_VALUE = "unexpected.data";
+    private static final String FIXED_ASSETS_DETAILS_PATH = "$.fixed_assets_investments.details";
+    private static final String MANDATORY_ELEMENT_MISSING_NAME = "mandatoryElementMissing";
+    private static final String MANDATORY_ELEMENT_MISSING_VALUE =
+            "mandatory_element_missing";
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    @Mock
+    private CurrentPeriodService mockCurrentPeriodService;
+
+    @Mock
+    private PreviousPeriodService mockPreviousPeriodService;
+
+
+    private FixedAssetsInvestments fixedAssetsInvestments;
+    private Errors errors;
+    private FixedAssetsInvestmentsValidator validator;
+
+
+    @BeforeEach
+    void setup() {
+        fixedAssetsInvestments = new FixedAssetsInvestments();
+        errors = new Errors();
+        validator = new FixedAssetsInvestmentsValidator(mockCurrentPeriodService,
+                mockPreviousPeriodService);
+    }
+
+    @Test
+    @DisplayName("Valid note submitted")
+    void testValidNote() throws DataException {
+
+        mockValidBalanceSheetCurrentPeriod();
+
+        fixedAssetsInvestments.setDetails("test");
+
+        errors = validator.validateFixedAssetsInvestments(mockRequest, fixedAssetsInvestments, "");
+
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    @DisplayName("Note submitted with no balance sheet values")
+    void testValidationWhenNoteSubmittedNoBalanceSheetValues() throws DataException,
+            ServiceException {
+
+        fixedAssetsInvestments.setDetails("test");
+
+        ReflectionTestUtils.setField(validator, UNEXPECTED_DATA_NAME,
+                UNEXPECTED_DATA_VALUE);
+
+        errors = validator.validateFixedAssetsInvestments(mockRequest, fixedAssetsInvestments, "");
+
+        assertTrue(errors.hasErrors());
+        assertTrue(errors.containsError(createError(UNEXPECTED_DATA_VALUE,
+                FIXED_ASSETS_DETAILS_PATH)));
+
+    }
+
+    @Test
+    @DisplayName("Empty note when balance sheet values")
+    void testValidationEmptyNoteWhenBalanceSheetValues() throws DataException, ServiceException {
+
+        mockValidBalanceSheetCurrentPeriod();
+
+        ReflectionTestUtils.setField(validator, MANDATORY_ELEMENT_MISSING_NAME,
+                MANDATORY_ELEMENT_MISSING_VALUE);
+
+        errors = validator.validateFixedAssetsInvestments(mockRequest, fixedAssetsInvestments, "");
+
+        assertTrue(errors.hasErrors());
+        assertTrue(errors.containsError(createError(MANDATORY_ELEMENT_MISSING_VALUE,
+                FIXED_ASSETS_DETAILS_PATH)));
+
+    }
+
+    private Error createError(String error, String path) {
+        return new Error(error, path, LocationType.JSON_PATH.getValue(),
+                ErrorType.VALIDATION.getType());
+    }
+
+    private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> generateValidCurrentPeriodResponseObject() {
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject =
+                new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod>(
+                        ResponseStatus.FOUND);
+
+        uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriodTest =
+                new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
+
+        BalanceSheet balanceSheet = new BalanceSheet();
+
+        FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setInvestments(5L);
+        fixedAssets.setTotal(5L);
+
+        balanceSheet.setFixedAssets(fixedAssets);
+
+        currentPeriodTest.setBalanceSheet(balanceSheet);
+
+        currentPeriodResponseObject.setData(currentPeriodTest);
+        return currentPeriodResponseObject;
+    }
+
+    private void mockValidBalanceSheetCurrentPeriod() throws DataException {
+        doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).find(
+                "", mockRequest);
+    }
+
+
+
+    // empty note when balance sheet not
+
+    // note when balance sheet null
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/FixedInvestmentsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/FixedInvestmentsValidatorTest.java
@@ -32,6 +32,8 @@ public class FixedInvestmentsValidatorTest {
     private static final String UNEXPECTED_DATA_NAME = "unexpectedData";
     private static final String UNEXPECTED_DATA_VALUE = "unexpected.data";
     private static final String FIXED_ASSETS_DETAILS_PATH = "$.fixed_assets_investments.details";
+    private static final String EMPTY_RESOURCE_NAME = "emptyResource";
+    private static final String EMPTY_RESOURCE_VALUE = "empty_resource";
     private static final String MANDATORY_ELEMENT_MISSING_NAME = "mandatoryElementMissing";
     private static final String MANDATORY_ELEMENT_MISSING_VALUE =
             "mandatory_element_missing";
@@ -60,7 +62,7 @@ public class FixedInvestmentsValidatorTest {
     }
 
     @Test
-    @DisplayName("Valid note submitted")
+    @DisplayName("Valid note submitted successfully")
     void testValidNote() throws DataException {
 
         mockValidBalanceSheetCurrentPeriod();
@@ -73,7 +75,7 @@ public class FixedInvestmentsValidatorTest {
     }
 
     @Test
-    @DisplayName("Note submitted with no balance sheet values")
+    @DisplayName("Error thrown when note submitted with no balance sheet values")
     void testValidationWhenNoteSubmittedNoBalanceSheetValues() throws DataException,
             ServiceException {
 
@@ -91,7 +93,7 @@ public class FixedInvestmentsValidatorTest {
     }
 
     @Test
-    @DisplayName("Empty note when balance sheet values")
+    @DisplayName("Error thrown when empty note submitted when balance sheet values")
     void testValidationEmptyNoteWhenBalanceSheetValues() throws DataException, ServiceException {
 
         mockValidBalanceSheetCurrentPeriod();
@@ -103,6 +105,22 @@ public class FixedInvestmentsValidatorTest {
 
         assertTrue(errors.hasErrors());
         assertTrue(errors.containsError(createError(MANDATORY_ELEMENT_MISSING_VALUE,
+                FIXED_ASSETS_DETAILS_PATH)));
+
+    }
+
+    @Test
+    @DisplayName("Error thrown when empty resource submitted")
+    void testValidationEmptyResource() throws DataException, ServiceException {
+
+
+        ReflectionTestUtils.setField(validator, EMPTY_RESOURCE_NAME,
+                EMPTY_RESOURCE_VALUE);
+
+        errors = validator.validateFixedAssetsInvestments(mockRequest, fixedAssetsInvestments, "");
+
+        assertTrue(errors.hasErrors());
+        assertTrue(errors.containsError(createError(EMPTY_RESOURCE_VALUE,
                 FIXED_ASSETS_DETAILS_PATH)));
 
     }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
@@ -80,25 +80,28 @@ public class PreviousPeriodValidatorTest {
         otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(4L);
         otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(5L);
         otherLiabilitiesOrAssets.setNetCurrentAssets(2L);
-        otherLiabilitiesOrAssets.setTotalAssetsLessCurrentLiabilities(4L);
+        otherLiabilitiesOrAssets.setTotalAssetsLessCurrentLiabilities(5L);
         otherLiabilitiesOrAssets.setCreditorsAfterOneYear(1L);
         otherLiabilitiesOrAssets.setProvisionForLiabilities(1L);
         otherLiabilitiesOrAssets.setAccrualsAndDeferredIncome(1L);
-        otherLiabilitiesOrAssets.setTotalNetAssets(1L);
+        otherLiabilitiesOrAssets.setTotalNetAssets(2L);
         balanceSheet.setOtherLiabilitiesOrAssets(otherLiabilitiesOrAssets);
 
         CapitalAndReserves capitalAndReserves = new CapitalAndReserves();
         capitalAndReserves.setCalledUpShareCapital(1L);
-        capitalAndReserves.setOtherReserves(0L);
+        capitalAndReserves.setOtherReserves(1L);
         capitalAndReserves.setProfitAndLoss(0L);
         capitalAndReserves.setSharePremiumAccount(0L);
-        capitalAndReserves.setTotalShareholdersFunds(1L);
+        capitalAndReserves.setTotalShareholdersFunds(2L);
         balanceSheet.setCapitalAndReserves(capitalAndReserves);
 
         FixedAssets fixedAssets = new FixedAssets();
         fixedAssets.setTangible(1L);
-        fixedAssets.setTotal(1L);
+        fixedAssets.setInvestments(1L);
+        fixedAssets.setTotal(2L);
         balanceSheet.setFixedAssets(fixedAssets);
+
+        balanceSheet.setCalledUpShareCapitalNotPaid(1L);
 
         balanceSheet.setCalledUpShareCapitalNotPaid(1L);
 


### PR DESCRIPTION
Add 'investments' to the fixed assets section of balance sheet api.

Add investments to rest and entity fixed assets models
Add validation to fields
Add unit tests

SFA-1169