### PR TITLE
SFA-1713 - Add class to paragraph field on cic_report

### DIFF
--- a/src/main/resources/filing/templates/small-full-accounts.html
+++ b/src/main/resources/filing/templates/small-full-accounts.html
@@ -3264,28 +3264,28 @@
       {{if $companyActivitiesAndImpact := $cicStatements.company_activities_and_impact}}
       <div>
         <span class="strong">Company activities and impact</span>
-        <p>{{$companyActivitiesAndImpact}}</p>
+        <p class="text-area-display">{{$companyActivitiesAndImpact}}</p>
       </div>
       {{end}}
 
       {{if $consultationWithStakeholders := $cicStatements.consultation_with_stakeholders}}
       <div>
         <span class="strong">Consultation with stakeholders</span>
-        <p>{{$consultationWithStakeholders}}</p>
+        <p class="text-area-display">{{$consultationWithStakeholders}}</p>
       </div>
       {{end}}
 
       {{if $directorsRemuneration := $cicStatements.directors_remuneration}}
       <div>
         <span class="strong">Directors' remuneration</span>
-        <p>{{$directorsRemuneration}}</p>
+        <p class="text-area-display">{{$directorsRemuneration}}</p>
       </div>
       {{end}}
 
       {{if $transferOfAssets := $cicStatements.transfer_of_assets}}
       <div>
         <span class="strong">Transfer of assets</span>
-        <p>{{$transferOfAssets}}</p>
+        <p class="text-area-display">{{$transferOfAssets}}</p>
       </div>
       {{end}}
 


### PR DESCRIPTION
Bug fix for SFA-1713.
The fields Company activities and impact, Consultation with stakeholders, Directors' remuneration , Transfer of assets were not being displayed correctly.
Issue being when a carriage return was entered the field did not recognise them.
By changing the class on the paragraph field this issue was fixed.

