### PR TITLE
Correct bug due to details submission on notes

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
@@ -12,6 +12,7 @@ import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
 import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.notes.creditorsafteroneyearentity.CreditorsAfterOneYearEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.notes.creditorsafteroneyear.CreditorsAfterOneYear;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.creditorsafteroneyear.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.repository.CreditorsAfterOneYearRepository;
 import uk.gov.companieshouse.api.accounts.service.ResourceService;
@@ -52,6 +53,12 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
     @Override
     public ResponseObject<CreditorsAfterOneYear> create(CreditorsAfterOneYear rest,
             Transaction transaction, String companyAccountId, HttpServletRequest request) throws DataException {
+
+        // Details value should not be saved if no other current period fields are provided
+        CurrentPeriod currentPeriod = rest.getCurrentPeriod();
+        if (validator.validateIfOnlyDetails(currentPeriod)) {
+            rest.setCurrentPeriod(null);
+        }
 
         Errors errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsAfterOneYearService.java
@@ -91,6 +91,12 @@ public class CreditorsAfterOneYearService implements ResourceService<CreditorsAf
     public ResponseObject<CreditorsAfterOneYear> update(CreditorsAfterOneYear rest,
             Transaction transaction, String companyAccountId, HttpServletRequest request) throws DataException {
 
+        // Details value should not be saved if no other current period fields are provided
+        CurrentPeriod currentPeriod = rest.getCurrentPeriod();
+        if (validator.validateIfOnlyDetails(currentPeriod)) {
+            rest.setCurrentPeriod(null);
+        }
+
         Errors errors = validator.validateCreditorsAfterOneYear(rest, transaction, companyAccountId, request);
 
         if (errors.hasErrors()) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CreditorsWithinOneYearService.java
@@ -15,6 +15,7 @@ import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
 import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.notes.creditorswithinoneyear.CreditorsWithinOneYearEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.notes.creditorswithinoneyear.CreditorsWithinOneYear;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.creditorswithinoneyear.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.repository.CreditorsWithinOneYearRepository;
 import uk.gov.companieshouse.api.accounts.service.ResourceService;
@@ -53,6 +54,12 @@ public class CreditorsWithinOneYearService implements ResourceService<CreditorsW
             String companyAccountId,
             HttpServletRequest request) throws DataException {
 
+        // Details value should not be saved if no other current period fields are provided
+        CurrentPeriod currentPeriod = rest.getCurrentPeriod();
+        if (validator.validateIfOnlyDetails(currentPeriod)) {
+            rest.setCurrentPeriod(null);
+        }
+
         Errors errors = validator.validateCreditorsWithinOneYear(rest, transaction, companyAccountId, request);
 
         if (errors.hasErrors()) {
@@ -84,6 +91,12 @@ public class CreditorsWithinOneYearService implements ResourceService<CreditorsW
             Transaction transaction,
             String companyAccountId,
             HttpServletRequest request) throws DataException {
+
+        // Details value should not be saved if no other current period fields are provided
+        CurrentPeriod currentPeriod = rest.getCurrentPeriod();
+        if (validator.validateIfOnlyDetails(currentPeriod)) {
+            rest.setCurrentPeriod(null);
+        }
 
         Errors errors = validator.validateCreditorsWithinOneYear(rest, transaction, companyAccountId, request);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsService.java
@@ -14,16 +14,17 @@ import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
 import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.notes.debtors.DebtorsEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.debtors.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.model.rest.notes.debtors.Debtors;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.repository.DebtorsRepository;
 import uk.gov.companieshouse.api.accounts.service.ResourceService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.DebtorsTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
 import uk.gov.companieshouse.api.accounts.validation.DebtorsValidator;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @Service
 public class DebtorsService implements ResourceService<Debtors> {
@@ -35,7 +36,7 @@ public class DebtorsService implements ResourceService<Debtors> {
     private DebtorsValidator debtorsValidator;
 
     @Autowired
-    public DebtorsService (DebtorsRepository repository, DebtorsTransformer transformer,
+    public DebtorsService(DebtorsRepository repository, DebtorsTransformer transformer,
             SmallFullService smallFullService, KeyIdGenerator keyIdGenerator,
             DebtorsValidator debtorsValidator) {
 
@@ -47,8 +48,15 @@ public class DebtorsService implements ResourceService<Debtors> {
     }
 
     @Override
-    public ResponseObject<Debtors> create (Debtors rest, Transaction transaction,
+    public ResponseObject<Debtors> create(Debtors rest, Transaction transaction,
             String companyAccountsId, HttpServletRequest request) throws DataException {
+
+        // Details value should not be saved if no other current period fields are provided
+        CurrentPeriod currentPeriodDebtors = rest.getCurrentPeriod();
+        if (debtorsValidator.validateIfOnlyDetails(currentPeriodDebtors)) {
+            rest.setCurrentPeriod(null);
+
+        }
 
         Errors errors = debtorsValidator.validateDebtors(rest, transaction, companyAccountsId,
                 request);
@@ -81,9 +89,15 @@ public class DebtorsService implements ResourceService<Debtors> {
     }
 
     @Override
-    public ResponseObject<Debtors> update (Debtors rest, Transaction transaction,
+    public ResponseObject<Debtors> update(Debtors rest, Transaction transaction,
             String companyAccountsId, HttpServletRequest request) throws DataException {
         setMetadataOnRestObject(rest, transaction, companyAccountsId);
+
+        // Details value should not be saved if no other current period fields are provided
+        CurrentPeriod currentPeriodDebtors = rest.getCurrentPeriod();
+        if (debtorsValidator.validateIfOnlyDetails(currentPeriodDebtors)) {
+            rest.setCurrentPeriod(null);
+        }
 
         Errors errors = debtorsValidator.validateDebtors(rest, transaction, companyAccountsId,
                 request);
@@ -145,26 +159,26 @@ public class DebtorsService implements ResourceService<Debtors> {
         return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.DEBTORS.getName());
     }
 
-    private String generateSelfLink (Transaction transaction, String companyAccountId) {
+    private String generateSelfLink(Transaction transaction, String companyAccountId) {
 
         return transaction.getLinks().getSelf() + "/"
                 + ResourceName.COMPANY_ACCOUNT.getName() + "/" + companyAccountId + "/"
                 + ResourceName.SMALL_FULL.getName() + "/notes/" + ResourceName.DEBTORS.getName();
     }
 
-    public String getSelfLinkFromDebtorsEntity (DebtorsEntity entity) {
+    public String getSelfLinkFromDebtorsEntity(DebtorsEntity entity) {
 
         return entity.getData().getLinks().get(BasicLinkType.SELF.getLink());
     }
 
-    private Map<String, String> createSelfLink (Transaction transaction, String companyAccountsId) {
+    private Map<String, String> createSelfLink(Transaction transaction, String companyAccountsId) {
 
         Map<String, String> map = new HashMap<>();
         map.put(BasicLinkType.SELF.getLink(), generateSelfLink(transaction, companyAccountsId));
         return map;
     }
 
-    private void setMetadataOnRestObject (Debtors rest, Transaction transaction,
+    private void setMetadataOnRestObject(Debtors rest, Transaction transaction,
             String companyAccountsId) {
 
         rest.setLinks(createSelfLink(transaction, companyAccountsId));

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
@@ -47,7 +47,7 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
 
     public boolean validateIfOnlyDetails(CurrentPeriod currentPeriodNote) {
         return (currentPeriodNote != null && currentPeriodNote.getDetails() != null &&
-                (currentPeriodNote.getTotal() == null) && isCreditorsNumericFieldsNull(currentPeriodNote));
+                isCreditorsNumericFieldsNull(currentPeriodNote));
     }
 
     private boolean isCreditorsNumericFieldsNull(CurrentPeriod currentPeriodNote) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
@@ -46,11 +46,15 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
     }
 
     public boolean validateIfOnlyDetails(CurrentPeriod currentPeriodNote) {
-        return (currentPeriodNote != null && currentPeriodNote.getDetails() != null && (currentPeriodNote.getTotal() == null) && isCreditorsNumericFieldsNull(currentPeriodNote));
+        return (currentPeriodNote != null && currentPeriodNote.getDetails() != null &&
+                (currentPeriodNote.getTotal() == null) && isCreditorsNumericFieldsNull(currentPeriodNote));
     }
 
     private boolean isCreditorsNumericFieldsNull(CurrentPeriod currentPeriodNote) {
-        return currentPeriodNote.getBankLoansAndOverdrafts() == null && currentPeriodNote.getBankLoansAndOverdrafts() == null && currentPeriodNote.getOtherCreditors() == null;
+        return currentPeriodNote.getBankLoansAndOverdrafts() == null &&
+                currentPeriodNote.getOtherCreditors() == null &&
+                currentPeriodNote.getFinanceLeasesAndHirePurchaseContracts() == null &&
+                currentPeriodNote.getTotal() == null;
     }
 
     private Errors validateIfEmptyResource(CreditorsAfterOneYear creditorsAfterOneYear,

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterOneYearValidator.java
@@ -45,6 +45,14 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
         this.previousPeriodService = previousPeriodService;
     }
 
+    public boolean validateIfOnlyDetails(CurrentPeriod currentPeriodNote) {
+        return (currentPeriodNote != null && currentPeriodNote.getDetails() != null && (currentPeriodNote.getTotal() == null) && isCreditorsNumericFieldsNull(currentPeriodNote));
+    }
+
+    private boolean isCreditorsNumericFieldsNull(CurrentPeriod currentPeriodNote) {
+        return currentPeriodNote.getBankLoansAndOverdrafts() == null && currentPeriodNote.getBankLoansAndOverdrafts() == null && currentPeriodNote.getOtherCreditors() == null;
+    }
+
     private Errors validateIfEmptyResource(CreditorsAfterOneYear creditorsAfterOneYear,
             HttpServletRequest request, String companyAccountsId) throws DataException {
 
@@ -105,7 +113,9 @@ public class CreditorsAfterOneYearValidator extends BaseValidator implements Cro
                 ! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet);
         boolean hasCurrentPeriodNoteData = currentPeriodNote != null;
 
+
         if (! hasCurrentPeriodBalanceSheetNoteValue && hasCurrentPeriodNoteData) {
+
 
             if (validateNoUnexpectedDataPresent(hasCurrentPeriodBalanceSheet,
                     CREDITORS_AFTER_CURRENT_PERIOD_PATH, errors)) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -46,6 +46,14 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
         this.previousPeriodService = previousPeriodService;
     }
 
+    public boolean validateIfOnlyDetails(CurrentPeriod currentPeriodNote) {
+        return (currentPeriodNote != null && currentPeriodNote.getDetails() != null && creditorsNumberFieldsAreNull(currentPeriodNote));
+    }
+
+    private boolean creditorsNumberFieldsAreNull(CurrentPeriod currentPeriodNote) {
+        return currentPeriodNote.getTotal() == null && currentPeriodNote.getTradeCreditors() == null && currentPeriodNote.getAccrualsAndDeferredIncome() == null && currentPeriodNote.getOtherCreditors() == null && currentPeriodNote.getTaxationAndSocialSecurity()==null && currentPeriodNote.getFinanceLeasesAndHirePurchaseContracts()==null && currentPeriodNote.getBankLoansAndOverdrafts()==null;
+    }
+
     private Errors validateIfEmptyResource(CreditorsWithinOneYear creditorsWithinOneYear,
             HttpServletRequest request, String companyAccountsId) throws DataException {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -47,7 +47,8 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
     }
 
     public boolean validateIfOnlyDetails(CurrentPeriod currentPeriodNote) {
-        return (currentPeriodNote != null && currentPeriodNote.getDetails() != null && creditorsNumberFieldsAreNull(currentPeriodNote));
+        return (currentPeriodNote != null && currentPeriodNote.getDetails() != null
+                && creditorsNumberFieldsAreNull(currentPeriodNote));
     }
 
     private boolean creditorsNumberFieldsAreNull(CurrentPeriod currentPeriodNote) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidator.java
@@ -51,7 +51,12 @@ public class CreditorsWithinOneYearValidator extends BaseValidator implements Cr
     }
 
     private boolean creditorsNumberFieldsAreNull(CurrentPeriod currentPeriodNote) {
-        return currentPeriodNote.getTotal() == null && currentPeriodNote.getTradeCreditors() == null && currentPeriodNote.getAccrualsAndDeferredIncome() == null && currentPeriodNote.getOtherCreditors() == null && currentPeriodNote.getTaxationAndSocialSecurity()==null && currentPeriodNote.getFinanceLeasesAndHirePurchaseContracts()==null && currentPeriodNote.getBankLoansAndOverdrafts()==null;
+        return currentPeriodNote.getTotal() == null && currentPeriodNote.getTradeCreditors() == null &&
+                currentPeriodNote.getAccrualsAndDeferredIncome() == null &&
+                currentPeriodNote.getOtherCreditors() == null &&
+                currentPeriodNote.getTaxationAndSocialSecurity() == null &&
+                currentPeriodNote.getFinanceLeasesAndHirePurchaseContracts() == null &&
+                currentPeriodNote.getBankLoansAndOverdrafts() == null;
     }
 
     private Errors validateIfEmptyResource(CreditorsWithinOneYear creditorsWithinOneYear,

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -43,7 +43,14 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     }
 
     public boolean validateIfOnlyDetails(CurrentPeriod currentPeriodNote) {
-        return (currentPeriodNote != null && currentPeriodNote.getDetails() != null && (currentPeriodNote.getTotal() == null && currentPeriodNote.getOtherDebtors() == null && currentPeriodNote.getPrepaymentsAndAccruedIncome() == null && currentPeriodNote.getTradeDebtors() == null));
+        return (currentPeriodNote != null && currentPeriodNote.getDetails() != null
+                && isDebtorsNumericFieldsNull(currentPeriodNote));
+    }
+
+    boolean isDebtorsNumericFieldsNull(CurrentPeriod currentPeriodNote) {
+        return currentPeriodNote.getTotal() == null && currentPeriodNote.getOtherDebtors() == null
+                && currentPeriodNote.getPrepaymentsAndAccruedIncome() == null
+                && currentPeriodNote.getTradeDebtors() == null;
     }
 
     private Errors validateIfEmptyResource(Debtors debtors,
@@ -69,7 +76,6 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     public Errors validateDebtors(@Valid Debtors debtors, Transaction transaction,
             String companyAccountsId,
             HttpServletRequest request) throws DataException {
-
 
         Errors errors = validateIfEmptyResource(debtors, request, companyAccountsId);
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -42,6 +42,10 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         this.previousPeriodService = previousPeriodService;
     }
 
+    public boolean validateIfOnlyDetails(CurrentPeriod currentPeriodNote) {
+        return (currentPeriodNote != null && currentPeriodNote.getDetails() != null && (currentPeriodNote.getTotal() == null && currentPeriodNote.getOtherDebtors() == null && currentPeriodNote.getPrepaymentsAndAccruedIncome() == null && currentPeriodNote.getTradeDebtors() == null));
+    }
+
     private Errors validateIfEmptyResource(Debtors debtors,
             HttpServletRequest request, String companyAccountsId) throws DataException {
 
@@ -65,6 +69,7 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
     public Errors validateDebtors(@Valid Debtors debtors, Transaction transaction,
             String companyAccountsId,
             HttpServletRequest request) throws DataException {
+
 
         Errors errors = validateIfEmptyResource(debtors, request, companyAccountsId);
 
@@ -93,15 +98,17 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         return errors;
     }
 
+
     private void validateCurrentPeriod(CurrentPeriod currentPeriodNote,
             BalanceSheet currentPeriodBalanceSheet, Errors errors) {
 
         boolean hasCurrentPeriodBalanceSheet = currentPeriodBalanceSheet != null;
         boolean hasCurrentPeriodBalanceSheetNoteValue =
                 ! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet);
-        boolean hasCurrentPeriodNoteData = currentPeriodNote!=null && (currentPeriodNote.getTradeDebtors()!=null || currentPeriodNote.getPrepaymentsAndAccruedIncome() !=null || currentPeriodNote.getOtherDebtors()!=null || currentPeriodNote.getTotal()!=null);
+        boolean hasCurrentPeriodNoteData = currentPeriodNote != null;
 
         if (! hasCurrentPeriodBalanceSheetNoteValue && hasCurrentPeriodNoteData) {
+
             if (validateNoUnexpectedDataPresent(hasCurrentPeriodBalanceSheet,
                     DEBTORS_PATH_CURRENT, errors)) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
@@ -120,8 +127,7 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         boolean hasPreviousPeriodBalanceSheet = previousPeriodBalanceSheet != null;
         boolean hasPreviousPeriodBalanceSheetNoteValue =
                 ! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet);
-        boolean hasPreviousPeriodNoteData = previousPeriodNote != null && (previousPeriodNote.getTradeDebtors()!=null || previousPeriodNote.getPrepaymentsAndAccruedIncome() !=null || previousPeriodNote.getOtherDebtors()!=null || previousPeriodNote.getTotal()!=null);
-        ;
+        boolean hasPreviousPeriodNoteData = previousPeriodNote != null;
 
         if (! hasPreviousPeriodBalanceSheetNoteValue && hasPreviousPeriodNoteData) {
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -99,10 +99,9 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         boolean hasCurrentPeriodBalanceSheet = currentPeriodBalanceSheet != null;
         boolean hasCurrentPeriodBalanceSheetNoteValue =
                 ! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet);
-        boolean hasCurrentPeriodNoteData = currentPeriodNote != null;
+        boolean hasCurrentPeriodNoteData = currentPeriodNote!=null && (currentPeriodNote.getTradeDebtors()!=null || currentPeriodNote.getPrepaymentsAndAccruedIncome() !=null || currentPeriodNote.getOtherDebtors()!=null || currentPeriodNote.getTotal()!=null);
 
         if (! hasCurrentPeriodBalanceSheetNoteValue && hasCurrentPeriodNoteData) {
-
             if (validateNoUnexpectedDataPresent(hasCurrentPeriodBalanceSheet,
                     DEBTORS_PATH_CURRENT, errors)) {
                 validateCurrentPeriodFields(currentPeriodNote, errors);
@@ -121,7 +120,8 @@ public class DebtorsValidator extends BaseValidator implements CrossValidator<De
         boolean hasPreviousPeriodBalanceSheet = previousPeriodBalanceSheet != null;
         boolean hasPreviousPeriodBalanceSheetNoteValue =
                 ! isPreviousPeriodBalanceSheetDataNull(previousPeriodBalanceSheet);
-        boolean hasPreviousPeriodNoteData = previousPeriodNote != null;
+        boolean hasPreviousPeriodNoteData = previousPeriodNote != null && (previousPeriodNote.getTradeDebtors()!=null || previousPeriodNote.getPrepaymentsAndAccruedIncome() !=null || previousPeriodNote.getOtherDebtors()!=null || previousPeriodNote.getTotal()!=null);
+        ;
 
         if (! hasPreviousPeriodBalanceSheetNoteValue && hasPreviousPeriodNoteData) {
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsServiceTest.java
@@ -298,23 +298,4 @@ public class DebtorsServiceTest {
 
         assertEquals(responseObject.getStatus(), ResponseStatus.VALIDATION_ERROR);
     }
-
-    @Test
-    @DisplayName("Tests ")
-    void test() throws DataException {
-
-        when(mockTransformer.transform(mockDebtors)).thenReturn(debtorsEntity);
-        when(debtorsValidator.validateIfOnlyDetails(mockDebtorsCurrentPeriod)).thenReturn(true);
-        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "", mockRequest)).thenReturn(mockErrors);
-
-        when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
-        when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
-
-        ResponseObject<Debtors> result = service.create(mockDebtors, mockTransaction,
-                "", mockRequest);
-
-        assertNull(mockDebtors.getCurrentPeriod());
-
-
-    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DebtorsServiceTest.java
@@ -32,15 +32,16 @@ import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
 import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.notes.debtors.DebtorsDataEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.notes.debtors.DebtorsEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.notes.debtors.CurrentPeriod;
 import uk.gov.companieshouse.api.accounts.model.rest.notes.debtors.Debtors;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.repository.DebtorsRepository;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.DebtorsTransformer;
 import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
 import uk.gov.companieshouse.api.accounts.validation.DebtorsValidator;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 
 @ExtendWith(MockitoExtension.class)
@@ -83,6 +84,9 @@ public class DebtorsServiceTest {
     @Mock
     private Errors mockErrors;
 
+    @Mock
+    private CurrentPeriod mockDebtorsCurrentPeriod;
+
     @InjectMocks
     private DebtorsService service;
 
@@ -110,13 +114,13 @@ public class DebtorsServiceTest {
     void canCreateDebtors() throws DataException {
 
         when(mockTransformer.transform(mockDebtors)).thenReturn(debtorsEntity);
-        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "",mockRequest)).thenReturn(mockErrors);
+        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "", mockRequest)).thenReturn(mockErrors);
 
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
 
         ResponseObject<Debtors> result = service.create(mockDebtors, mockTransaction,
-            "", mockRequest);
+                "", mockRequest);
 
         assertNotNull(result);
         assertEquals(mockDebtors, result.getData());
@@ -127,16 +131,16 @@ public class DebtorsServiceTest {
     void createDebtorsDuplicateKey() throws DataException {
 
         doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
-            .any(Debtors.class));
+                .any(Debtors.class));
 
-        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "",mockRequest)).thenReturn(mockErrors);
+        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "", mockRequest)).thenReturn(mockErrors);
         when(mockRepository.insert(debtorsEntity)).thenThrow(mockDuplicateKeyException);
 
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
 
         ResponseObject response = service.create(mockDebtors, mockTransaction, "",
-            mockRequest);
+                mockRequest);
 
         assertNotNull(response);
         assertEquals(response.getStatus(), ResponseStatus.DUPLICATE_KEY_ERROR);
@@ -148,22 +152,22 @@ public class DebtorsServiceTest {
     void createDebtorsMongoExceptionFailure() throws DataException {
 
         doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
-            .any(Debtors.class));
-        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "",mockRequest)).thenReturn(mockErrors);
+                .any(Debtors.class));
+        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "", mockRequest)).thenReturn(mockErrors);
         when(mockRepository.insert(debtorsEntity)).thenThrow(mockMongoException);
 
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
 
         assertThrows(DataException.class,
-            () -> service.create(mockDebtors, mockTransaction, "", mockRequest));
+                () -> service.create(mockDebtors, mockTransaction, "", mockRequest));
     }
 
     @Test
     @DisplayName("Tests the successful update of a debtors resource")
     void canUpdateADebtors() throws DataException {
 
-        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "",mockRequest)).thenReturn(mockErrors);
+        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "", mockRequest)).thenReturn(mockErrors);
 
         when(mockTransformer.transform(mockDebtors)).thenReturn(debtorsEntity);
 
