### PR TITLE
Fix Sonar issues by changing pom parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
   <parent>
     <groupId>uk.gov.companieshouse</groupId>
-    <artifactId>companies-house-spring-boot-parent</artifactId>
-    <version>1.2.0</version>
+    <artifactId>companies-house-parent</artifactId>
+    <version>1.3.0</version>
   </parent>
 
   <properties>
@@ -30,11 +30,23 @@
     <api-security-java.version>0.2.10</api-security-java.version>
     <commons-io.version>2.4</commons-io.version>
 
-    <!-- Jacoco -->
-    <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
+    <spring-boot-dependencies.version>2.1.3.RELEASE</spring-boot-dependencies.version>
+    <spring-boot-maven-plugin.version>2.1.3.RELEASE</spring-boot-maven-plugin.version>
 
     <jackson.version>2.9.0.pr4</jackson.version>
   </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
   <dependencies>
     <!-- Compile -->
@@ -123,6 +135,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot-maven-plugin.version}</version>
         <configuration>
           <mainClass>uk.gov.companieshouse.api.accounts.CompanyAccountsApplication
           </mainClass>
@@ -139,22 +152,6 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${jacoco-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>default-prepare-agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>default-report</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
We changed Sonar and, in doing so, needed to upgrade to use a more
 recent companies house parent pom. Just changing to use a newer
 companies-house-spring-boot-parent did not work breaking lots of
 tests. We are not supposed to use that as a parent any more, so
 this is a chance to use the proper companies-house-parent. In doing
 so, other changes to pull in correct spring dependencies were
 needed.
Also used spring-boot-maven-plugin.version, which was previously
 unspecified.