### PR TITLE
CIC approval date validation update to cover accounting reference date functionality

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/enumeration/AccountType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/enumeration/AccountType.java
@@ -1,17 +1,27 @@
 package uk.gov.companieshouse.api.accounts.enumeration;
 
+import uk.gov.companieshouse.api.accounts.links.CompanyAccountLinkType;
+
 public enum AccountType {
 
-    SMALL_FULL("small-full"),
-    MICRO("micro");
+    SMALL_FULL("small-full", CompanyAccountLinkType.SMALL_FULL),
+    MICRO("micro", CompanyAccountLinkType.MICRO);
 
-    AccountType(String type) {
+    AccountType(String type, CompanyAccountLinkType companyAccountLinkType) {
+
         this.type = type;
+        this.companyAccountLinkType = companyAccountLinkType;
     }
 
     private String type;
 
+    private CompanyAccountLinkType companyAccountLinkType;
+
     public String getType() {
         return type;
+    }
+
+    public CompanyAccountLinkType getCompanyAccountLinkType() {
+        return companyAccountLinkType;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/links/CompanyAccountLinkType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/links/CompanyAccountLinkType.java
@@ -4,6 +4,7 @@ public enum CompanyAccountLinkType implements LinkType {
 
     SELF("self"),
     SMALL_FULL("small_full_accounts"),
+    MICRO("micro_accounts"),
     TRANSACTION("transaction"),
     CIC_REPORT("cic_report");
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/AccountTypeFactory.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/AccountTypeFactory.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.api.accounts.utility;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.accounts.enumeration.AccountType;
+
+@Component
+public class AccountTypeFactory {
+
+    private Map<String, AccountType> accountTypeMap;
+
+    AccountTypeFactory() {
+
+        this.accountTypeMap = new HashMap<>();
+
+        Arrays.stream(AccountType.values()).forEach(accountType ->
+                this.accountTypeMap.put(accountType.getCompanyAccountLinkType().getLink(), accountType)
+        );
+    }
+
+    public AccountType getAccountTypeForCompanyAccountLinkType(String companyAccountLinkType) {
+
+        return accountTypeMap.get(companyAccountLinkType);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/AccountTypeFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/AccountTypeFactoryTest.java
@@ -1,0 +1,38 @@
+package uk.gov.companieshouse.api.accounts.utility;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.accounts.enumeration.AccountType;
+import uk.gov.companieshouse.api.accounts.links.CompanyAccountLinkType;
+
+public class AccountTypeFactoryTest {
+
+    private AccountTypeFactory accountTypeFactory = new AccountTypeFactory();
+
+    private static final String NON_ACCOUNT_LINK_TYPE = "nonAccountLinkType";
+
+    @Test
+    void getAccountTypeForSmallFullLinkType() {
+
+        assertEquals(AccountType.SMALL_FULL,
+                accountTypeFactory.getAccountTypeForCompanyAccountLinkType(
+                        CompanyAccountLinkType.SMALL_FULL.getLink()));
+    }
+
+    @Test
+    void getAccountTypeForMicroLinkType() {
+
+        assertEquals(AccountType.MICRO,
+                accountTypeFactory.getAccountTypeForCompanyAccountLinkType(
+                        CompanyAccountLinkType.MICRO.getLink()));
+    }
+
+    @Test
+    void getAccountTypeForNonAccountLinkType() {
+
+        assertNull(accountTypeFactory.getAccountTypeForCompanyAccountLinkType(
+                        NON_ACCOUNT_LINK_TYPE));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CicApprovalValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CicApprovalValidatorTest.java
@@ -3,12 +3,14 @@ package uk.gov.companieshouse.api.accounts.validation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.Month;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,12 +21,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import uk.gov.companieshouse.api.accounts.AttributeName;
+import uk.gov.companieshouse.api.accounts.enumeration.AccountType;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.exception.ServiceException;
 import uk.gov.companieshouse.api.accounts.model.rest.CicApproval;
+import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.parent.ParentResource;
+import uk.gov.companieshouse.api.accounts.parent.ParentResourceFactory;
 import uk.gov.companieshouse.api.accounts.service.CompanyService;
+import uk.gov.companieshouse.api.accounts.utility.AccountTypeFactory;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
 import uk.gov.companieshouse.api.model.company.account.NextAccountsApi;
@@ -47,32 +55,52 @@ public class CicApprovalValidatorTest {
     
     @Mock
     private Transaction transaction;
+
+    @Mock
+    private CompanyAccount companyAccount;
     
     @Mock
     private CompanyService companyService;
 
+    @Mock
+    private AccountTypeFactory accountTypeFactory;
+
+    @Mock
+    private ParentResourceFactory parentResourceFactory;
+
+    @Mock
+    private ParentResource parentResource;
+
+    private static final AccountType ACCOUNT_TYPE = AccountType.SMALL_FULL;
+
+    private static final String ACCOUNT_TYPE_LINK = "accountTypeLink";
+
+    private static final String NON_ACCOUNT_TYPE_LINK = "nonAccountTypeLink";
+
     @BeforeEach
     void setup() throws ServiceException {
-        validator = new CicApprovalValidator(companyService);
+        validator = new CicApprovalValidator(companyService, accountTypeFactory, parentResourceFactory);
         validator.dateInvalid = "date.invalid";
         cicApproval = new CicApproval();
         transaction.setCompanyNumber(COMPANY_NUMBER);
-        when(httpServletRequestMock.getAttribute(anyString())).thenReturn(transaction);
+        doReturn(transaction).when(httpServletRequestMock).getAttribute(AttributeName.TRANSACTION.getValue());
+        doReturn(companyAccount).when(httpServletRequestMock).getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
         when(companyService.getCompanyProfile(transaction.getCompanyNumber())).thenReturn(createCompanyProfile());
-
     }
 
     @Test
-    @DisplayName("Validate with a valid approval date ")
-    void validateApprovalWithValidDate() throws DataException{
+    @DisplayName("Validate with a valid approval date - no associated accounts")
+    void validateApprovalWithValidDateNoAssociatedAccounts() throws DataException {
+        when(companyAccount.getLinks()).thenReturn(getCompanyAccountLinks(false));
         cicApproval.setDate(LocalDate.of(2018, Month.NOVEMBER, 2));
         errors = validator.validateCicReportApproval(cicApproval,httpServletRequestMock);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    @DisplayName("Validate with approval date before period end on date")
-    void validateApprovalDateBeforePeriodEnd() throws DataException{
+    @DisplayName("Validate with approval date before period end on date - no associated accounts")
+    void validateApprovalDateBeforePeriodEndNoAssociatedAccounts() throws DataException {
+        when(companyAccount.getLinks()).thenReturn(getCompanyAccountLinks(false));
         cicApproval.setDate(LocalDate.of(2018, Month.OCTOBER, 2));
         errors = validator.validateCicReportApproval(cicApproval,httpServletRequestMock);
         assertTrue(errors.hasErrors());
@@ -81,9 +109,50 @@ public class CicApprovalValidatorTest {
     }
 
     @Test
-    @DisplayName("Validate with approval date equal to period end on date")
-    void validateApprovalDateSameAsPeriodEnd() throws DataException{
+    @DisplayName("Validate with approval date equal to period end on date - no associated accounts")
+    void validateApprovalDateSameAsPeriodEndNoAssociatedAccounts() throws DataException {
+        when(companyAccount.getLinks()).thenReturn(getCompanyAccountLinks(false));
         cicApproval.setDate(LocalDate.of(2018, Month.NOVEMBER, 1));
+        errors = validator.validateCicReportApproval(cicApproval,httpServletRequestMock);
+        assertTrue(errors.hasErrors());
+        assertEquals(1, errors.getErrorCount());
+        assertTrue(errors.containsError(createError("date.invalid", "$.cic_approval.date")));
+    }
+
+    @Test
+    @DisplayName("Validate with a valid approval date - has associated accounts")
+    void validateApprovalWithValidDateHasAssociatedAccounts() throws DataException {
+        when(companyAccount.getLinks()).thenReturn(getCompanyAccountLinks(true));
+        doReturn(ACCOUNT_TYPE).when(accountTypeFactory).getAccountTypeForCompanyAccountLinkType(ACCOUNT_TYPE_LINK);
+        when(parentResourceFactory.getParentResource(ACCOUNT_TYPE)).thenReturn(parentResource);
+        when(parentResource.getPeriodEndOn(httpServletRequestMock)).thenReturn(LocalDate.of(2018, Month.OCTOBER, 30));
+        cicApproval.setDate(LocalDate.of(2018, Month.OCTOBER, 31));
+        errors = validator.validateCicReportApproval(cicApproval,httpServletRequestMock);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    @DisplayName("Validate with approval date before period end on date - has associated accounts")
+    void validateApprovalDateBeforePeriodEndHasAssociatedAccounts() throws DataException {
+        when(companyAccount.getLinks()).thenReturn(getCompanyAccountLinks(true));
+        doReturn(ACCOUNT_TYPE).when(accountTypeFactory).getAccountTypeForCompanyAccountLinkType(ACCOUNT_TYPE_LINK);
+        when(parentResourceFactory.getParentResource(ACCOUNT_TYPE)).thenReturn(parentResource);
+        when(parentResource.getPeriodEndOn(httpServletRequestMock)).thenReturn(LocalDate.of(2018, Month.NOVEMBER, 3));
+        cicApproval.setDate(LocalDate.of(2018, Month.NOVEMBER, 2));
+        errors = validator.validateCicReportApproval(cicApproval,httpServletRequestMock);
+        assertTrue(errors.hasErrors());
+        assertEquals(1, errors.getErrorCount());
+        assertTrue(errors.containsError(createError("date.invalid", "$.cic_approval.date")));
+    }
+
+    @Test
+    @DisplayName("Validate with approval date equal to period end on date - has associated accounts")
+    void validateApprovalDateSameAsPeriodEndHasAssociatedAccounts() throws DataException {
+        when(companyAccount.getLinks()).thenReturn(getCompanyAccountLinks(true));
+        doReturn(ACCOUNT_TYPE).when(accountTypeFactory).getAccountTypeForCompanyAccountLinkType(ACCOUNT_TYPE_LINK);
+        when(parentResourceFactory.getParentResource(ACCOUNT_TYPE)).thenReturn(parentResource);
+        when(parentResource.getPeriodEndOn(httpServletRequestMock)).thenReturn(LocalDate.of(2018, Month.NOVEMBER, 2 ));
+        cicApproval.setDate(LocalDate.of(2018, Month.NOVEMBER, 2));
         errors = validator.validateCicReportApproval(cicApproval,httpServletRequestMock);
         assertTrue(errors.hasErrors());
         assertEquals(1, errors.getErrorCount());
@@ -103,6 +172,17 @@ public class CicApprovalValidatorTest {
     private Error createError(String error, String path) {
         return new Error(error, path, LocationType.JSON_PATH.getValue(),
                 ErrorType.VALIDATION.getType());
+    }
+
+    private Map<String, String> getCompanyAccountLinks(boolean hasAssociatedAccounts) {
+
+        Map<String, String> companyAccountsLinks = new HashMap<>();
+        companyAccountsLinks.put(NON_ACCOUNT_TYPE_LINK, NON_ACCOUNT_TYPE_LINK);
+        if (hasAssociatedAccounts) {
+            companyAccountsLinks.put(ACCOUNT_TYPE_LINK, ACCOUNT_TYPE_LINK);
+        }
+
+        return companyAccountsLinks;
     }
 }
 


### PR DESCRIPTION
Compare CIC approval date against the period end date from the company profile, unless an associated account type exists against the company accounts - in which case, compare against the period end derived from the account type.

This ensures that if an associated account type exists having submitted a CIC approval, if the user has changed their accounting reference date, we compare against the updated period end.

Resolves SFA-3205