### PR TITLE
Debtors additional information validation rework

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -99,21 +99,13 @@ public class DebtorsValidator extends BaseValidator implements NoteValidator<Deb
             BalanceSheet currentPeriodBalanceSheet, Errors errors) {
 
         boolean hasCurrentPeriodBalanceSheet = currentPeriodBalanceSheet != null;
-        boolean hasCurrentPeriodBalanceSheetNoteValue =
-                ! isCurrentPeriodBalanceSheetDataNull(currentPeriodBalanceSheet);
-        boolean hasCurrentPeriodNoteData = currentPeriodNote != null;
+        boolean hasCurrentPeriodNote = currentPeriodNote != null;
 
-        if (! hasCurrentPeriodBalanceSheetNoteValue && hasCurrentPeriodNoteData) {
-
-            if (validateNoUnexpectedDataPresent(hasCurrentPeriodBalanceSheet,
-                    DEBTORS_PATH_CURRENT, errors)) {
-                validateCurrentPeriodFields(currentPeriodNote, errors);
-            }
-
-        } else if (validateCurrentPeriodExists(hasCurrentPeriodBalanceSheetNoteValue,
-                hasCurrentPeriodNoteData, errors) && hasCurrentPeriodNoteData) {
+        if (hasCurrentPeriodNote && hasCurrentPeriodBalanceSheet) {
             validateCurrentPeriodFields(currentPeriodNote, errors);
             crossValidateCurrentPeriodFields(currentPeriodNote, currentPeriodBalanceSheet, errors);
+        } else {
+            validateCurrentPeriodExists(hasCurrentPeriodBalanceSheet, hasCurrentPeriodNote, errors);
         }
     }
 
@@ -160,9 +152,9 @@ public class DebtorsValidator extends BaseValidator implements NoteValidator<Deb
     }
 
     private void validateCurrentPeriodFields(CurrentPeriod debtorsCurrentPeriod, Errors errors) {
-        if (debtorsCurrentPeriod.getTotal() == null) {
+        if (debtorsCurrentPeriod.getTotal() == null && debtorsCurrentPeriod.getDetails() == null) {
             addError(errors, mandatoryElementMissing, CURRENT_TOTAL_PATH);
-        } else {
+        } else if (debtorsCurrentPeriod.getTotal() != null){
             validateCurrentPeriodTotalCalculation(debtorsCurrentPeriod, errors);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidator.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.accounts.enumeration.AccountingNoteType;
@@ -152,7 +153,7 @@ public class DebtorsValidator extends BaseValidator implements NoteValidator<Deb
     }
 
     private void validateCurrentPeriodFields(CurrentPeriod debtorsCurrentPeriod, Errors errors) {
-        if (debtorsCurrentPeriod.getTotal() == null && debtorsCurrentPeriod.getDetails() == null) {
+        if (debtorsCurrentPeriod.getTotal() == null && StringUtils.isBlank(debtorsCurrentPeriod.getDetails())) {
             addError(errors, mandatoryElementMissing, CURRENT_TOTAL_PATH);
         } else if (debtorsCurrentPeriod.getTotal() != null){
             validateCurrentPeriodTotalCalculation(debtorsCurrentPeriod, errors);


### PR DESCRIPTION
-Changed validation to allow users to progress if they only provide "additional information" details in the current period And leave the current period blank on the balance sheet.