### PR TITLE
Update SDK version to latest version to allow deserialization of transaction payment status

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <jackson-datatype-jsr310.version>2.9.6</jackson-datatype-jsr310.version>
     <spring-test.version>5.0.8.RELEASE</spring-test.version>
     <hibernate-validator.version>6.0.13.Final</hibernate-validator.version>
-    <api-sdk-java.version>4.0.6</api-sdk-java.version>
+    <api-sdk-java.version>4.1.4</api-sdk-java.version>
     <private-api-sdk-java.version>2.0.0</private-api-sdk-java.version>
     <api-sdk-manager-java-library.version>1.0.1</api-sdk-manager-java-library.version>
     <gson.version>2.8.0</gson.version>

--- a/src/main/resources/costs/costs.yaml
+++ b/src/main/resources/costs/costs.yaml
@@ -3,7 +3,7 @@ costs:
     amount: 15
     available_payment_methods: [credit-card, account]
     class_of_payment: [data-maintenance]
-    description: CIC report cost
+    description: CIC report and accounts
     description_identifier: cic-report
     kind: cost#cost
     resource_kind: cost#cic-report


### PR DESCRIPTION
Due to the new transaction status of 'closed pending payment', company accounts api was failing to deserialize transactions which are to be paid. An SDK update corrects this problem.

Required for SFA-1453