@@ -171,7 +175,7 @@ public class DebtorsServiceTest {
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
 
         ResponseObject<Debtors> result = service.update(mockDebtors, mockTransaction,
-            "", mockRequest);
+                "", mockRequest);
 
         assertNotNull(result);
         assertEquals(mockDebtors, result.getData());
@@ -181,17 +185,17 @@ public class DebtorsServiceTest {
     @DisplayName("Tests the mongo exception when updating a debtors resource")
     void updateDebtorsMongoExceptionFailure() throws DataException {
 
-        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "",mockRequest)).thenReturn(mockErrors);
+        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "", mockRequest)).thenReturn(mockErrors);
 
         doReturn(debtorsEntity).when(mockTransformer).transform(ArgumentMatchers
-            .any(Debtors.class));
+                .any(Debtors.class));
         when(mockRepository.save(debtorsEntity)).thenThrow(mockMongoException);
 
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
         when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
 
         assertThrows(DataException.class,
-            () -> service.update(mockDebtors, mockTransaction, "", mockRequest));
+                () -> service.update(mockDebtors, mockTransaction, "", mockRequest));
     }
 
     @Test
@@ -201,7 +205,7 @@ public class DebtorsServiceTest {
         when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.DEBTORS.getName()))
                 .thenReturn(DEBTORS_ID);
         when(mockRepository.findById(DEBTORS_ID))
