### PR TITLE
Update current assets investments

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentAssetsInvestmentsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CurrentAssetsInvestmentsValidator.java
@@ -45,11 +45,12 @@ public class CurrentAssetsInvestmentsValidator extends BaseValidator {
             currentAssetsInvestments.getDetails() == null) {
             addEmptyResourceError(errors, CURRENT_ASSETS_DETAILS_PATH);
         }
-
-        if ((!hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) &&
-            !hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet)) &&
-            currentAssetsInvestments.getDetails() != null) {
-            addError(errors, unexpectedData, CURRENT_ASSETS_DETAILS_PATH);
+        if(currentPeriodBalanceSheet!=null || previousPeriodBalanceSheet!=null) {
+            if ((!hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) &&
+                    !hasPreviousBalanceSheetInvestmentsValue(previousPeriodBalanceSheet)) &&
+                    currentAssetsInvestments.getDetails() != null) {
+                addError(errors, unexpectedData, CURRENT_ASSETS_DETAILS_PATH);
+            }
         }
 
         if ((hasCurrentBalanceSheetInvestmentsValue(currentPeriodBalanceSheet) ||

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentInvestmentsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentInvestmentsValidatorTest.java
@@ -77,10 +77,10 @@ public class CurrentInvestmentsValidatorTest {
     }
 
     @Test
-    @DisplayName("Error thrown when note submitted with no balance sheet values")
-    void testValidationWhenNoteSubmittedNoBalanceSheetValues() throws DataException,
+    @DisplayName("Error thrown when note submitted with no current assets values in the balance sheet")
+    void testValidationWhenNoteSubmittedNoCurrentAssetsInBalanceSheetValues() throws DataException,
         ServiceException {
-
+        mockValidBalanceSheetCurrentPeriodWithoutCurrentAssetsInvestments();
         currentAssetsInvestments.setDetails("test");
 
         ReflectionTestUtils.setField(validator, UNEXPECTED_DATA_NAME,
@@ -91,6 +91,17 @@ public class CurrentInvestmentsValidatorTest {
         assertTrue(errors.hasErrors());
         assertTrue(errors.containsError(createError(UNEXPECTED_DATA_VALUE,
             CURRENT_ASSETS_DETAILS_PATH)));
+
+    }
+
+    @Test
+    @DisplayName("Valid note submitted when no balance sheet")
+    void testValidationWhenNoteSubmittedNoBalanceSheetValues() throws DataException,
+            ServiceException {
+
+        currentAssetsInvestments.setDetails("test");
+        errors = validator.validateCurrentAssetsInvestments(mockRequest, currentAssetsInvestments, "");
+        assertFalse(errors.hasErrors());
 
     }
 
@@ -154,8 +165,29 @@ public class CurrentInvestmentsValidatorTest {
         return currentPeriodResponseObject;
     }
 
+    private ResponseObject<CurrentPeriod> generateValidCurrentPeriodResponseObjectWithoutCurrentAssets() {
+        ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod> currentPeriodResponseObject =
+                new ResponseObject<uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod>(
+                        ResponseStatus.FOUND);
+
+        uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod currentPeriodTest =
+                new uk.gov.companieshouse.api.accounts.model.rest.CurrentPeriod();
+
+        BalanceSheet balanceSheet = new BalanceSheet();
+
+        currentPeriodTest.setBalanceSheet(balanceSheet);
+
+        currentPeriodResponseObject.setData(currentPeriodTest);
+        return currentPeriodResponseObject;
+    }
+
     private void mockValidBalanceSheetCurrentPeriod() throws DataException {
         doReturn(generateValidCurrentPeriodResponseObject()).when(mockCurrentPeriodService).find(
             "", mockRequest);
+    }
+
+    private void mockValidBalanceSheetCurrentPeriodWithoutCurrentAssetsInvestments() throws DataException {
+        doReturn(generateValidCurrentPeriodResponseObjectWithoutCurrentAssets()).when(mockCurrentPeriodService).find(
+                "", mockRequest);
     }
 }


### PR DESCRIPTION
- Update current assets investments to check balance sheet value on the note only if balance sheet exists.
- Update tests as per the code changes.

Similar changes added for fixed assets investments.
https://github.com/companieshouse/company-accounts.api.ch.gov.uk/pull/323