### PR TITLE
Add validation for company account period start date

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
@@ -58,18 +58,20 @@ public class CompanyAccountController {
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
 
-        Errors errors = validator.validateCompanyAccount(companyAccount, transaction);
-        if(errors.hasErrors()) {
-            return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
-        }
-
         try {
+            Errors errors = validator.validateCompanyAccount(transaction);
+            if(errors.hasErrors()) {
+                return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+            }
+
             ResponseObject<CompanyAccount> responseObject = companyAccountService
                 .create(companyAccount, transaction, request);
-            return apiResponseMapper
-                .map(responseObject.getStatus(), responseObject.getData(),
+
+            return apiResponseMapper.map(responseObject.getStatus(), responseObject.getData(),
                     responseObject.getErrors());
+
         } catch (PatchException | DataException ex) {
+
             final Map<String, Object> debugMap = new HashMap<>();
             debugMap.put("transaction_id", transaction.getId());
             LOGGER.errorRequest(request, ex, debugMap);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountController.java
@@ -20,8 +20,10 @@ import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.exception.PatchException;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.service.CompanyAccountService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.validation.CompanyAccountValidator;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.CompanyAccountTransformer;
 import uk.gov.companieshouse.api.accounts.utility.ApiResponseMapper;
@@ -46,12 +48,20 @@ public class CompanyAccountController {
     @Autowired
     private CompanyAccountTransformer companyAccountTransformer;
 
+    @Autowired
+    private CompanyAccountValidator validator;
+
     @PostMapping
     public ResponseEntity createCompanyAccount(@Valid @RequestBody CompanyAccount companyAccount,
         HttpServletRequest request) {
 
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
+
+        Errors errors = validator.validateCompanyAccount(companyAccount, transaction);
+        if(errors.hasErrors()) {
+            return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+        }
 
         try {
             ResponseObject<CompanyAccount> responseObject = companyAccountService

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/BaseValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/BaseValidator.java
@@ -18,6 +18,9 @@ public class BaseValidator {
     @Value("${date.invalid}")
     protected String dateInvalid;
 
+    @Value("${date.outside.range}")
+    protected String dateOutsideRange;
+
     @Value("${unexpected.data}")
     protected String unexpectedData;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CompanyAccountValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CompanyAccountValidator.java
@@ -36,7 +36,7 @@ public class CompanyAccountValidator extends BaseValidator {
         super(companyService);
     }
 
-    public Errors validateCompanyAccount(CompanyAccount companyAccount, Transaction transaction) {
+    public Errors validateCompanyAccount(Transaction transaction) throws DataException {
 
         Errors errors = new Errors();
 
@@ -54,7 +54,7 @@ public class CompanyAccountValidator extends BaseValidator {
 
         } catch (ServiceException e) {
 
-            throw new UncheckedDataException("Error fetching company profile", e);
+            throw new DataException("Error fetching company profile", e);
         }
 
         return errors;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/CompanyAccountValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/CompanyAccountValidator.java
@@ -1,0 +1,62 @@
+package uk.gov.companieshouse.api.accounts.validation;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.accounts.AttributeName;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.exception.ServiceException;
+import uk.gov.companieshouse.api.accounts.exception.UncheckedDataException;
+import uk.gov.companieshouse.api.accounts.model.rest.Approval;
+import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
+import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
+import uk.gov.companieshouse.api.accounts.model.rest.directorsreport.Director;
+import uk.gov.companieshouse.api.accounts.model.validation.Error;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.service.CompanyService;
+import uk.gov.companieshouse.api.accounts.service.impl.DirectorService;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class CompanyAccountValidator extends BaseValidator {
+
+    private static final String ERROR_PATH = "$.company_account";
+    private static final int NUMBER_OF_DAYS = 7;
+
+    @Autowired
+    public CompanyAccountValidator(CompanyService companyService) {
+        super(companyService);
+    }
+
+    public Errors validateCompanyAccount(CompanyAccount companyAccount, Transaction transaction) {
+
+        Errors errors = new Errors();
+
+        try {
+            CompanyProfileApi companyProfile = super.getCompanyService()
+                    .getCompanyProfile(transaction.getCompanyNumber());
+
+            LocalDate periodStart = companyProfile.getAccounts().getNextAccounts().getPeriodStartOn();
+
+            boolean result = LocalDate.now().isAfter(periodStart.minusDays(NUMBER_OF_DAYS));
+            if (!result) {
+                errors.addError(new Error(dateOutsideRange, ERROR_PATH, LocationType.JSON_PATH.getValue(),
+                        ErrorType.VALIDATION.getType()));
+            }
+
+        } catch (ServiceException e) {
+
+            throw new UncheckedDataException("Error fetching company profile", e);
+        }
+
+        return errors;
+    }
+}

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -11,6 +11,7 @@ invalid.input.length=invalid_input_length
 incorrect.total=incorrect_total
 invalid.value=invalid_value
 date.invalid=date_is_invalid
+date.outside.range=date_is_outside_valid_range
 date.outsideRange.periodEnd=date_outside_range_of_period_end
 shareholders.mismatch=shareholder_funds_mismatch
 membersFunds.mismatch=members_funds_mismatch

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
@@ -26,9 +26,11 @@ import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.exception.PatchException;
 import uk.gov.companieshouse.api.accounts.model.entity.CompanyAccountEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.service.CompanyAccountService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.accounts.validation.CompanyAccountValidator;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.CompanyAccountTransformer;
 import uk.gov.companieshouse.api.accounts.utility.ApiResponseMapper;
@@ -58,6 +60,9 @@ public class CompanyAccountControllerTest {
     @Mock
     private ApiResponseMapper apiResponseMapper;
 
+    @Mock
+    private CompanyAccountValidator validator;
+
     @InjectMocks
     private CompanyAccountController companyAccountController;
 
@@ -68,7 +73,11 @@ public class CompanyAccountControllerTest {
 
     @Test
     @DisplayName("Tests the successful creation of an company account resource and patching transaction resource")
-    void canCreateAccountSuccesfully() throws DataException, PatchException {
+    void canCreateAccountSuccessfully() throws DataException, PatchException {
+
+        Errors errors = new Errors(); //Empty.
+        when(validator.validateCompanyAccount(transactionMock)).thenReturn(errors);
+
         when(httpServletRequestMock.getAttribute("transaction")).thenReturn(transactionMock);
         ResponseObject responseObject = new ResponseObject<>(ResponseStatus.CREATED,
             companyAccount);
@@ -94,6 +103,10 @@ public class CompanyAccountControllerTest {
     @Test
     @DisplayName("Tests the unsuccessful creation of an company account resource due to duplicate key error")
     void canCreateAccountWithDuplicateKeyError() throws DataException, PatchException {
+
+        Errors errors = new Errors(); //Empty.
+        when(validator.validateCompanyAccount(transactionMock)).thenReturn(errors);
+
         when(httpServletRequestMock.getAttribute("transaction")).thenReturn(transactionMock);
         ResponseObject responseObject = new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR,
             companyAccount);
@@ -116,6 +129,10 @@ public class CompanyAccountControllerTest {
     @Test
     @DisplayName("Tests the unsuccessful creation of an company account resource due to an internal error (MongoException")
     void canCreateAccountWithInternalError() throws DataException, PatchException {
+
+        Errors errors = new Errors(); //Empty.
+        when(validator.validateCompanyAccount(transactionMock)).thenReturn(errors);
+
         when(httpServletRequestMock.getAttribute("transaction")).thenReturn(transactionMock);
         doThrow(mock(DataException.class)).when(companyAccountServiceMock)
                 .create(companyAccount, transactionMock, httpServletRequestMock);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CompanyAccountValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CompanyAccountValidatorTest.java
@@ -50,15 +50,6 @@ public class CompanyAccountValidatorTest {
     private Transaction transaction;
 
     @Mock
-    private BaseValidator baseValidator;
-
-    @Mock
-    private HttpServletRequest request;
-
-    @Mock
-    private CompanyAccount companyAccount;
-
-    @Mock
     private CompanyService companyService;
 
     @Mock

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CompanyAccountValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CompanyAccountValidatorTest.java
@@ -1,0 +1,128 @@
+package uk.gov.companieshouse.api.accounts.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.api.accounts.AttributeName;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.exception.ServiceException;
+import uk.gov.companieshouse.api.accounts.model.rest.Approval;
+import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
+import uk.gov.companieshouse.api.accounts.model.rest.NextAccounts;
+import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
+import uk.gov.companieshouse.api.accounts.model.rest.directorsreport.Director;
+import uk.gov.companieshouse.api.accounts.model.validation.Error;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.service.CompanyService;
+import uk.gov.companieshouse.api.accounts.service.impl.DirectorService;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
+import uk.gov.companieshouse.api.model.company.account.NextAccountsApi;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.LocalDate;
+import java.time.Month;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class CompanyAccountValidatorTest {
+
+    private static final String ERROR_PATH = "$.company_account";
+
+    private Errors errors;
+
+    @Mock
+    private Transaction transaction;
+
+    @Mock
+    private BaseValidator baseValidator;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private CompanyAccount companyAccount;
+
+    @Mock
+    private CompanyService companyService;
+
+    @Mock
+    private CompanyProfileApi companyProfileApi;
+
+    @Mock
+    private CompanyAccountApi accounts;
+
+    @Mock
+    private NextAccountsApi nextAccounts;
+
+    private CompanyAccountValidator validator;
+
+    @BeforeEach
+    void setup() {
+
+        validator = new CompanyAccountValidator(companyService);
+        validator.dateOutsideRange = "date.outside.range";
+    }
+
+    @Test
+    @DisplayName("Validate with a valid date")
+    void validateCompanyAccountWithValidDate() throws ServiceException, DataException {
+
+        when(companyService.getCompanyProfile(transaction.getCompanyNumber())).thenReturn(companyProfileApi);
+
+        when(companyProfileApi.getAccounts()).thenReturn(accounts);
+        when(accounts.getNextAccounts()).thenReturn(nextAccounts);
+        when(nextAccounts.getPeriodStartOn()).thenReturn(LocalDate.now());
+
+        errors = validator.validateCompanyAccount(transaction);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    @DisplayName("Validate with an invalid date")
+    void validateCompanyAccountWithInvalidDate() throws ServiceException, DataException {
+
+        when(companyService.getCompanyProfile(transaction.getCompanyNumber())).thenReturn(companyProfileApi);
+
+        when(companyProfileApi.getAccounts()).thenReturn(accounts);
+        when(accounts.getNextAccounts()).thenReturn(nextAccounts);
+        when(nextAccounts.getPeriodStartOn()).thenReturn(LocalDate.now().plusDays(8));
+
+        errors = validator.validateCompanyAccount(transaction);
+        assertTrue(errors.hasErrors());
+
+        Error error = createError(validator.dateOutsideRange, ERROR_PATH);
+
+        assertTrue(errors.containsError(error));
+    }
+
+    @Test
+    @DisplayName("Validator throws service exception")
+    void validateCompanyAccountThrowsServiceException() throws ServiceException, DataException {
+
+        when(companyService.getCompanyProfile(transaction.getCompanyNumber())).thenThrow(ServiceException.class);
+
+        assertThrows(DataException.class,
+                () -> validator.validateCompanyAccount(transaction));
+    }
+
+    private Error createError(String error, String path) {
+        return new Error(error, path, LocationType.JSON_PATH.getValue(),
+                ErrorType.VALIDATION.getType());
+    }
+}


### PR DESCRIPTION
-Add a company account validator which handles checking of whether you can create a company account yet.

Todays date has to be within 7 days before period_start_on.

E.g. 

Todays date: 01-01-2020
Period_start_on: 07-01-2020 
VALID

Todays date: 01-01-2020
Period_start_on: 08-01-2020 
INVALID
