### PR TITLE
Update Spring Boot from 2.1.3 to 2.1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,8 @@
     <commons-io.version>2.4</commons-io.version>
 
     <spring-boot-dependencies.version>2.1.10.RELEASE</spring-boot-dependencies.version>
-    <spring-boot-maven-plugin.version>2.1.3.RELEASE</spring-boot-maven-plugin.version>
+    <spring-boot-maven-plugin.version>2.1.10.RELEASE</spring-boot-maven-plugin.version>
 
-    <jackson.version>2.9.0.pr4</jackson.version>
     <!-- Maven and Surefire plugins -->
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <api-security-java.version>0.2.10</api-security-java.version>
     <commons-io.version>2.4</commons-io.version>
 
-    <spring-boot-dependencies.version>2.1.3.RELEASE</spring-boot-dependencies.version>
+    <spring-boot-dependencies.version>2.1.10.RELEASE</spring-boot-dependencies.version>
     <spring-boot-maven-plugin.version>2.1.3.RELEASE</spring-boot-maven-plugin.version>
 
     <jackson.version>2.9.0.pr4</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,13 +24,13 @@
     <java.version>1.8</java.version>
 
     <!-- Dependency Versions -->
-    <api-helper-java.version>1.1.0-rc1</api-helper-java.version>
+    <api-helper-java.version>1.4.3</api-helper-java.version>
     <structured-logging.version>1.4.0-rc2</structured-logging.version>
     <aws-java-sdk.version>1.11.486</aws-java-sdk.version>
-    <company-accounts-library.version>1.2.4</company-accounts-library.version>
-    <private-api-sdk-java.version>2.0.27</private-api-sdk-java.version>
-    <api-sdk-manager-java-library.version>1.0.1</api-sdk-manager-java-library.version>
-    <api-security-java.version>0.2.10</api-security-java.version>
+    <company-accounts-library.version>1.2.7</company-accounts-library.version>
+    <private-api-sdk-java.version>2.0.64</private-api-sdk-java.version>
+    <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
+    <api-security-java.version>0.2.16</api-security-java.version>
     <commons-io.version>2.4</commons-io.version>
 
     <spring-boot-dependencies.version>2.1.10.RELEASE</spring-boot-dependencies.version>


### PR DESCRIPTION
This new version ensures to update the version of jackson-annotations dependency from 2.9.0 to 2.9.10
to ensure that Sonar does not complain about the unsafe data binding and unsafe deserialisation issue