### PR TITLE
Add authentication to create company accounts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <company-accounts-library.version>1.1.0-rc1</company-accounts-library.version>
     <private-api-sdk-java.version>2.0.0</private-api-sdk-java.version>
     <api-sdk-manager-java-library.version>1.0.1</api-sdk-manager-java-library.version>
+    <api-security-java.version>0.2.9</api-security-java.version>
 
     <!-- Maven and Surefire plugins -->
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
@@ -91,6 +92,12 @@
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>company-accounts-library</artifactId>
       <version>${company-accounts-library.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>uk.gov.companieshouse</groupId>
+      <artifactId>api-security-java</artifactId>
+      <version>${api-security-java.version}</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/src/main/java/uk/gov/companieshouse/api/accounts/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/ApplicationConfiguration.java
@@ -2,14 +2,17 @@ package uk.gov.companieshouse.api.accounts;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+
 import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.annotation.RequestScope;
+
 import uk.gov.companieshouse.accountsdates.AccountsDatesHelper;
 import uk.gov.companieshouse.accountsdates.impl.AccountsDatesHelperImpl;
+import uk.gov.companieshouse.api.interceptor.TokenPermissionsInterceptor;
 import uk.gov.companieshouse.charset.validation.CharSetValidation;
 import uk.gov.companieshouse.charset.validation.impl.CharSetValidationImpl;
 import uk.gov.companieshouse.environment.EnvironmentReader;
@@ -46,5 +49,10 @@ public class ApplicationConfiguration {
     @Bean
     public AccountsDatesHelper getAccountsDatesHelper() {
         return new AccountsDatesHelperImpl();
+    }
+
+    @Bean
+    public TokenPermissionsInterceptor tokenPermissionsInterceptor() {
+        return new TokenPermissionsInterceptor();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,60 @@
+package uk.gov.companieshouse.api.accounts.interceptor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
+import uk.gov.companieshouse.api.util.security.AuthorisationUtil;
+import uk.gov.companieshouse.api.util.security.Permission.Key;
+import uk.gov.companieshouse.api.util.security.Permission.Value;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Component
+public class AuthenticationInterceptor extends HandlerInterceptorAdapter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
+
+    /**
+     * Pre handle method to authorize the request before it reaches the controller.
+     * Retrieves the TokenPermissions stored in the request (which must have been
+     * previously added by the TokenPermissionsInterceptor) and checks the relevant
+     * permissions
+     */
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+
+        // TokenPermissions should have been set up in the request by TokenPermissionsInterceptor
+        final TokenPermissions tokenPermissions = getTokenPermissions(request)
+                .orElseThrow(() -> new IllegalStateException("TokenPermissions object not present in request"));
+
+        boolean hasCompanyAccountsUpdatePermission = tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.UPDATE);
+
+        final Map<String, Object> debugMap = new HashMap<>();
+        debugMap.put("request_method", request.getMethod());
+        debugMap.put("has_company_accounts_update_permission", hasCompanyAccountsUpdatePermission);
+
+        if (hasCompanyAccountsUpdatePermission) {
+            LOGGER.debugRequest(request, "AuthInterceptor authorised with company_accounts=update permission",
+                    debugMap);
+            return true;
+        }
+
+        LOGGER.debugRequest(request, "AuthInterceptor unauthorised", debugMap);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return false;
+    }
+
+    protected Optional<TokenPermissions> getTokenPermissions(HttpServletRequest request) {
+        return AuthorisationUtil.getTokenPermissions(request);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplicationTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplicationTest.java
@@ -1,19 +1,23 @@
 package uk.gov.companieshouse.api.accounts;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+
+import uk.gov.companieshouse.api.accounts.interceptor.AuthenticationInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.CicReportInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.ClosedTransactionInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.CompanyAccountInterceptor;
@@ -24,10 +28,7 @@ import uk.gov.companieshouse.api.accounts.interceptor.OpenTransactionInterceptor
 import uk.gov.companieshouse.api.accounts.interceptor.PreviousPeriodInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.SmallFullInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.TransactionInterceptor;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import uk.gov.companieshouse.api.interceptor.TokenPermissionsInterceptor;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -67,6 +68,12 @@ public class CompanyAccountsApplicationTest {
     private LoggingInterceptor loggingInterceptor;
 
     @Mock
+    private TokenPermissionsInterceptor tokenPermissiosInterceptor;
+
+    @Mock
+    private AuthenticationInterceptor authenticationInterceptor;
+
+    @Mock
     private InterceptorRegistry interceptorRegistry;
 
     @Mock
@@ -75,24 +82,28 @@ public class CompanyAccountsApplicationTest {
     @Test
     @DisplayName("Test if interceptors are added correctly")
     void testAddInterceptors() {
-
-        when(interceptorRegistry.addInterceptor(any())).thenReturn(interceptorRegistration);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(loggingInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(tokenPermissiosInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(authenticationInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(transactionInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(openTransactionInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(closedTransactionInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(companyAccountInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(smallFullInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(currentPeriodInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(previousPeriodInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(cicReportInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(directorsReportInterceptor);
         when(interceptorRegistration.addPathPatterns(Mockito.<String>any())).thenReturn(interceptorRegistration);
         when(interceptorRegistration.excludePathPatterns(anyString())).thenReturn(interceptorRegistration);
+
         companyAccountsApplication.addInterceptors(interceptorRegistry);
-        verify(interceptorRegistry, times(1)).addInterceptor(loggingInterceptor);
-        verify(interceptorRegistry, times(1)).addInterceptor(transactionInterceptor);
-        verify(interceptorRegistry, times(1)).addInterceptor(openTransactionInterceptor);
-        verify(interceptorRegistry, times(1)).addInterceptor(closedTransactionInterceptor);
-        verify(interceptorRegistry, times(1)).addInterceptor(companyAccountInterceptor);
-        verify(interceptorRegistry, times(1)).addInterceptor(smallFullInterceptor);
-        verify(interceptorRegistry, times(1)).addInterceptor(currentPeriodInterceptor);
-        verify(interceptorRegistry, times(1)).addInterceptor(previousPeriodInterceptor);
-        verify(interceptorRegistry, times(1)).addInterceptor(cicReportInterceptor);
-        verify(interceptorRegistry, times(1)).addInterceptor(directorsReportInterceptor);
-        verify(interceptorRegistration, times(4)).excludePathPatterns(anyString());
-        verify(interceptorRegistration, times(6)).addPathPatterns(anyString(),anyString());
-        verify(interceptorRegistration, times(3)).addPathPatterns(anyString());
+
+        InOrder inOrder = Mockito.inOrder(interceptorRegistry);
+        inOrder.verify(interceptorRegistry).addInterceptor(tokenPermissiosInterceptor);
+        inOrder.verify(interceptorRegistry).addInterceptor(authenticationInterceptor);
+
+        verifyNoMoreInteractions(interceptorRegistry);
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/AuthenticationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/AuthenticationInterceptorTest.java
@@ -1,0 +1,73 @@
+package uk.gov.companieshouse.api.accounts.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.api.util.security.Permission.Key;
+import uk.gov.companieshouse.api.util.security.Permission.Value;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthenticationInterceptorTest {
+
+    @Spy
+    private AuthenticationInterceptor interceptor;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private TokenPermissions tokenPermissions;
+
+    private final Object handler = null;
+
+    @Test
+    @DisplayName("Test preHandle when request is authorized")
+    void preHandleAuthorized() throws Exception {
+        setupTokenPermissions();
+        final boolean hasCompanyAccountsUpdatePermission = true;
+        when(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.UPDATE))
+                .thenReturn(hasCompanyAccountsUpdatePermission);
+
+        assertTrue(interceptor.preHandle(request, response, handler));
+    }
+
+    @Test
+    @DisplayName("Test preHandle when request is unauthorized")
+    void preHandleUnauthorized() throws Exception {
+        setupTokenPermissions();
+        final boolean hasCompanyAccountsUpdatePermission = false;
+        when(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.UPDATE))
+                .thenReturn(hasCompanyAccountsUpdatePermission);
+
+        assertFalse(interceptor.preHandle(request, response, handler));
+    }
+
+    @Test
+    @DisplayName("Test preHandle when TokenPermissions is not present in request")
+    void preHandleMissingTokenPermissions() throws Exception {
+        assertThrows(IllegalStateException.class, () -> interceptor.preHandle(request, response, handler));
+    }
+
+    private void setupTokenPermissions() {
+        doReturn(Optional.of(tokenPermissions)).when(interceptor).getTokenPermissions(request);
+    }
+}


### PR DESCRIPTION
Create a new interceptor to check the `company_accounts.update` permission. This requires the [TokenPermissionsInterceptor](https://github.com/companieshouse/api-security-java/blob/master/src/main/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptor.java) to run beforehand and put the relevant object in the session.

Apply both interceptors to the create company accounts endpoint `/transactions/{transactionId}/company-accounts`

Resolves FA-530