### PR TITLE
Validation closure infrastructure

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/ValidationStatusController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/ValidationStatusController.java
@@ -1,0 +1,39 @@
+package uk.gov.companieshouse.api.accounts.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.model.validation.ValidationStatus;
+import uk.gov.companieshouse.api.accounts.service.ValidationStatusService;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping(value = "/transactions/{transactionId}/company-accounts/{companyAccountId}/validate", produces = MediaType.APPLICATION_JSON_VALUE)
+public class ValidationStatusController {
+
+    @Autowired
+    private ValidationStatusService validationStatusService;
+
+    @GetMapping
+    public ResponseEntity<ValidationStatus> getValidationStatus(@PathVariable("companyAccountId") String companyAccountId,
+                                                                HttpServletRequest request ) {
+
+        try {
+            Errors errors = validationStatusService.getValidationErrors(companyAccountId, request);
+
+            ValidationStatus validationStatus = new ValidationStatus(errors.hasErrors(), errors.getErrors());
+
+            return ResponseEntity.ok(validationStatus);
+        } catch (DataException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/ValidationStatusController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/ValidationStatusController.java
@@ -29,7 +29,7 @@ public class ValidationStatusController {
         try {
             Errors errors = validationStatusService.getValidationErrors(companyAccountId, request);
 
-            ValidationStatus validationStatus = new ValidationStatus(errors.hasErrors(), errors.getErrors());
+            ValidationStatus validationStatus = new ValidationStatus(!errors.hasErrors(), errors.getErrors());
 
             return ResponseEntity.ok(validationStatus);
         } catch (DataException e) {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/links/TransactionLinkType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/links/TransactionLinkType.java
@@ -5,6 +5,7 @@ public enum TransactionLinkType implements LinkType {
     SELF("self"),
     PAYMENTS("payments"),
     RESOURCE("resource"),
+    VALIDATION_STATUS("validation_status"),
     COSTS("costs");
 
     private String link;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Errors.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Errors.java
@@ -39,6 +39,15 @@ public class Errors {
     }
 
     /**
+     * Get errors set
+     *
+     * @return Set of errors
+     */
+    public Set<Error> getErrors() {
+        return this.errors;
+    }
+
+    /**
      * Determine whether the given {@link Error} is contained
      *
      * @return True or false

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/ValidationStatus.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/ValidationStatus.java
@@ -1,0 +1,35 @@
+package uk.gov.companieshouse.api.accounts.model.validation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Set;
+
+public class ValidationStatus {
+
+    public ValidationStatus(boolean isValid, Set<Error> errors) {
+        this.isValid = isValid;
+        this.errors = errors;
+    }
+
+    @JsonProperty("is_valid")
+    private boolean isValid;
+
+    @JsonProperty("errors")
+    private Set<Error> errors;
+
+    public boolean isValid() {
+        return isValid;
+    }
+
+    public void setValid(boolean valid) {
+        isValid = valid;
+    }
+
+    public Set<Error> getErrors() {
+        return errors;
+    }
+
+    public void setErrors(Set<Error> errors) {
+        this.errors = errors;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/ValidationStatus.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/ValidationStatus.java
@@ -17,11 +17,11 @@ public class ValidationStatus {
     @JsonProperty("errors")
     private Set<Error> errors;
 
-    public boolean isValid() {
+    public boolean getIsValid() {
         return isValid;
     }
 
-    public void setValid(boolean valid) {
+    public void setIsValid(boolean valid) {
         isValid = valid;
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/ValidationStatusService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/ValidationStatusService.java
@@ -1,0 +1,11 @@
+package uk.gov.companieshouse.api.accounts.service;
+
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface ValidationStatusService {
+
+    Errors getValidationErrors(String companyAccountsId, HttpServletRequest request) throws DataException;
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImpl.java
@@ -191,6 +191,7 @@ public class CompanyAccountServiceImpl implements CompanyAccountService {
 
         Map<String, String> links = new HashMap<>();
         links.put(TransactionLinkType.RESOURCE.getLink(), selfLink);
+        links.put(TransactionLinkType.VALIDATION_STATUS.getLink(), selfLink + "/validate");
 
         if (isPayableTransaction) {
             links.put(TransactionLinkType.COSTS.getLink(), selfLink + "/costs");

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/ValidationStatusServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/ValidationStatusServiceImpl.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.api.accounts.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.accounts.AttributeName;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.service.ValidationStatusService;
+import uk.gov.companieshouse.api.accounts.validation.AccountsValidator;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Service
+public class ValidationStatusServiceImpl implements ValidationStatusService {
+
+    @Autowired
+    private AccountsValidator accountsValidator;
+
+    @Override
+    public Errors getValidationErrors(String companyAccountsId, HttpServletRequest request) throws DataException {
+
+        Transaction transaction = (Transaction) request.getAttribute(AttributeName.TRANSACTION.getValue());
+
+        return accountsValidator.validationSubmission(transaction, companyAccountsId, request);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/AccountsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/AccountsValidator.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.api.accounts.validation;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Component
+public class AccountsValidator {
+
+    public Errors validationSubmission(Transaction transaction, String companyAccountsId, HttpServletRequest request)
+            throws DataException {
+
+        return new Errors();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/ValidationStatusControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/ValidationStatusControllerTest.java
@@ -1,0 +1,62 @@
+package uk.gov.companieshouse.api.accounts.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.model.validation.ValidationStatus;
+import uk.gov.companieshouse.api.accounts.service.ValidationStatusService;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ValidationStatusControllerTest {
+
+    @Mock
+    ValidationStatusService service;
+
+    @Mock
+    HttpServletRequest request;
+
+    @InjectMocks
+    ValidationStatusController controller;
+
+    private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
+
+    @Test
+    @DisplayName("Get - validation status with no errors | is valid")
+    void getValidationStatusNoErrorsIsValid() throws DataException {
+
+        Errors errors = new Errors(); //Empty, no errors.
+
+        when(service.getValidationErrors(COMPANY_ACCOUNTS_ID, request)).thenReturn(errors);
+
+        ResponseEntity<ValidationStatus> responseEntity = controller.getValidationStatus(COMPANY_ACCOUNTS_ID, request);
+
+        assertEquals(responseEntity.getStatusCode(), HttpStatus.OK);
+        assertTrue(responseEntity.getBody().getIsValid());
+    }
+
+    @Test
+    @DisplayName("Get - Throws Data exception")
+    void getValidationStatusThrowsException() throws DataException {
+
+        when(service.getValidationErrors(COMPANY_ACCOUNTS_ID, request)).thenThrow(DataException.class);
+
+        ResponseEntity<ValidationStatus> responseEntity = controller.getValidationStatus(COMPANY_ACCOUNTS_ID, request);
+
+        assertEquals(responseEntity.getStatusCode(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyAccountServiceImplTest.java
@@ -55,7 +55,7 @@ import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CompanyAccountServiceImplTest {
+class CompanyAccountServiceImplTest {
 
     @Mock
     private CompanyAccountRepository repository;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/ValidationStatusServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/ValidationStatusServiceImplTest.java
@@ -1,0 +1,53 @@
+package uk.gov.companieshouse.api.accounts.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.accounts.AttributeName;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.accounts.validation.AccountsValidator;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ValidationStatusServiceImplTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private AccountsValidator validator;
+
+    @Mock
+    private Transaction transaction;
+
+    @InjectMocks
+    private ValidationStatusServiceImpl service;
+
+    private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
+
+    @Test
+    @DisplayName("Get validation returns no errors")
+    void getValidationErrorsReturnsEmptyErrors() throws DataException {
+
+        Errors errors = new Errors();
+
+        when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
+        when(validator.validationSubmission(transaction, COMPANY_ACCOUNTS_ID, request)).thenReturn(errors);
+
+        Errors responseErrors = service.getValidationErrors(COMPANY_ACCOUNTS_ID, request);
+
+        assertEquals(responseErrors, errors);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/AccountsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/AccountsValidatorTest.java
@@ -1,0 +1,46 @@
+package uk.gov.companieshouse.api.accounts.validation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.model.validation.Errors;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AccountsValidatorTest {
+
+    @Mock
+    private Transaction transaction;
+
+    @Mock
+    private HttpServletRequest request;
+
+    private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
+
+    @InjectMocks
+    private AccountsValidator validator;
+
+
+    @Test
+    @DisplayName("Validate Submission - successful, no errors")
+    void validateSubmissionNoErrorsFound() throws DataException {
+
+        Errors errors = new Errors();
+
+        Errors responseErrors = validator.validationSubmission(transaction, COMPANY_ACCOUNTS_ID, request);
+
+        assertFalse(responseErrors.hasErrors());
+        assertEquals(errors.getErrors(), responseErrors.getErrors());
+    }
+}


### PR DESCRIPTION
Group worked with other developers on Aardvark to get the infrastructure in place so that we can begin to work on transaction closure validation for each of the notes in the company accounts journey.

-Added a new controller too expose the validation endpoint
-Added new service (with interface) too handle calling of validation logic
-Added validator too handle all validation
-Added custom ValidationStatus model which is used in the Response entity (Transactions API expects this model back).

-Added unit tests and changed unit tests where needed.