-            .thenReturn(Optional.ofNullable(debtorsEntity));
+                .thenReturn(Optional.ofNullable(debtorsEntity));
         when(mockTransformer.transform(debtorsEntity)).thenReturn(mockDebtors);
 
         ResponseObject<Debtors> result = service.find(COMPANY_ACCOUNTS_ID, mockRequest);
@@ -217,7 +221,7 @@ public class DebtorsServiceTest {
         when(mockKeyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.DEBTORS.getName()))
                 .thenReturn(DEBTORS_ID);
         when(mockRepository.findById(DEBTORS_ID))
-            .thenReturn(Optional.ofNullable(debtorsEntity));
+                .thenReturn(Optional.ofNullable(debtorsEntity));
 
         ResponseObject<Debtors> result = service.find(COMPANY_ACCOUNTS_ID, mockRequest);
 
@@ -283,7 +287,7 @@ public class DebtorsServiceTest {
     @DisplayName("Test correct response when validation fails on update")
     void validationFailsOnUpdate() throws DataException {
 
-        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "",mockRequest)).thenReturn(mockErrors);
+        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "", mockRequest)).thenReturn(mockErrors);
         when(mockErrors.hasErrors()).thenReturn(true);
 
         when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
@@ -295,4 +299,22 @@ public class DebtorsServiceTest {
         assertEquals(responseObject.getStatus(), ResponseStatus.VALIDATION_ERROR);
     }
 
