### PR TITLE
Remove validation for some fields

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/LoanValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/LoanValidator.java
@@ -17,10 +17,6 @@ public class LoanValidator extends BaseValidator {
 
     private static final String LOANS_BREAKDOWN_PATH = LOANS_PATH + ".breakdown";
 
-    private static final String LOANS_BREAKDOWN_PATH_ADVANCES_CREDIT_MADE = LOANS_PATH + ".breakdown.advances_credits_made";
-
-    private static final String LOANS_BREAKDOWN_PATH_ADVANCES_CREDIT_REPAID = LOANS_PATH + ".breakdown.advances_credits_repaid";
-
     private static final String LOANS_BREAKDOWN_PATH_BALANCE_AT_PERIOD_START = LOANS_PATH + ".breakdown.balance_at_period_start";
 
     private static final String LOANS_BREAKDOWN_PATH_BALANCE_AT_PERIOD_END = LOANS_PATH + ".breakdown.balance_at_period_end";
@@ -44,15 +40,6 @@ public class LoanValidator extends BaseValidator {
             addError(errors, mandatoryElementMissing, LOANS_BREAKDOWN_PATH);
 		} else {
 			Boolean missingBreakdownElement = false;
-			if (loanBreakdown.getAdvancesCreditsMade() == null) {
-				missingBreakdownElement = true;
-	            addError(errors, mandatoryElementMissing, LOANS_BREAKDOWN_PATH_ADVANCES_CREDIT_MADE);
-			}
-	
-			if (loanBreakdown.getAdvancesCreditsRepaid() == null) {
-				missingBreakdownElement = true;
-	            addError(errors, mandatoryElementMissing, LOANS_BREAKDOWN_PATH_ADVANCES_CREDIT_REPAID);
-			}
 	
 			if (loanBreakdown.getBalanceAtPeriodStart() == null) {
 				missingBreakdownElement = true;
@@ -73,7 +60,18 @@ public class LoanValidator extends BaseValidator {
 	}
 	
 	private void validateLoanCalculation(LoanBreakdownResource loanBreakdown, Errors errors) {
-		if ((loanBreakdown.getBalanceAtPeriodStart() + loanBreakdown.getAdvancesCreditsMade()) - loanBreakdown.getAdvancesCreditsRepaid() != loanBreakdown.getBalanceAtPeriodEnd()) {
+		Long advancesCreditsMade = 0L;
+		Long advancesCreditsRepaid = 0L;
+		
+		if (loanBreakdown.getAdvancesCreditsMade() != null) {
+			advancesCreditsMade = loanBreakdown.getAdvancesCreditsMade();
+		}
+		
+		if (loanBreakdown.getAdvancesCreditsRepaid() != null) {
+			advancesCreditsRepaid = loanBreakdown.getAdvancesCreditsRepaid();
+		}
+		
+		if ((loanBreakdown.getBalanceAtPeriodStart() + advancesCreditsMade) - advancesCreditsRepaid != loanBreakdown.getBalanceAtPeriodEnd()) {
             addError(errors, incorrectTotal, LOANS_BREAKDOWN_PATH_BALANCE_AT_PERIOD_END);
 		}
 	}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/LoanValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/LoanValidatorTest.java
@@ -30,8 +30,6 @@ public class LoanValidatorTest {
     private static final String LOANS_PATH = "$.loans";
     private static final String LOANS_DIRECTOR_NAME_PATH = LOANS_PATH + ".director_name";
     private static final String LOANS_DESCRIPTION_PATH = LOANS_PATH + ".description";
-    private static final String LOANS_BREAKDOWN_PATH_ADVANCES_CREDIT_MADE = LOANS_PATH + ".breakdown.advances_credits_made";
-    private static final String LOANS_BREAKDOWN_PATH_ADVANCES_CREDIT_REPAID = LOANS_PATH +  ".breakdown.advances_credits_repaid";
     private static final String LOANS_BREAKDOWN_PATH_BALANCE_AT_PERIOD_START = LOANS_PATH +  ".breakdown.balance_at_period_start";
     private static final String LOANS_BREAKDOWN_PATH_BALANCE_AT_PERIOD_END = LOANS_PATH +  ".breakdown.balance_at_period_end";
 
@@ -140,44 +138,46 @@ public class LoanValidatorTest {
 
     @Test
     @DisplayName("Loan validation with missing advances_credits_made")
-    void testMissingLoanBreakdownAdvancesCreditsMade() {
+    void testSuccessfulLoanCalculationValidationWithMissingAdvancesCreditsMade() {
         ReflectionTestUtils.setField(validator, MANDATORY_ELEMENT_MISSING_NAME,
                 MANDATORY_ELEMENT_MISSING_VALUE);
 
     	loan.setDirectorName(LOAN_DIRECTOR_NAME);
     	loan.setDescription(LOAN_DESCRIPTION);
     	
-        createValidLoanBreakdown();
+        LoanBreakdownResource loanBreakdown = new LoanBreakdownResource();
+        loanBreakdown.setBalanceAtPeriodStart(2000L);
+        loanBreakdown.setAdvancesCreditsMade(null);
+        loanBreakdown.setAdvancesCreditsRepaid(1000L);
+        loanBreakdown.setBalanceAtPeriodEnd(1000L);
 
-        loan.getBreakdown().setAdvancesCreditsMade(null);
-        
+        loan.setBreakdown(loanBreakdown);
+
         errors = validator.validateLoan(loan);
 
-        assertTrue(errors.containsError(createError(MANDATORY_ELEMENT_MISSING_VALUE,
-        		LOANS_BREAKDOWN_PATH_ADVANCES_CREDIT_MADE)));
-
-        assertEquals(1, errors.getErrorCount());
+        assertFalse(errors.hasErrors());
     }
 
     @Test
     @DisplayName("Loan validation with missing advances_credits_repaid")
-    void testMissingLoanBreakdownAdvancesCreditsRepaid() {
+    void testSuccessfulLoanCalculationValidationWithMissingAdvancesCreditsRepaid() {
         ReflectionTestUtils.setField(validator, MANDATORY_ELEMENT_MISSING_NAME,
                 MANDATORY_ELEMENT_MISSING_VALUE);
 
     	loan.setDirectorName(LOAN_DIRECTOR_NAME);
     	loan.setDescription(LOAN_DESCRIPTION);
     	
-        createValidLoanBreakdown();
+        LoanBreakdownResource loanBreakdown = new LoanBreakdownResource();
+        loanBreakdown.setBalanceAtPeriodStart(2000L);
+        loanBreakdown.setAdvancesCreditsMade(1000L);
+        loanBreakdown.setAdvancesCreditsRepaid(null);
+        loanBreakdown.setBalanceAtPeriodEnd(3000L);
 
-        loan.getBreakdown().setAdvancesCreditsRepaid(null);
+        loan.setBreakdown(loanBreakdown);
         
         errors = validator.validateLoan(loan);
 
-        assertTrue(errors.containsError(createError(MANDATORY_ELEMENT_MISSING_VALUE,
-        		LOANS_BREAKDOWN_PATH_ADVANCES_CREDIT_REPAID)));
-
-        assertEquals(1, errors.getErrorCount());
+        assertFalse(errors.hasErrors());
     }
 
     @Test


### PR DESCRIPTION
Remove mandatory validation for advances credits made and advances credits repaid as these are actually optional. Update calculation if these aren't present.
Update tests to test successful calculation with advances credits made and advances credits repaid missing

BI-4040