### PR TITLE
Run validation only if balance sheet exists

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidator.java
@@ -44,11 +44,12 @@ public class FixedAssetsInvestmentsValidator extends BaseValidator {
                 fixedAssetsNote.getDetails() == null) {
             addEmptyResourceError(errors, FIXED_ASSETS_DETAILS_PATH);
         }
-
-        if ((!hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) &&
-                !hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet)) &&
-                fixedAssetsNote.getDetails() != null) {
-            addError(errors, unexpectedData, FIXED_ASSETS_DETAILS_PATH);
+        if(currentPeriodBalanceSheet!=null || previousPeriodBalanceSheet!=null) {
+            if ((!hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) &&
+                    !hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet)) &&
+                    fixedAssetsNote.getDetails() != null) {
+                addError(errors, unexpectedData, FIXED_ASSETS_DETAILS_PATH);
+            }
         }
 
         if ((hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) ||

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/FixedInvestmentsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/FixedInvestmentsValidatorTest.java
@@ -75,10 +75,10 @@ public class FixedInvestmentsValidatorTest {
     }
 
     @Test
-    @DisplayName("Error thrown when note submitted with no balance sheet values")
-    void testValidationWhenNoteSubmittedNoBalanceSheetValues() throws DataException,
+    @DisplayName("Error thrown when note submitted with no fixed assets values in the balance sheet")
+    void testValidationWhenNoteSubmittedNoFixedAssetsInBalanceSheetValues() throws DataException,
             ServiceException {
-
+        mockValidBalanceSheetCurrentPeriodWithoutFixedAssetsInvestments();
         fixedAssetsInvestments.setDetails("test");
 
         ReflectionTestUtils.setField(validator, UNEXPECTED_DATA_NAME,
@@ -92,6 +92,17 @@ public class FixedInvestmentsValidatorTest {
 
     }
 
+    @Test
+    @DisplayName("Valid note submitted when no balance sheet")
+    void testValidationWhenNoteSubmittedNoBalanceSheetValues() throws DataException,
+            ServiceException {
+
+        fixedAssetsInvestments.setDetails("test");
+        errors = validator.validateFixedAssetsInvestments(mockRequest, fixedAssetsInvestments, "");
+        assertFalse(errors.hasErrors());
+
+    }
+    
     @Test
     @DisplayName("Error thrown when empty note submitted when balance sheet values")
     void testValidationEmptyNoteWhenBalanceSheetValues() throws DataException, ServiceException {
@@ -152,8 +163,29 @@ public class FixedInvestmentsValidatorTest {
         return currentPeriodResponseObject;
     }
 
+    private ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> generateValidCurrentPeriodResponseObjectWithoutFixedAssets() {
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject =
+                new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod>(
+                        ResponseStatus.FOUND);
+
+        uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriodTest =
+                new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
+
+        BalanceSheet balanceSheet = new BalanceSheet();
+
+        currentPeriodTest.setBalanceSheet(balanceSheet);
+
+        currentPeriodResponseObject.setData(currentPeriodTest);
+        return currentPeriodResponseObject;
+    }
+
     private void mockValidBalanceSheetCurrentPeriod() throws DataException {
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).find(
+                "", mockRequest);
+    }
+
+    private void mockValidBalanceSheetCurrentPeriodWithoutFixedAssetsInvestments() throws DataException {
+        doReturn(generateValidCurrentPeriodResponseObjectWithoutFixedAssets()).when(mockCurrentPeriodService).find(
                 "", mockRequest);
     }
 }


### PR DESCRIPTION
- Run the validation only if balance sheet exits.
- Add test for both scenarios.
 