+    @Test
+    @DisplayName("Tests ")
+    void test() throws DataException {
+
+        when(mockTransformer.transform(mockDebtors)).thenReturn(debtorsEntity);
+        when(debtorsValidator.validateIfOnlyDetails(mockDebtorsCurrentPeriod)).thenReturn(true);
+        when(debtorsValidator.validateDebtors(mockDebtors, mockTransaction, "", mockRequest)).thenReturn(mockErrors);
+
+        when(mockTransaction.getLinks()).thenReturn(mockTransactionLinks);
+        when(mockTransactionLinks.getSelf()).thenReturn(SELF_LINK);
+
+        ResponseObject<Debtors> result = service.create(mockDebtors, mockTransaction,
+                "", mockRequest);
+
+        assertNull(mockDebtors.getCurrentPeriod());
+
+
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -355,18 +355,25 @@ public class DebtorsValidatorTest {
         mockValidBalanceSheetPreviousPeriod();
 
         ReflectionTestUtils.setField(validator, MANDATORY_ELEMENT_MISSING_NAME, MANDATORY_ELEMENT_MISSING_VALUE);
+        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
+                CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
+        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
+                PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(true);
 
         errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.hasErrors());
-        assertEquals(2, errors.getErrorCount());
+        assertEquals(4, errors.getErrorCount());
         assertTrue(errors.containsError(createError(MANDATORY_ELEMENT_MISSING_VALUE,
-                DEBTORS_PATH_CURRENT)));
-
+                CURRENT_TOTAL_PATH)));
         assertTrue(errors.containsError(createError(MANDATORY_ELEMENT_MISSING_VALUE,
-                DEBTORS_PATH_PREVIOUS)));
+                PREVIOUS_TOTAL_PATH)));
+        assertTrue(errors.containsError(createError(CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE, CURRENT_TOTAL_PATH
+                )));
+        assertTrue(errors.containsError(createError(PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE,
+                PREVIOUS_TOTAL_PATH)));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -355,25 +355,18 @@ public class DebtorsValidatorTest {
         mockValidBalanceSheetPreviousPeriod();
 
         ReflectionTestUtils.setField(validator, MANDATORY_ELEMENT_MISSING_NAME, MANDATORY_ELEMENT_MISSING_VALUE);
-        ReflectionTestUtils.setField(validator, CURRENT_BALANCE_SHEET_NOT_EQUAL_NAME,
-            CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE);
-        ReflectionTestUtils.setField(validator, PREVIOUS_BALANCE_SHEET_NOT_EQUAL_NAME,
-            PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE);
 
         when(mockCompanyService.isMultipleYearFiler(mockTransaction)).thenReturn(true);
 
         errors = validator.validateDebtors(debtors, mockTransaction, COMPANY_ACCOUNTS_ID, mockRequest);
 
         assertTrue(errors.hasErrors());
-        assertEquals(4, errors.getErrorCount());
+        assertEquals(2, errors.getErrorCount());
         assertTrue(errors.containsError(createError(MANDATORY_ELEMENT_MISSING_VALUE,
-            CURRENT_TOTAL_PATH)));
-        assertTrue(errors.containsError(createError(CURRENT_BALANCE_SHEET_NOT_EQUAL_VALUE,
-            CURRENT_TOTAL_PATH)));
+                DEBTORS_PATH_CURRENT)));
+
         assertTrue(errors.containsError(createError(MANDATORY_ELEMENT_MISSING_VALUE,
-            PREVIOUS_TOTAL_PATH)));
-        assertTrue(errors.containsError(createError(PREVIOUS_BALANCE_SHEET_NOT_EQUAL_VALUE,
-            PREVIOUS_TOTAL_PATH)));
+                DEBTORS_PATH_PREVIOUS)));
     }
 
     @Test


### PR DESCRIPTION
Correct bug where notes cannot be submitted if a previous period value and details are submitted.

Set current period to null if details is the only field that has been submitted, to avoid cross validation failing.

SFA-1354