### PR TITLE
Fix sonar code smells for company accounts API

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImpl.java
@@ -6,6 +6,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpEntity;
@@ -157,7 +159,7 @@ public class TnepValidationServiceImpl implements TnepValidationService {
         return environmentReader.getMandatoryString(IXBRL_VALIDATOR_URI);
     }
 
-    private class FileMessageResource extends ByteArrayResource {
+    private static class FileMessageResource extends ByteArrayResource {
 
         /**
          * The filename to be associated with the {@link MimeMessage} in the form data.
@@ -179,6 +181,28 @@ public class TnepValidationServiceImpl implements TnepValidationService {
         @Override
         public String getFilename() {
             return filename;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof FileMessageResource)) {
+                return false;
+            }
+
+            if (!super.equals(o)) {
+                return false;
+            }
+
+            FileMessageResource that = (FileMessageResource) o;
+            return Objects.equals(filename, that.filename);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), filename);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/utility/ErrorMapper.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/utility/ErrorMapper.java
@@ -6,6 +6,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
 import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.validation.ErrorType;
@@ -30,7 +31,7 @@ public class ErrorMapper {
 
         Errors errors = new Errors();
 
-        for (Object object : bindingResult.getAllErrors()) {
+        for (ObjectError object : bindingResult.getAllErrors()) {
 
             if (object instanceof FieldError) {
                 FieldError fieldError = (FieldError) object;
@@ -48,7 +49,7 @@ public class ErrorMapper {
 
         Errors errors = new Errors();
 
-        for (Object object : bindingResult.getAllErrors()) {
+        for (ObjectError object : bindingResult.getAllErrors()) {
 
             if (object instanceof FieldError) {
                 FieldError fieldError = (FieldError) object;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DirectorServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DirectorServiceTest.java
@@ -224,8 +224,7 @@ class DirectorServiceTest {
 
         when(request.getRequestURI()).thenReturn(URI);
 
-        DirectorEntity directorEntity = null;
-        when(repository.findById(DIRECTOR_ID)).thenReturn(Optional.ofNullable(directorEntity));
+        when(repository.findById(DIRECTOR_ID)).thenReturn(Optional.empty());
 
         ResponseObject<Director> response =
                 directorService.find(COMPANY_ACCOUNTS_ID, request);


### PR DESCRIPTION
-Change for each object types (as suggested by sonar)
-Fix unit tests

-Override both equals and hashcode methods (using Intellij's built in generator) for the FileMessageResource innner class of the TnepValidationService class.
As this is a private inner class, no unit tests have been written.