### PR TITLE
Fix bug with first pass to Statement not showing correct ARD date

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/StatementService.java
@@ -96,10 +96,10 @@ public class StatementService implements ResourceService<Statement> {
     @Override
     public ResponseObject<Statement> update(Statement rest, Transaction transaction,
         String companyAccountId, HttpServletRequest request) throws DataException {
-
-        SmallFull smallFull =
-                ((SmallFull) request.getAttribute(AttributeName.SMALLFULL.getValue()));
-
+        
+        ResponseObject<SmallFull> smallFullResponse = smallFullService.find(companyAccountId, request);
+        SmallFull smallFull = smallFullResponse.getData();
+        
         setMetadataOnRestObject(rest, transaction, companyAccountId,
             getPeriodEndOn(smallFull));
 


### PR DESCRIPTION
- Update the method update to retrieve the SmallFull details from the DB by calling the SmallFullService to get the period end date.
- Update unit tests to stub new call to SmallFullService in StatementService.update method.
- Some consolidation of mocks

BI-3184