### PR TITLE
Autodelete Loans To Director loans on director change

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DirectorService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DirectorService.java
@@ -19,7 +19,6 @@ import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
 import uk.gov.companieshouse.api.accounts.links.LoansToDirectorsLinkType;
 import uk.gov.companieshouse.api.accounts.model.entity.directorsreport.DirectorEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.directorsreport.Director;
-import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.loanstodirectors.AdditionalInformation;
 import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.loanstodirectors.LoansToDirectors;
 import uk.gov.companieshouse.api.accounts.repository.DirectorRepository;
 import uk.gov.companieshouse.api.accounts.service.DirectorsReportService;
@@ -42,7 +41,6 @@ public class DirectorService implements MultipleResourceService<Director> {
     private KeyIdGenerator keyIdGenerator;
 
     private LoanServiceImpl loanService;
-    private LoansToDirectorsAdditionalInformationService loansToDirectorsAdditionalInfoService;
     private LoansToDirectorsServiceImpl loansToDirectorsService;
 
     @Autowired
@@ -50,7 +48,6 @@ public class DirectorService implements MultipleResourceService<Director> {
                            DirectorsReportService directorsReportService,
                            LoanServiceImpl loanService,
                            LoansToDirectorsServiceImpl loansToDirectorsService,
-                           LoansToDirectorsAdditionalInformationService loansToDirectorsAdditionalInfoService,
                            KeyIdGenerator keyIdGenerator) {
 
         this.transformer = transformer;
@@ -58,7 +55,6 @@ public class DirectorService implements MultipleResourceService<Director> {
         this.directorsReportService = directorsReportService;
         this.loanService = loanService;
         this.loansToDirectorsService = loansToDirectorsService;
-        this.loansToDirectorsAdditionalInfoService = loansToDirectorsAdditionalInfoService;
         this.keyIdGenerator = keyIdGenerator;
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DirectorService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/DirectorService.java
@@ -88,7 +88,7 @@ public class DirectorService implements MultipleResourceService<Director> {
 
         directorsReportService.addDirector(companyAccountId, directorId, getSelfLink(rest), request);
 
-        directorsResourceChanged(transaction, companyAccountId, request);
+        removeAssociatedLoans(transaction, companyAccountId, request);
         return new ResponseObject<>(ResponseStatus.CREATED, rest);
     }
 
@@ -111,7 +111,7 @@ public class DirectorService implements MultipleResourceService<Director> {
             throw new DataException(e);
         }
 
-        directorsResourceChanged(transaction, companyAccountId, request);
+        removeAssociatedLoans(transaction, companyAccountId, request);
 
         return new ResponseObject<>(ResponseStatus.UPDATED, rest);
     }
@@ -174,7 +174,7 @@ public class DirectorService implements MultipleResourceService<Director> {
 
                 Transaction transaction = (Transaction) request
                                 .getAttribute(AttributeName.TRANSACTION.getValue());
-                directorsResourceChanged(transaction, companyAccountsId, request);
+                removeAssociatedLoans(transaction, companyAccountsId, request);
 
                 return new ResponseObject<>(ResponseStatus.UPDATED);
             } else {
@@ -200,7 +200,7 @@ public class DirectorService implements MultipleResourceService<Director> {
             throw new DataException(e);
         }
 
-        directorsResourceChanged(transaction, companyAccountId, request);
+        removeAssociatedLoans(transaction, companyAccountId, request);
         return new ResponseObject<>(ResponseStatus.UPDATED);
     }
 
@@ -255,7 +255,7 @@ public class DirectorService implements MultipleResourceService<Director> {
         return directorId;
     }
 
-    private void directorsResourceChanged(Transaction transaction, String companyAccountsId,
+    private void removeAssociatedLoans(Transaction transaction, String companyAccountsId,
                     HttpServletRequest request) throws DataException {
 
         ResponseObject<LoansToDirectors> loansToDirectorsResponse =

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DirectorServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DirectorServiceTest.java
@@ -86,9 +86,6 @@ class DirectorServiceTest {
     @Mock
     private LoansToDirectors loansToDirectors;
 
-    @Mock
-    private Map<String, String> loans;
-
     @InjectMocks
     private DirectorService directorService;
 


### PR DESCRIPTION
When a director is created/updated/deleted, then the Loans To Director's resource's loans become uncertain. The cleanest, easiest solution is to delete them and prompt the user to re-enter the lot. This is unlikely to happen, as the user will usually have entered all the directors and then their loans, so this is safe.

Implement logic and unit tests.