### PR TITLE
Loans to directors cross validation with directors report

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/LoanServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/LoanServiceImpl.java
@@ -94,7 +94,7 @@ public class LoanServiceImpl implements MultipleResourceService<Loan> {
     @Override
     public ResponseObject<Loan> create(Loan rest, Transaction transaction, String companyAccountId, HttpServletRequest request) throws DataException {
 
-        Errors errors = loanValidator.validateLoan(rest);
+        Errors errors = loanValidator.validateLoan(rest, transaction, companyAccountId, request);
         if (errors.hasErrors()) {
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);
         }
@@ -125,7 +125,7 @@ public class LoanServiceImpl implements MultipleResourceService<Loan> {
     @Override
     public ResponseObject<Loan> update(Loan rest, Transaction transaction, String companyAccountId, HttpServletRequest request) throws DataException {
 
-        Errors errors = loanValidator.validateLoan(rest);
+        Errors errors = loanValidator.validateLoan(rest, transaction, companyAccountId, request);
         if (errors.hasErrors()) {
             return new ResponseObject<>(ResponseStatus.VALIDATION_ERROR, errors);
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/BaseValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/BaseValidator.java
@@ -34,6 +34,9 @@ public class BaseValidator {
     @Value("${mustMatch.directorOrSecretary}")
     protected String mustMatchDirectorOrSecretary;
 
+    @Value("${mustMatch.director}")
+    protected String mustMatchDirector;
+
     @Value("${invalid.value}")
     protected String invalidValue;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/DirectorValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/DirectorValidator.java
@@ -1,0 +1,50 @@
+package uk.gov.companieshouse.api.accounts.validation;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.model.rest.directorsreport.Director;
+import uk.gov.companieshouse.api.accounts.service.impl.DirectorService;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class DirectorValidator extends BaseValidator {
+
+    @Autowired
+    private DirectorService directorService;
+
+    public List<String> getValidDirectorNames(Transaction transaction,
+                                              String companyAccountId, HttpServletRequest request) throws DataException {
+
+        ResponseObject<Director> directorsReportResponseObject = directorService.findAll(transaction, companyAccountId, request);
+
+        Director[] directors = Optional.of(directorsReportResponseObject)
+                .map(ResponseObject::getDataForMultipleResources)
+                .orElse(null);
+
+        List<String> allNames = new ArrayList<>();
+
+        if (directors != null) {
+            for (Director director : directors) {
+                if (isValidDirector(director)) {
+                    allNames.add(director.getName());
+                }
+            }
+        }
+
+        return allNames;
+    }
+
+    private boolean isValidDirector(Director director) {
+
+        return director.getResignationDate() == null
+                || (director.getAppointmentDate() != null
+                && director.getAppointmentDate().isAfter(director.getResignationDate()));
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/LoanValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/LoanValidator.java
@@ -1,21 +1,42 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.loanstodirectors.Loan;
 import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.loanstodirectors.LoanBreakdownResource;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.service.impl.DirectorService;
+import uk.gov.companieshouse.api.accounts.service.impl.DirectorsReportServiceImpl;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
 
 @Component
 public class LoanValidator extends BaseValidator {
 
     private static final String LOANS_BREAKDOWN_PATH_BALANCE_AT_PERIOD_END = "$.loan.breakdown.balance_at_period_end";
+	private static final String LOANS_DIRECTOR_NAME = "$.loan.directorName";
 
-	public Errors validateLoan(Loan loan) {
+	@Autowired
+	private DirectorService directorService;
+
+	@Autowired
+	private DirectorValidator directorValidator;
+
+	@Autowired
+	private DirectorsReportServiceImpl directorsReportService;
+
+	public Errors validateLoan(Loan loan, Transaction transaction,
+							   String companyAccountId, HttpServletRequest request) throws DataException {
 
 		Errors errors = new Errors();
 
 		validateLoanCalculation(loan.getBreakdown(), errors);
+		crossValidateDirectorNameDR(loan, transaction, companyAccountId, request, errors);
 		
 		return errors;
 	}
@@ -35,6 +56,21 @@ public class LoanValidator extends BaseValidator {
 		
 		if (loanBreakdown.getBalanceAtPeriodStart() + advancesCreditsMade - advancesCreditsRepaid != loanBreakdown.getBalanceAtPeriodEnd()) {
             addError(errors, incorrectTotal, LOANS_BREAKDOWN_PATH_BALANCE_AT_PERIOD_END);
+		}
+	}
+
+	private void crossValidateDirectorNameDR(Loan loan, Transaction transaction,
+											 String companyAccountId, HttpServletRequest request, Errors errors) throws DataException {
+
+		if (directorsReportService.find(companyAccountId, request).getStatus() == ResponseStatus.FOUND) {
+			String directorName = loan.getDirectorName();
+
+			List<String> allNames = directorValidator.getValidDirectorNames(transaction, companyAccountId, request);
+
+			if (!allNames.isEmpty() && !allNames.contains(directorName)) {
+
+				addError(errors, mustMatchDirector, LOANS_DIRECTOR_NAME);
+			}
 		}
 	}
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/LoanValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/LoanValidator.java
@@ -59,8 +59,8 @@ public class LoanValidator extends BaseValidator {
 		}
 	}
 
-	private void crossValidateDirectorNameDR(Loan loan, Transaction transaction,
-											 String companyAccountId, HttpServletRequest request, Errors errors) throws DataException {
+	private void crossValidateDirectorNameDR(Loan loan, Transaction transaction, String companyAccountId, HttpServletRequest request, Errors errors)
+			throws DataException {
 
 		if (directorsReportService.find(companyAccountId, request).getStatus() == ResponseStatus.FOUND) {
 			String directorName = loan.getDirectorName();

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -22,4 +22,5 @@ value.required=value_required
 empty.resource=empty_resource
 date.outside.currentPeriod=date_outside_current_period
 mustMatch.directorOrSecretary=must_match_director_or_secretary
+mustMatch.director=must_match_a_director_given_in_directors_report
 mustMatch.frs101.or.frs102=must_match_frs101_or_frs102

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/LoanServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/LoanServiceImplTest.java
@@ -279,7 +279,6 @@ class LoanServiceImplTest {
 
         when(request.getRequestURI()).thenReturn(URI);
 
-        LoanEntity loanEntity = null;
         when(repository.findById(LOAN_ID)).thenReturn(Optional.empty());
 
         ResponseObject<Loan> response =

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/LoanServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/LoanServiceImplTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.api.accounts.service.impl;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -106,7 +105,7 @@ class LoanServiceImplTest {
     @DisplayName("Tests the successful creation of a loan resource")
     void createLoanSuccess() throws DataException {
 
-        when(loanValidator.validateLoan(loan)).thenReturn(errors);        
+        when(loanValidator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(errors);
         when(errors.hasErrors()).thenReturn(false);
 
         when(keyIdGenerator.generateRandom()).thenReturn(LOAN_ID);
@@ -134,7 +133,7 @@ class LoanServiceImplTest {
     @DisplayName("Tests the creation of a loan resource where the repository throws a duplicate key exception")
     void createLoanDuplicateKeyException() throws DataException {
 
-        when(loanValidator.validateLoan(loan)).thenReturn(errors);
+        when(loanValidator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(errors);
         when(errors.hasErrors()).thenReturn(false);
 
         when(keyIdGenerator.generateRandom()).thenReturn(LOAN_ID);
@@ -161,7 +160,7 @@ class LoanServiceImplTest {
     @DisplayName("Tests the creation of a loan resource where the repository throws a Mongo exception")
     void createLoanMongoException() throws DataException {
 
-        when(loanValidator.validateLoan(loan)).thenReturn(errors);
+        when(loanValidator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(errors);
         when(errors.hasErrors()).thenReturn(false);
         
         when(keyIdGenerator.generateRandom()).thenReturn(LOAN_ID);
@@ -186,7 +185,7 @@ class LoanServiceImplTest {
     @DisplayName("Tests the creation of a loan resource where the validator returns errors")
     void createLoanWithValidationErrors() throws DataException {
 
-    	when(loanValidator.validateLoan(loan)).thenReturn(errors);
+    	when(loanValidator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(errors);
         when(errors.hasErrors()).thenReturn(true);
         
         ResponseObject<Loan> response =
@@ -201,7 +200,7 @@ class LoanServiceImplTest {
     @DisplayName("Tests the successful update of a loan resource")
     void updateLoanSuccess() throws DataException {
 
-        when(loanValidator.validateLoan(loan)).thenReturn(errors);
+        when(loanValidator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(errors);
 
         when(request.getRequestURI()).thenReturn(URI);
 
@@ -222,9 +221,9 @@ class LoanServiceImplTest {
 
     @Test
     @DisplayName("Tests the update of a loan resource where the repository throws a Mongo exception")
-    void updateLoanMongoException() {
+    void updateLoanMongoException() throws DataException {
 
-        when(loanValidator.validateLoan(loan)).thenReturn(errors);
+        when(loanValidator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(errors);
         when(request.getRequestURI()).thenReturn(URI);
 
         when(transformer.transform(loan)).thenReturn(loanEntity);
@@ -246,7 +245,7 @@ class LoanServiceImplTest {
     @DisplayName("Tests the update of a loan resource where the validator returns errors")
     void updateLoanWithValidationErrors() throws DataException {
 
-    	when(loanValidator.validateLoan(loan)).thenReturn(errors);
+    	when(loanValidator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(errors);
         when(errors.hasErrors()).thenReturn(true);
         
         ResponseObject<Loan> response =
@@ -281,7 +280,7 @@ class LoanServiceImplTest {
         when(request.getRequestURI()).thenReturn(URI);
 
         LoanEntity loanEntity = null;
-        when(repository.findById(LOAN_ID)).thenReturn(Optional.ofNullable(loanEntity));
+        when(repository.findById(LOAN_ID)).thenReturn(Optional.empty());
 
         ResponseObject<Loan> response =
                 loanService.find(COMPANY_ACCOUNTS_ID, request);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DirectorValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DirectorValidatorTest.java
@@ -1,0 +1,110 @@
+package uk.gov.companieshouse.api.accounts.validation;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.model.rest.directorsreport.Director;
+import uk.gov.companieshouse.api.accounts.service.impl.DirectorService;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DirectorValidatorTest {
+
+    @Mock
+    DirectorService directorService;
+
+    @Mock
+    private Transaction transaction;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @InjectMocks
+    DirectorValidator directorValidator;
+
+    private static final String COMPANY_ACCOUNTS_ID = "companyAccountId";
+
+    private static final String NAME = "directorName";
+    private static final LocalDate RESIGNATION_DATE = LocalDate.of(2019, 1, 1);
+    private static final LocalDate APPOINTMENT_DATE_AFTER_RES = RESIGNATION_DATE.plusDays(1);
+
+    @Test
+    @DisplayName("get valid directors - found")
+    void getValidDirectorsFound() throws DataException {
+
+        when(directorService.findAll(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, createDirectors()));
+        List<String> validNames = directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request);
+
+        assertFalse(validNames.isEmpty());
+        assertTrue(validNames.contains(NAME));
+    }
+
+    @Test
+    @DisplayName("get no valid directors - none found")
+    void getValidDirectorsNoneFound() throws DataException {
+
+        when(directorService.findAll(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, createInvalidDirectors()));
+        List<String> validNames = directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request);
+
+        assertTrue(validNames.isEmpty());
+    }
+
+    @Test
+    @DisplayName("get director with app after res date - found")
+    void getValidDirectorWithAppAfterRes() throws DataException {
+
+        when(directorService.findAll(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, createDirectorWithAppAfterRes()));
+        List<String> validNames = directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request);
+
+        assertFalse(validNames.isEmpty());
+        assertTrue(validNames.contains(NAME));
+    }
+
+    private Director[] createDirectors() {
+
+        Director[] directors = new Director[1];
+        directors[0] = new Director();
+        directors[0].setName(NAME);
+
+        return directors;
+    }
+
+    private Director[] createInvalidDirectors() {
+
+        Director[] directors = new Director[1];
+        directors[0] = new Director();
+        directors[0].setName(NAME);
+        directors[0].setResignationDate(RESIGNATION_DATE);
+
+        return directors;
+    }
+
+    private Director[] createDirectorWithAppAfterRes() {
+
+        Director[] directors = new Director[1];
+        directors[0] = new Director();
+        directors[0].setName(NAME);
+        directors[0].setAppointmentDate(APPOINTMENT_DATE_AFTER_RES);
+        directors[0].setResignationDate(RESIGNATION_DATE);
+
+        return directors;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DirectorValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DirectorValidatorTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 public class DirectorValidatorTest {
 
     @Mock
-    DirectorService directorService;
+    private DirectorService directorService;
 
     @Mock
     private Transaction transaction;
@@ -38,6 +38,7 @@ public class DirectorValidatorTest {
     private HttpServletRequest request;
 
     @InjectMocks
+    private
     DirectorValidator directorValidator;
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountId";

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DirectorValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DirectorValidatorTest.java
@@ -58,6 +58,17 @@ public class DirectorValidatorTest {
     }
 
     @Test
+    @DisplayName("get valid directors - service returns null")
+    void getValidDirectorsNullReturned() throws DataException {
+
+        when(directorService.findAll(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
+
+        List<String> validNames = directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request);
+
+        assertTrue(validNames.isEmpty());
+    }
+
+    @Test
     @DisplayName("get no valid directors - none found")
     void getValidDirectorsNoneFound() throws DataException {
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DirectorsApprovalValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DirectorsApprovalValidatorTest.java
@@ -9,23 +9,21 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
-import uk.gov.companieshouse.api.accounts.model.rest.directorsreport.Director;
 import uk.gov.companieshouse.api.accounts.model.rest.directorsreport.DirectorsApproval;
 import uk.gov.companieshouse.api.accounts.model.rest.directorsreport.Secretary;
 import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
-import uk.gov.companieshouse.api.accounts.service.impl.DirectorService;
 import uk.gov.companieshouse.api.accounts.service.impl.SecretaryService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 import javax.servlet.http.HttpServletRequest;
-import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -43,7 +41,7 @@ class DirectorsApprovalValidatorTest {
     private SecretaryService secretaryService;
 
     @Mock
-    private DirectorService directorService;
+    private DirectorValidator directorValidator;
 
     @InjectMocks
     private DirectorsApprovalValidator validator;
@@ -60,23 +58,28 @@ class DirectorsApprovalValidatorTest {
     @DisplayName("Validate with a valid approval name ")
     void validateApprovalWithValidName() throws DataException {
 
+        List<String> validNames = new ArrayList<>();
+        validNames.add(OTHER_NAME);
+
         DirectorsApproval directorsApproval = createDirectorsApproval(OTHER_NAME);
 
         when(secretaryService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
-        when(directorService.findAll(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
+        when(directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(validNames);
 
         Errors errors = validator.validateApproval(directorsApproval, transaction, COMPANY_ACCOUNTS_ID, request);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    @DisplayName("Validate with a valid secretary approval name ")
+    @DisplayName("Validate with a valid secretary approval name")
     void validateApprovalWhenSecretaryIsNotNullAndNameMatches() throws DataException {
+
+        List<String> validNames = new ArrayList<>();
 
         DirectorsApproval directorsApproval = createDirectorsApproval(SECRETARY_NAME);
 
         when(secretaryService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, createSecretary()));
-        when(directorService.findAll(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
+        when(directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(validNames);
 
         Errors errors = validator.validateApproval(directorsApproval, transaction, COMPANY_ACCOUNTS_ID, request);
         assertFalse(errors.hasErrors());
@@ -86,12 +89,14 @@ class DirectorsApprovalValidatorTest {
     @DisplayName("Validate with a invalid secretary approval name ")
     void validateApprovalWhenSecretaryIsNotNullAndNameDoesNotMatch() throws DataException {
 
-       DirectorsApproval directorsApproval = createDirectorsApproval(OTHER_NAME);
+        List<String> validNames = new ArrayList<>();
+
+        DirectorsApproval directorsApproval = createDirectorsApproval(OTHER_NAME);
 
         ReflectionTestUtils.setField(validator, MUST_MATCH_DIRECTOR_OR_SECRETARY_KEY, MUST_MATCH_DIRECTOR_OR_SECRETARY);
 
         when(secretaryService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, createSecretary()));
-        when(directorService.findAll(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
+        when(directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(validNames);
 
         Errors errors = validator.validateApproval(directorsApproval, transaction, COMPANY_ACCOUNTS_ID, request);
         assertEquals(1, errors.getErrorCount());
@@ -99,30 +104,36 @@ class DirectorsApprovalValidatorTest {
     }
 
     @Test
-    @DisplayName("Validate with a valid directors approval name ")
+    @DisplayName("Validate with a valid directors approval name")
     void validateApprovalWhenDirectorIsNotNullAndNameMatches() throws DataException {
+
+        List<String> validNames = new ArrayList<>();
+        validNames.add(DIRECTOR_NAME);
 
         DirectorsApproval directorsApproval = createDirectorsApproval(DIRECTOR_NAME);
 
         ReflectionTestUtils.setField(validator, MUST_MATCH_DIRECTOR_OR_SECRETARY_KEY, MUST_MATCH_DIRECTOR_OR_SECRETARY);
 
         when(secretaryService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
-        when(directorService.findAll(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, createDirectors()));
+        when(directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(validNames);
 
         Errors errors = validator.validateApproval(directorsApproval, transaction, COMPANY_ACCOUNTS_ID, request);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    @DisplayName("Validate with a invalid directors approval name ")
+    @DisplayName("Validate with a invalid directors approval name")
     void validateApprovalWhenDirectorsIsNotNullAndNameDoesNotMatch() throws DataException {
+
+        List<String> validNames = new ArrayList<>();
+        validNames.add(DIRECTOR_NAME);
 
         DirectorsApproval directorsApproval = createDirectorsApproval(OTHER_NAME);
 
         ReflectionTestUtils.setField(validator, MUST_MATCH_DIRECTOR_OR_SECRETARY_KEY, MUST_MATCH_DIRECTOR_OR_SECRETARY);
 
         when(secretaryService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.NOT_FOUND));
-        when(directorService.findAll(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, createDirectors()));
+        when(directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(validNames);
 
         Errors errors = validator.validateApproval(directorsApproval, transaction, COMPANY_ACCOUNTS_ID, request);
         assertEquals(1, errors.getErrorCount());
@@ -130,13 +141,18 @@ class DirectorsApprovalValidatorTest {
     }
 
     @Test
-    @DisplayName("Validate with a valid secretary or directors approval name ")
+    @DisplayName("Validate with a valid secretary or directors approval name")
     void validateApprovalWhenSecretaryOrDirectorsIsNotNullAndNameMatches() throws DataException {
+
+        List<String> validNames = new ArrayList<>();
+        validNames.add(DIRECTOR_NAME);
 
         DirectorsApproval directorsApproval = createDirectorsApproval(DIRECTOR_NAME);
 
         when(secretaryService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, createSecretary()));
-        when(directorService.findAll(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, createDirectors()));
+        validNames.add(SECRETARY_NAME);
+
+        when(directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(validNames);
 
         Errors errors = validator.validateApproval(directorsApproval, transaction, COMPANY_ACCOUNTS_ID, request);
         assertFalse(errors.hasErrors());
@@ -146,74 +162,21 @@ class DirectorsApprovalValidatorTest {
     @DisplayName("Validate with a invalid directors or secretary approval name ")
     void validateApprovalWhenDirectorsOrSecretaryIsNotNullAndNameDoesNotMatch() throws DataException {
 
+        List<String> validNames = new ArrayList<>();
+        validNames.add(DIRECTOR_NAME);
+
         DirectorsApproval directorsApproval = createDirectorsApproval(OTHER_NAME);
 
         ReflectionTestUtils.setField(validator, MUST_MATCH_DIRECTOR_OR_SECRETARY_KEY, MUST_MATCH_DIRECTOR_OR_SECRETARY);
 
         when(secretaryService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, createSecretary()));
-        when(directorService.findAll(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, createDirectors()));
+        validNames.add(SECRETARY_NAME);
+
+        when(directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(validNames);
 
         Errors errors = validator.validateApproval(directorsApproval, transaction, COMPANY_ACCOUNTS_ID, request);
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(createError(MUST_MATCH_DIRECTOR_OR_SECRETARY, "$.directors_approval.name")));
-    }
-
-    @Test
-    @DisplayName("Validate when director is reappointed")
-    void validateApprovalWithReappointedDirectors() throws DataException {
-
-        DirectorsApproval directorsApproval = createDirectorsApproval(DIRECTOR_NAME);
-
-        Director[] directors = createReappointedDirector();
-
-        Director newDirector = new Director();
-        newDirector.setResignationDate(LocalDate.of(2017, 04, 01));
-        newDirector.setAppointmentDate(LocalDate.of(2017, 03, 01));
-
-        when(secretaryService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, createSecretary()));
-        when(directorService.findAll(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(new ResponseObject<>(ResponseStatus.FOUND, directors));
-
-        Errors errors = validator.validateApproval(directorsApproval, transaction, COMPANY_ACCOUNTS_ID, request);
-        assertFalse(errors.hasErrors());
-        assertEquals(newDirector.getResignationDate(), directors[0].getResignationDate());
-    }
-
-
-    private Director[] createDirectors() {
-
-        Director[] directors = new Director[1];
-        directors[0] = new Director();
-        directors[0].setName(DIRECTOR_NAME);
-
-        return directors;
-    }
-
-    private Director[] createReappointedDirector() {
-
-        Director[] directors = new Director[3];
-
-        Director director = createDirectors()[0];
-
-        director.setResignationDate(LocalDate.of(2017, 04, 01));
-        director.setAppointmentDate(LocalDate.of(2017, 03, 01));
-
-        directors[0] = director;
-
-        director = new Director();
-        director.setName(DIRECTOR_NAME);
-        director.setAppointmentDate(LocalDate.of(2017, 01, 01));
-
-        directors[1] = director;
-
-        director = new Director();
-
-        director.setName(OTHER_NAME);
-        director.setResignationDate(LocalDate.of(2017, 03, 01));
-        director.setAppointmentDate(LocalDate.of(2017, 04, 01));
-
-        directors[2] = director;
-
-        return directors;
     }
 
     private Secretary createSecretary() {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/LoanValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/LoanValidatorTest.java
@@ -3,19 +3,32 @@ package uk.gov.companieshouse.api.accounts.validation;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.model.rest.directorsreport.DirectorsReport;
 import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.loanstodirectors.Loan;
 import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.loanstodirectors.LoanBreakdownResource;
 import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.service.impl.DirectorsReportServiceImpl;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -23,44 +36,70 @@ public class LoanValidatorTest {
 
     private static final String LOANS_BREAKDOWN_PATH_BALANCE_AT_PERIOD_END = "$.loan.breakdown.balance_at_period_end";
 
+    private static final String OTHER_NAME = "otherName";
+
     private static final String LOAN_DIRECTOR_NAME = "directorName";
     private static final String LOAN_DESCRIPTION = "description";
 
     private static final String INCORRECT_TOTAL_NAME = "incorrectTotal";
     private static final String INCORRECT_TOTAL_VALUE = "incorrect.total";
 
-    private Loan loan;
+    private static final String INVALID_DR_NAME = "mustMatchDirector";
+    private static final String INVALID_DR_VALUE = "mustMatch.director";
+
+    private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
+
+    @Mock
+    HttpServletRequest request;
+
+    @Mock
+    Transaction transaction;
+
+    @Mock
     private Errors errors;
+
+    @Mock
+    private DirectorsReportServiceImpl directorsReportService;
+
+    @Mock
+    private DirectorsReport directorsReport;
+
+    @Mock
+    private DirectorValidator directorValidator;
+
+    @InjectMocks
     private LoanValidator validator;
+
+    private Loan loan;
 
     @BeforeEach
     void setup() {
         loan = new Loan();
-        errors = new Errors();
-        validator = new LoanValidator();
     }
 
     @Test
     @DisplayName("Loan validation with valid loan and breakdown")
-    void testSuccessfulLoanCalculationValidation() {
+    void testSuccessfulLoanCalculationValidation() throws DataException {
 
     	loan.setDirectorName(LOAN_DIRECTOR_NAME);
     	loan.setDescription(LOAN_DESCRIPTION);
     	
         createValidLoanBreakdown();
 
-        errors = validator.validateLoan(loan);
+        when(directorsReportService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(getDirectorsReport(false));
+
+        errors = validator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertFalse(errors.hasErrors());
     }
 
     @Test
     @DisplayName("Loan validation with missing advances_credits_made")
-    void testSuccessfulLoanCalculationValidationWithMissingAdvancesCreditsMade() {
+    void testSuccessfulLoanCalculationValidationWithMissingAdvancesCreditsMade() throws DataException {
 
     	loan.setDirectorName(LOAN_DIRECTOR_NAME);
     	loan.setDescription(LOAN_DESCRIPTION);
-    	
+
         LoanBreakdownResource loanBreakdown = new LoanBreakdownResource();
         loanBreakdown.setBalanceAtPeriodStart(2000L);
         loanBreakdown.setAdvancesCreditsMade(null);
@@ -69,18 +108,19 @@ public class LoanValidatorTest {
 
         loan.setBreakdown(loanBreakdown);
 
-        errors = validator.validateLoan(loan);
+        when(directorsReportService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(getDirectorsReport(false));
+        errors = validator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertFalse(errors.hasErrors());
     }
 
     @Test
     @DisplayName("Loan validation with missing advances_credits_repaid")
-    void testSuccessfulLoanCalculationValidationWithMissingAdvancesCreditsRepaid() {
+    void testSuccessfulLoanCalculationValidationWithMissingAdvancesCreditsRepaid() throws DataException {
 
     	loan.setDirectorName(LOAN_DIRECTOR_NAME);
     	loan.setDescription(LOAN_DESCRIPTION);
-    	
+
         LoanBreakdownResource loanBreakdown = new LoanBreakdownResource();
         loanBreakdown.setBalanceAtPeriodStart(2000L);
         loanBreakdown.setAdvancesCreditsMade(1000L);
@@ -88,30 +128,74 @@ public class LoanValidatorTest {
         loanBreakdown.setBalanceAtPeriodEnd(3000L);
 
         loan.setBreakdown(loanBreakdown);
-        
-        errors = validator.validateLoan(loan);
+
+        when(directorsReportService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(getDirectorsReport(false));
+        errors = validator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertFalse(errors.hasErrors());
     }
 
     @Test
     @DisplayName("Loan validation with incorrect loan calculation")
-    void testIncorrectLoanCalculation() {
+    void testIncorrectLoanCalculation() throws DataException {
+
         ReflectionTestUtils.setField(validator, INCORRECT_TOTAL_NAME,
                 INCORRECT_TOTAL_VALUE);
 
     	loan.setDescription(LOAN_DESCRIPTION);
-    	
+
         createValidLoanBreakdown();
 
         loan.getBreakdown().setBalanceAtPeriodEnd(3000L);
-        
-        errors = validator.validateLoan(loan);
+
+        when(directorsReportService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(getDirectorsReport(false));
+        errors = validator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request);
 
         assertTrue(errors.containsError(createError(INCORRECT_TOTAL_VALUE,
         		LOANS_BREAKDOWN_PATH_BALANCE_AT_PERIOD_END)));
 
         assertEquals(1, errors.getErrorCount());
+    }
+
+    @Test
+    @DisplayName("Create valid loan with DR cross validation")
+    void validLoanWithCrossValidationDR() throws DataException {
+
+        List<String> validNames = new ArrayList<>();
+        validNames.add(LOAN_DIRECTOR_NAME);
+
+        loan.setDirectorName(LOAN_DIRECTOR_NAME);
+        loan.setDescription(LOAN_DESCRIPTION);
+        createValidLoanBreakdown();
+
+        when(directorsReportService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(getDirectorsReport(true));
+        when(directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(validNames);
+
+        errors = validator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request);
+
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    @DisplayName("Create invalid loan with DR cross validation")
+    void invalidLoanWithCrossValidationDR() throws DataException {
+
+        ReflectionTestUtils.setField(validator, INVALID_DR_NAME,
+                INVALID_DR_VALUE);
+
+        List<String> validNames = new ArrayList<>();
+        validNames.add(OTHER_NAME);
+
+        loan.setDirectorName(LOAN_DIRECTOR_NAME);
+        loan.setDescription(LOAN_DESCRIPTION);
+        createValidLoanBreakdown();
+
+        when(directorsReportService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(getDirectorsReport(true));
+        when(directorValidator.getValidDirectorNames(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(validNames);
+
+        errors = validator.validateLoan(loan, transaction, COMPANY_ACCOUNTS_ID, request);
+
+        assertTrue(errors.hasErrors());
     }
 
     private void createValidLoanBreakdown() {
@@ -127,5 +211,14 @@ public class LoanValidatorTest {
     private Error createError(String error, String path) {
         return new Error(error, path, LocationType.JSON_PATH.getValue(),
                 ErrorType.VALIDATION.getType());
+    }
+
+    private ResponseObject<DirectorsReport> getDirectorsReport(boolean returnFound) {
+
+        if(returnFound) {
+            return new ResponseObject<>(ResponseStatus.FOUND, directorsReport);
+        } else {
+            return new ResponseObject<>(ResponseStatus.NOT_FOUND);
+        }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/LoanValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/LoanValidatorTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class LoanValidatorTest {
+class LoanValidatorTest {
 
     private static final String LOANS_BREAKDOWN_PATH_BALANCE_AT_PERIOD_END = "$.loan.breakdown.balance_at_period_end";
 
@@ -50,10 +50,10 @@ public class LoanValidatorTest {
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
 
     @Mock
-    HttpServletRequest request;
+    private HttpServletRequest request;
 
     @Mock
-    Transaction transaction;
+    private Transaction transaction;
 
     @Mock
     private Errors errors;


### PR DESCRIPTION
This PR is to implement the cross validation needed for the loans to directors resource with the directors report.

If a user has a directors report then in the loans to directors resource, they can only supply director names which were originally listed on the directors report.

-Extract duplicate logic into a DirectorValidator class and unit test it.
-Add validation messages where needed
-Implement new logic and change / create unit tests as needed.