### PR TITLE
Updated Paths to Authentication and TokenPermission Interceptors

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
@@ -95,7 +95,8 @@ public class CompanyAccountsApplication implements WebMvcConfigurer {
                     "/transactions/{transactionId}/company-accounts/**");
 
         registry.addInterceptor(authenticationInterceptor)
-            .addPathPatterns("/transactions/{transactionId}/company-accounts",
+            .addPathPatterns(
+                    "/transactions/{transactionId}/company-accounts",
                     "/transactions/{transactionId}/company-accounts/**");
 
         registry.addInterceptor(transactionInterceptor)

--- a/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
@@ -29,9 +29,6 @@ public class CompanyAccountsApplication implements WebMvcConfigurer {
 
     public static final String APPLICATION_NAME_SPACE = "company-accounts.api.ch.gov.uk";
 
-    // Path pattern for URLs requiring authorization
-    private static final String AUTH_PATH_PATTERN = "/transactions/{transactionId}/company-accounts";
-
     @Autowired
     private TransactionInterceptor transactionInterceptor;
 
@@ -93,10 +90,13 @@ public class CompanyAccountsApplication implements WebMvcConfigurer {
             .excludePathPatterns("/healthcheck");
 
         registry.addInterceptor(tokenPermissionsInterceptor)
-            .addPathPatterns(AUTH_PATH_PATTERN);
+            .addPathPatterns(
+                    "/transactions/{transactionId}/company-accounts",
+                    "/transactions/{transactionId}/company-accounts/**");
 
         registry.addInterceptor(authenticationInterceptor)
-            .addPathPatterns(AUTH_PATH_PATTERN);
+            .addPathPatterns("/transactions/{transactionId}/company-accounts",
+                    "/transactions/{transactionId}/company-accounts/**");
 
         registry.addInterceptor(transactionInterceptor)
             .addPathPatterns(


### PR DESCRIPTION
API Filing tickets FA-657, FA-671, FA-674, FA-716  - Test Eric Header Permissions
Change - Updated the paths of the Authentication and TokenPermission Interceptors to include endpoints after and including transactions/{transactionId}/company-accounts. Made the change inline to match rest of code. 