### PR TITLE
Fix period links

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodService.java
@@ -67,12 +67,10 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod>
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);
         }
 
-        String selfLink = createSelfLink(transaction, companyAccountId);
-        initLinks(previousPeriod, selfLink);
-        previousPeriod.setEtag(GenerateEtagUtil.generateEtag());
-        previousPeriod.setKind(Kind.PREVIOUS_PERIOD.getValue());
-        PreviousPeriodEntity previousPeriodEntity = previousPeriodTransformer
-            .transform(previousPeriod);
+        Map<String, String> links = createLinks(transaction, companyAccountId);
+
+        populateMetadata(previousPeriod, links);
+        PreviousPeriodEntity previousPeriodEntity = previousPeriodTransformer.transform(previousPeriod);
 
         previousPeriodEntity.setId(generateID(companyAccountId));
 
@@ -85,7 +83,8 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod>
         }
 
         smallFullService
-            .addLink(companyAccountId, SmallFullLinkType.PREVIOUS_PERIOD, selfLink, request);
+            .addLink(companyAccountId, SmallFullLinkType.PREVIOUS_PERIOD,
+                    previousPeriod.getLinks().get(BasicLinkType.SELF.getLink()), request);
 
         return new ResponseObject<>(ResponseStatus.CREATED, previousPeriod);
     }
@@ -158,11 +157,17 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod>
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);
         }
 
-        populateMetadata(rest, transaction, companyAccountId);
-        PreviousPeriodEntity previousPeriodEntity = previousPeriodTransformer.transform(rest);
-        previousPeriodEntity.setId(generateID(companyAccountId));
-
         try {
+            PreviousPeriodEntity originalEntity =
+                    previousPeriodRepository.findById(generateID(companyAccountId))
+                            .orElseThrow(() -> new DataException("No previous period found to update")); // We should never get here
+
+            Map<String, String> links = originalEntity.getData().getLinks();
+            populateMetadata(rest, links);
+
+            PreviousPeriodEntity previousPeriodEntity = previousPeriodTransformer.transform(rest);
+            previousPeriodEntity.setId(generateID(companyAccountId));
+
             previousPeriodRepository.save(previousPeriodEntity);
         } catch (MongoException e) {
             throw new DataException(e);
@@ -175,29 +180,24 @@ public class PreviousPeriodService implements ResourceService<PreviousPeriod>
         return keyIdGenerator.generate(value + "-" + ResourceName.PREVIOUS_PERIOD.getName());
     }
 
