### PR TITLE
Fix error mappings for polymorphic types

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/NoteController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/NoteController.java
@@ -83,7 +83,7 @@ public class NoteController {
 
         if (bindingResult.hasErrors()) {
 
-            Errors errors = errorMapper.mapBindingResultErrorsToErrorModel(bindingResult);
+            Errors errors = errorMapper.mapBindingResultErrorsToErrorModel(bindingResult, data.getClass().getSimpleName());
             return new ResponseEntity(errors, HttpStatus.BAD_REQUEST);
 
         }
@@ -124,7 +124,7 @@ public class NoteController {
 
         if (bindingResult.hasErrors()) {
 
-            Errors errors = errorMapper.mapBindingResultErrorsToErrorModel(bindingResult);
+            Errors errors = errorMapper.mapBindingResultErrorsToErrorModel(bindingResult, data.getClass().getSimpleName());
             return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
 
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/ErrorMapper.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/ErrorMapper.java
@@ -34,49 +34,69 @@ public class ErrorMapper {
 
             if (object instanceof FieldError) {
                 FieldError fieldError = (FieldError) object;
-
-                String field = fieldError.getField();
-                String errorMessage = fieldError.getDefaultMessage();
-
-                //Convert returned location to a json path
-                String period = fieldError.getObjectName() + ".";
-                String location =
-                    "$." + ((period + field).replaceAll("(.)([A-Z])", "$1_$2")).toLowerCase();
-
-                if ("value.outside.range".equals(errorMessage) || "invalid.input.length"
-                    .equals(errorMessage)) {
-
-                    Object[] argument = fieldError.getArguments();
-
-                    Error error = new Error(
-                        environment.resolvePlaceholders("${" + errorMessage + "}"),
-                        location,
-                        LocationType.JSON_PATH.getValue(), ErrorType.VALIDATION.getType());
-                    error.addErrorValue("lower", argument[2].toString());
-                    error.addErrorValue("upper", argument[1].toString());
-                    errors.addError(error);
-
-                } else if ("max.length.exceeded".equals(errorMessage)) {
-
-                    Object[] argument = fieldError.getArguments();
-
-                    Error error = new Error(
-                        environment.resolvePlaceholders("${" + errorMessage + "}"),
-                        location,
-                        LocationType.JSON_PATH.getValue(), ErrorType.VALIDATION.getType());
-                    error.addErrorValue("max_length", argument[1].toString());
-                    errors.addError(error);
-
-                } else {
-                    Error error = new Error(errorMessage,
-                        location, LocationType.JSON_PATH.getValue(),
-                        ErrorType.VALIDATION.getType());
-
-                    errors.addError(error);
-                }
+                addFieldError(fieldError, errors, fieldError.getObjectName());
             }
         }
 
         return errors;
+    }
+
+    /**
+     * Maps each binding result error to {@link Error} model, and adds to returned {@link Errors}
+     */
+    public Errors mapBindingResultErrorsToErrorModel(BindingResult bindingResult, String beanType) {
+
+        Errors errors = new Errors();
+
+        for (Object object : bindingResult.getAllErrors()) {
+
+            if (object instanceof FieldError) {
+                FieldError fieldError = (FieldError) object;
+                addFieldError(fieldError, errors, beanType);
+            }
+        }
+
+        return errors;
+    }
+
+    private void addFieldError(FieldError fieldError, Errors errors, String objectName) {
+
+        String field = fieldError.getField();
+        String errorMessage = fieldError.getDefaultMessage();
+
+        String location =
+                "$." + ((objectName + "." + field).replaceAll("(.)([A-Z])", "$1_$2")).toLowerCase();
+
+        if ("value.outside.range".equals(errorMessage) || "invalid.input.length"
+                .equals(errorMessage)) {
+
+            Object[] argument = fieldError.getArguments();
+
+            Error error = new Error(
+                    environment.resolvePlaceholders("${" + errorMessage + "}"),
+                    location,
+                    LocationType.JSON_PATH.getValue(), ErrorType.VALIDATION.getType());
+            error.addErrorValue("lower", argument[2].toString());
+            error.addErrorValue("upper", argument[1].toString());
+            errors.addError(error);
+
+        } else if ("max.length.exceeded".equals(errorMessage)) {
+
+            Object[] argument = fieldError.getArguments();
+
+            Error error = new Error(
+                    environment.resolvePlaceholders("${" + errorMessage + "}"),
+                    location,
+                    LocationType.JSON_PATH.getValue(), ErrorType.VALIDATION.getType());
+            error.addErrorValue("max_length", argument[1].toString());
+            errors.addError(error);
+
+        } else {
+            Error error = new Error(errorMessage,
+                    location, LocationType.JSON_PATH.getValue(),
+                    ErrorType.VALIDATION.getType());
+
+            errors.addError(error);
+        }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/NoteControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/NoteControllerTest.java
@@ -35,6 +35,8 @@ import javax.servlet.http.HttpServletRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -137,7 +139,7 @@ public class NoteControllerTest {
     void createNoteResourceErrors() {
 
         when(bindingResult.hasErrors()).thenReturn(true);
-        when(errorMapper.mapBindingResultErrorsToErrorModel(bindingResult)).thenReturn(new Errors());
+        when(errorMapper.mapBindingResultErrorsToErrorModel(eq(bindingResult), anyString())).thenReturn(new Errors());
 
         ResponseEntity responseEntity =
                 noteController.create(note, bindingResult, COMPANY_ACCOUNTS_ID, accountType, noteType, request);
@@ -170,7 +172,7 @@ public class NoteControllerTest {
         when(parentResourceFactory.getParentResource(accountType)).thenReturn(parentResource);
         when(parentResource.childExists(request, accountingNoteTypeWithExplicitValidation.getLinkType())).thenReturn(true);
         when(bindingResult.hasErrors()).thenReturn(true);
-        when(errorMapper.mapBindingResultErrorsToErrorModel(bindingResult)).thenReturn(new Errors());
+        when(errorMapper.mapBindingResultErrorsToErrorModel(eq(bindingResult), anyString())).thenReturn(new Errors());
         when(parentResourceFactory.getParentResource(accountType)).thenReturn(parentResource);
 
         ResponseEntity responseEntity =

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/ErrorMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/ErrorMapperTest.java
@@ -28,16 +28,16 @@ import java.util.List;
 public class ErrorMapperTest {
 
     @InjectMocks
-    ErrorMapper errorMapper;
+    private ErrorMapper errorMapper;
 
     @Mock
-    Environment environment;
+    private Environment environment;
 
     @Mock
     private BindingResult mockBindingResult;
 
     @Test
-    @DisplayName("Test Mapping Error to Error Model correctly ")
+    @DisplayName("Test Mapping Error to Error Model correctly")
     void testMapErrorToErrorModel() {
         when(mockBindingResult.getAllErrors()).thenReturn(getAllErrors());
         when(environment.resolvePlaceholders(any())).thenReturn("error_string");
@@ -49,13 +49,28 @@ public class ErrorMapperTest {
         assertTrue(errors.containsError(createMaxError("error_string", "$.object3.field3","0")));
         assertTrue(errors.containsError(createError("incorrect.total", "$.object4.field4")));
     }
+
+    @Test
+    @DisplayName("Test Mapping Error to Error Model with object name correctly")
+    void testMapErrorToErrorModelWithObjectName() {
+        when(mockBindingResult.getAllErrors()).thenReturn(getAllErrors());
+        when(environment.resolvePlaceholders(any())).thenReturn("error_string");
+        Errors errors = errorMapper.mapBindingResultErrorsToErrorModel(mockBindingResult, "objectInError");
+        assertTrue(errors.hasErrors());
+        assertEquals(4, errors.getErrorCount());
+        assertTrue(errors.containsError(createRangeError("error_string", "$.object_in_error.field1","0","9999")));
+        assertTrue(errors.containsError(createRangeError("error_string", "$.object_in_error.field2","0","9999")));
+        assertTrue(errors.containsError(createMaxError("error_string", "$.object_in_error.field3","0")));
+        assertTrue(errors.containsError(createError("incorrect.total", "$.object_in_error.field4")));
+    }
+
     private List<ObjectError> getAllErrors(){
         Object[] argument = {0,0,9999};
         FieldError fieldError1= new FieldError("object1","field1",null,true,null,argument,"value.outside.range");
         FieldError fieldError2= new FieldError("object2","field2",null,true,null,argument,"invalid.input.length");
         FieldError fieldError3= new FieldError("object3","field3",null,true,null,argument,"max.length.exceeded");
         FieldError fieldError4= new FieldError("object4","field4","incorrect.total");
-        List errorList = new ArrayList();
+        List<ObjectError> errorList = new ArrayList<>();
         errorList.add(fieldError1);
         errorList.add(fieldError2);
         errorList.add(fieldError3);
@@ -63,14 +78,14 @@ public class ErrorMapperTest {
         return errorList;
     }
 
-    private Error createRangeError(String error, String path,String upper, String lower) {
+    private Error createRangeError(String error, String path, String upper, String lower) {
         Error returnError = new  Error(error, path, LocationType.JSON_PATH.getValue(),
                 ErrorType.VALIDATION.getType());
         returnError.addErrorValue("upper",upper);
         returnError.addErrorValue("lower",lower);
         return returnError;
     }
-    private Error createMaxError(String error, String path,String maxLength) {
+    private Error createMaxError(String error, String path, String maxLength) {
         Error returnError = new  Error(error, path, LocationType.JSON_PATH.getValue(),
                 ErrorType.VALIDATION.getType());
         returnError.addErrorValue("max_length",maxLength);


### PR DESCRIPTION
Fix error mappings for polymorphic types by allowing an object type to be passed into the error mapper with which to set location

Resolves bug found in SFA-2288