### PR TITLE
improve coverage and only give valid BS for prev period if multiyear …

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/AccountsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/AccountsValidator.java
@@ -79,7 +79,7 @@ public class AccountsValidator extends BaseValidator {
             }
 
             BalanceSheet currentPeriodBalanceSheet = currentPeriodService.find(companyAccountsId, request).getData().getBalanceSheet();
-            BalanceSheet previousPeriodBalanceSheet = new BalanceSheet();
+            BalanceSheet previousPeriodBalanceSheet = null;
             if (getIsMultipleYearFiler(transaction)) {
                 previousPeriodBalanceSheet = previousPeriodService.find(companyAccountsId, request).getData().getBalanceSheet();
             }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/AccountsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/AccountsValidatorTest.java
@@ -137,6 +137,38 @@ class AccountsValidatorTest {
     }
 
     @Test
+    @DisplayName("Validate Submission - single year filer, successful, no errors")
+    void validateSubmissionSYFNoErrorsFound() throws DataException, ServiceException {
+
+        Errors emptyErrors = new Errors();
+
+        when(smallFullService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(smallFullResponseObject);
+        when(smallFullResponseObject.getData()).thenReturn(smallFull);
+
+        when(currentPeriodTnClosureValidator.validate(any(String.class), any(SmallFull.class),
+                any(HttpServletRequest.class), any(Errors.class))).thenReturn(emptyErrors);
+        when(previousPeriodTnClosureValidator.validate(any(String.class), any(SmallFull.class),
+                any(Transaction.class), any(HttpServletRequest.class), any(Errors.class)))
+                .thenReturn(emptyErrors);
+
+        when(currentPeriodService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(cpResponseObj);
+        when(cpResponseObj.getData()).thenReturn(currentPeriod);
+        when(currentPeriod.getBalanceSheet()).thenReturn(currentPeriodBalanceSheet);
+
+        when (companyService.isMultipleYearFiler(transaction)).thenReturn(false);
+
+        when(stocksTnClosureValidator
+                .validate(COMPANY_ACCOUNTS_ID, smallFull, transaction, request, emptyErrors, currentPeriodBalanceSheet, null))
+                .thenReturn(emptyErrors);
+
+        Errors responseErrors = validator.validate(transaction, COMPANY_ACCOUNTS_ID, request);
+
+        assertFalse(responseErrors.hasErrors());
+        assertEquals(emptyErrors.getErrors(), responseErrors.getErrors());
+    }
+
+
+    @Test
     @DisplayName("Validate Submission - successful, no errors")
     void validateSubmissionNoErrorsFound() throws DataException, ServiceException {
 


### PR DESCRIPTION
…filer = true

As commit states, we only want to give a balance sheet for previous period if we have a company which is infact a multi-year filer.

Previously we fed each note validator a new BS if they were a single year filer but I believe this is miss-leading, so updated to pass in null if previous period doesnt exist, and then in the stocks validator we do an Optional call to ensure the null exception would be handled.

Updated unit tests to improve coverage to 100% as well.