-    public String createSelfLink(Transaction transaction, String companyAccountId) {
-        return transaction.getLinks().getSelf() + "/"
-            + ResourceName.COMPANY_ACCOUNT.getName() + "/"
-            + companyAccountId + "/" + ResourceName.SMALL_FULL.getName() + "/"
-            + ResourceName.PREVIOUS_PERIOD.getName();
-    }
+    private void populateMetadata(PreviousPeriod previousPeriod, Map<String, String> links) {
 
-    private void populateMetadata(PreviousPeriod previousPeriod, Transaction transaction,
-        String companyAccountId) {
-
-        if (previousPeriod.getLinks() == null) {
-            Map<String, String> map = new HashMap<>();
-            map.put(BasicLinkType.SELF.getLink(), createSelfLink(transaction, companyAccountId));
-
-            previousPeriod.setLinks(map);
-        }
+        previousPeriod.setLinks(links);
         previousPeriod.setEtag(GenerateEtagUtil.generateEtag());
         previousPeriod.setKind(Kind.PREVIOUS_PERIOD.getValue());
     }
 
-    private void initLinks(PreviousPeriod previousPeriod, String link) {
-        Map<String, String> map = new HashMap<>();
-        map.put(BasicLinkType.SELF.getLink(), link);
-        previousPeriod.setLinks(map);
+    private Map<String, String> createLinks(Transaction transaction, String companyAccountsId) {
+
+        Map<String, String> links = new HashMap<>();
+        links.put(BasicLinkType.SELF.getLink(), createSelfLink(transaction, companyAccountsId));
+        return links;
+    }
+
+    public String createSelfLink(Transaction transaction, String companyAccountId) {
+        return transaction.getLinks().getSelf() + "/"
+                + ResourceName.COMPANY_ACCOUNT.getName() + "/"
+                + companyAccountId + "/" + ResourceName.SMALL_FULL.getName() + "/"
+                + ResourceName.PREVIOUS_PERIOD.getName();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceTest.java
@@ -47,7 +47,7 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class CurrentPeriodServiceTest {
-
+/*
     @Mock
     private HttpServletRequest request;
 
@@ -290,4 +290,5 @@ public class CurrentPeriodServiceTest {
 
         assertThrows(DataException.class, () -> currentPeriodService.update(currentPeriod, transaction, COMPANY_ACCOUNTS_ID, request));
     }
+    */
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.api.accounts.service.impl;
 
 import com.mongodb.MongoException;
+import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,7 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class CurrentPeriodServiceTest {
-/*
+
     @Mock
     private HttpServletRequest request;
 
@@ -112,10 +113,11 @@ public class CurrentPeriodServiceTest {
     @DisplayName("Tests the successful creation of a currentPeriod resource")
     void canCreateCurrentPeriod() throws DataException {
 
-        when(currentPeriod.getLinks()).thenReturn(links);
-
         when(currentPeriodValidator.validateCurrentPeriod(currentPeriod, transaction)).thenReturn(errors);
         when(currentPeriodTransformer.transform(currentPeriod)).thenReturn(currentPeriodEntity);
+
+        when(transaction.getLinks()).thenReturn(transactionLinks);
+        when(transactionLinks.getSelf()).thenReturn(SELF_LINK);
 
         ResponseObject<CurrentPeriod> result = currentPeriodService
             .create(currentPeriod, transaction, COMPANY_ACCOUNTS_ID, request);
@@ -126,8 +128,6 @@ public class CurrentPeriodServiceTest {
     @Test
     @DisplayName("Tests the duplicate key when creating a current period resource")
     void createSmallfullDuplicateKey() throws DataException {
-
-        when(currentPeriod.getLinks()).thenReturn(null);
 
         when(currentPeriodValidator.validateCurrentPeriod(currentPeriod, transaction)).thenReturn(errors);
         doReturn(currentPeriodEntity).when(currentPeriodTransformer).transform(any(CurrentPeriod.class));
@@ -145,8 +145,6 @@ public class CurrentPeriodServiceTest {
     @Test
     @DisplayName("Tests the mongo exception when creating a current period")
     void createSmallfullMongoExceptionFailure() throws DataException {
-
-        when(currentPeriod.getLinks()).thenReturn(null);
 
         when(currentPeriodValidator.validateCurrentPeriod(currentPeriod, transaction)).thenReturn(errors);
         doReturn(currentPeriodEntity).when(currentPeriodTransformer).transform(any(CurrentPeriod.class));
@@ -280,15 +278,15 @@ public class CurrentPeriodServiceTest {
     @DisplayName("PUT - Failure - Previous Period - Mongo Exception")
     void canUpdatePreviousPeriodFailureMongoException() throws DataException {
 
-        when(currentPeriod.getLinks()).thenReturn(null);
+        when(currentPeriodRepository.findById(RESOURCE_ID)).thenReturn(Optional.of(currentPeriodEntity));
+        when(currentPeriodEntity.getData()).thenReturn(currentPeriodDataEntity);
+        when(currentPeriodDataEntity.getLinks()).thenReturn(new HashMap<>());
+
         when(currentPeriodTransformer.transform(currentPeriod)).thenReturn(currentPeriodEntity);
         when(currentPeriodValidator.validateCurrentPeriod(currentPeriod, transaction)).thenReturn(errors);
         when(currentPeriodRepository.save(any())).thenThrow(new MongoException("ERROR"));
 
-        when(transaction.getLinks()).thenReturn(transactionLinks);
-        when(transactionLinks.getSelf()).thenReturn(SELF_LINK);
-
         assertThrows(DataException.class, () -> currentPeriodService.update(currentPeriod, transaction, COMPANY_ACCOUNTS_ID, request));
     }
-    */
+
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodServiceTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PreviousPeriodServiceTest {
-
+/*
     @Mock
     private HttpServletRequest request;
 
@@ -254,5 +254,5 @@ public class PreviousPeriodServiceTest {
                 previousPeriodService.addLink(
                         COMPANY_ACCOUNTS_ID, PreviousPeriodLinkType.PROFIT_AND_LOSS, PREVIOUS_PERIOD_PROFIT_AND_LOSS, request));
     }
-
+*/
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.api.accounts.service.impl;
 
 import com.mongodb.MongoException;
+import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PreviousPeriodServiceTest {
-/*
+
     @Mock
     private HttpServletRequest request;
 
@@ -189,7 +190,9 @@ public class PreviousPeriodServiceTest {
     @DisplayName("PUT - Success - Previous Period")
     void canUpdatePreviousPeriod() throws DataException {
 
-        when(previousPeriod.getLinks()).thenReturn(links);
+        when(previousPeriodRepository.findById(RESOURCE_ID)).thenReturn(Optional.of(previousPeriodEntity));
+        when(previousPeriodEntity.getData()).thenReturn(previousPeriodDataEntity);
+        when(previousPeriodDataEntity.getLinks()).thenReturn(new HashMap<>());
 
         when(previousPeriodTransformer.transform(previousPeriod)).thenReturn(previousPeriodEntity);
         when(previousPeriodValidator.validatePreviousPeriod(previousPeriod, transaction)).thenReturn(errors);
@@ -203,7 +206,9 @@ public class PreviousPeriodServiceTest {
     @DisplayName("PUT - Failure - Previous Period - Mongo Exception")
     void canUpdatePreviousPeriodFailureMongoException() throws DataException {
 
-        when(previousPeriod.getLinks()).thenReturn(links);
+        when(previousPeriodRepository.findById(RESOURCE_ID)).thenReturn(Optional.of(previousPeriodEntity));
+        when(previousPeriodEntity.getData()).thenReturn(previousPeriodDataEntity);
+        when(previousPeriodDataEntity.getLinks()).thenReturn(new HashMap<>());
 
         when(previousPeriodTransformer.transform(previousPeriod)).thenReturn(previousPeriodEntity);
         when(previousPeriodValidator.validatePreviousPeriod(previousPeriod, transaction)).thenReturn(errors);
@@ -254,5 +259,5 @@ public class PreviousPeriodServiceTest {
                 previousPeriodService.addLink(
                         COMPANY_ACCOUNTS_ID, PreviousPeriodLinkType.PROFIT_AND_LOSS, PREVIOUS_PERIOD_PROFIT_AND_LOSS, request));
     }
-*/
+
 }


### PR DESCRIPTION
On creation of a current / previous period resource, create a set of links containing just a `self` link.

On update, use the links from the resource saved in the database.

If a period resource contains a child link, when updated the links will be persisted.

Resolves SFA-2253