### PR TITLE
Add interceptor class for related party transactions

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
@@ -16,6 +16,7 @@ import uk.gov.companieshouse.api.accounts.interceptor.LoansToDirectorsIntercepto
 import uk.gov.companieshouse.api.accounts.interceptor.LoggingInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.OpenTransactionInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.PreviousPeriodInterceptor;
+import uk.gov.companieshouse.api.accounts.interceptor.RelatedPartyTransactionsInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.SmallFullInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.TransactionInterceptor;
 import uk.gov.companieshouse.api.accounts.utility.AccountsNotesPathsYamlReader;
@@ -67,6 +68,9 @@ public class CompanyAccountsApplication implements WebMvcConfigurer {
     
     @Autowired
     private LoansToDirectorsInterceptor loansToDirectorsInterceptor;
+
+    @Autowired
+    private RelatedPartyTransactionsInterceptor relatedPartyTransactionsInterceptor;
 
     public static void main(String[] args) {
 
@@ -155,5 +159,11 @@ public class CompanyAccountsApplication implements WebMvcConfigurer {
                         "/transactions/{transactionId}/company-accounts/{companyAccountId}/small-full/notes/loans-to-directors/**")
                 .excludePathPatterns(
                         "/transactions/{transactionId}/company-accounts/{companyAccountId}/small-full/notes/loans-to-directors");
+
+        registry.addInterceptor(relatedPartyTransactionsInterceptor)
+                .addPathPatterns(
+                        "/transactions/{transactionId}/company-accounts/{companyAccountId}/small-full/notes/related-party-transactions/**")
+                .excludePathPatterns(
+                        "/transactions/{transactionId}/company-accounts/{companyAccountId}/small-full/notes/related-party-transactions");
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/RelatedPartyTransactionsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/RelatedPartyTransactionsInterceptor.java
@@ -1,0 +1,86 @@
+package uk.gov.companieshouse.api.accounts.interceptor;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import uk.gov.companieshouse.api.accounts.AttributeName;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
+import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
+import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
+import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.relatedpartytransactions.RelatedPartyTransactions;
+import uk.gov.companieshouse.api.accounts.service.impl.RelatedPartyTransactionsServiceImpl;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.accounts.utility.LoggingHelper;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+@Component
+public class RelatedPartyTransactionsInterceptor extends HandlerInterceptorAdapter {
+
+    @Autowired
+    private RelatedPartyTransactionsServiceImpl relatedPartyTransactionsService;
+
+    private static final String COMPANY_ACCOUNTS_ID_PATH_VARIABLE = "companyAccountId";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) {
+
+        Transaction transaction = (Transaction) request
+                .getAttribute(AttributeName.TRANSACTION.getValue());
+
+        Map<String, String> pathVariables = (Map) request
+                .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        String companyAccountId = pathVariables.get(COMPANY_ACCOUNTS_ID_PATH_VARIABLE);
+
+        try {
+            ResponseObject<RelatedPartyTransactions> responseObject = relatedPartyTransactionsService.find(companyAccountId, request);
+
+            if (!responseObject.getStatus().equals(ResponseStatus.FOUND)) {
+
+                LoggingHelper.logInfo(
+                        companyAccountId, transaction, "Related party transaction not found", request);
+
+                response.setStatus(HttpStatus.NOT_FOUND.value());
+                return false;
+            }
+
+            SmallFull smallFull = (SmallFull) request
+                    .getAttribute(AttributeName.SMALLFULL.getValue());
+
+            String smallFullRelatedPartyTransactionsLink =
+                    smallFull.getLinks().get(SmallFullLinkType.RELATED_PARTY_TRANSACTIONS.getLink());
+
+            RelatedPartyTransactions relatedPartyTransactions = responseObject.getData();
+            String relatedPartyTransactionsSelfLink = relatedPartyTransactions.getLinks().get(BasicLinkType.SELF.getLink());
+
+            if (!relatedPartyTransactionsSelfLink.equals(smallFullRelatedPartyTransactionsLink)) {
+
+                LoggingHelper.logInfo(
+                        companyAccountId, transaction, "Related party transactions link not present in small full resource", request);
+
+                response.setStatus(HttpStatus.BAD_REQUEST.value());
+                return false;
+            }
+
+            request.setAttribute(AttributeName.RELATED_PARTY_TRANSACTIONS.getValue(), relatedPartyTransactions);
+            return true;
+
+        } catch (DataException e) {
+
+            LoggingHelper.logException(
+                    companyAccountId, transaction, "Failed to retrieve related party transactions resource", e, request);
+
+            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+            return false;
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplicationTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplicationTest.java
@@ -21,6 +21,7 @@ import uk.gov.companieshouse.api.accounts.interceptor.LoansToDirectorsIntercepto
 import uk.gov.companieshouse.api.accounts.interceptor.LoggingInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.OpenTransactionInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.PreviousPeriodInterceptor;
+import uk.gov.companieshouse.api.accounts.interceptor.RelatedPartyTransactionsInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.SmallFullInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.TransactionInterceptor;
 import uk.gov.companieshouse.api.interceptor.TokenPermissionsInterceptor;
@@ -68,10 +69,13 @@ public class CompanyAccountsApplicationTest {
     private LoansToDirectorsInterceptor loansToDirectorsInterceptor;
 
     @Mock
+    private RelatedPartyTransactionsInterceptor relatedPartyTransactionsInterceptor;
+
+    @Mock
     private LoggingInterceptor loggingInterceptor;
 
     @Mock
-    private TokenPermissionsInterceptor tokenPermissiosInterceptor;
+    private TokenPermissionsInterceptor tokenPermissionsInterceptor;
 
     @Mock
     private AuthenticationInterceptor authenticationInterceptor;
@@ -86,7 +90,7 @@ public class CompanyAccountsApplicationTest {
     @DisplayName("Test if interceptors are added correctly")
     void testAddInterceptors() {
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(loggingInterceptor);
-        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(tokenPermissiosInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(tokenPermissionsInterceptor);
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(authenticationInterceptor);
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(transactionInterceptor);
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(openTransactionInterceptor);
@@ -98,13 +102,14 @@ public class CompanyAccountsApplicationTest {
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(cicReportInterceptor);
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(directorsReportInterceptor);
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(loansToDirectorsInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(relatedPartyTransactionsInterceptor);
         when(interceptorRegistration.addPathPatterns(Mockito.<String>any())).thenReturn(interceptorRegistration);
         when(interceptorRegistration.excludePathPatterns(anyString())).thenReturn(interceptorRegistration);
 
         companyAccountsApplication.addInterceptors(interceptorRegistry);
 
         InOrder inOrder = Mockito.inOrder(interceptorRegistry);
-        inOrder.verify(interceptorRegistry).addInterceptor(tokenPermissiosInterceptor);
+        inOrder.verify(interceptorRegistry).addInterceptor(tokenPermissionsInterceptor);
         inOrder.verify(interceptorRegistry).addInterceptor(authenticationInterceptor);
 
         verifyNoMoreInteractions(interceptorRegistry);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/RelatedPartyTransactionsInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/RelatedPartyTransactionsInterceptorTest.java
@@ -1,0 +1,157 @@
+package uk.gov.companieshouse.api.accounts.interceptor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerMapping;
+import uk.gov.companieshouse.api.accounts.AttributeName;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
+import uk.gov.companieshouse.api.accounts.links.SmallFullLinkType;
+import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
+import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.relatedpartytransactions.RelatedPartyTransactions;
+import uk.gov.companieshouse.api.accounts.service.impl.RelatedPartyTransactionsServiceImpl;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RelatedPartyTransactionsInterceptorTest {
+
+    @Mock
+    private RelatedPartyTransactionsServiceImpl relatedPartyTransactionsService;
+
+    @InjectMocks
+    private RelatedPartyTransactionsInterceptor interceptor;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private Transaction transaction;
+
+    @Mock
+    private RelatedPartyTransactions relatedPartyTransactions;
+
+    @Mock
+    private ResponseObject responseObject;
+
+    @Mock
+    private SmallFull smallFull;
+
+    @Mock
+    private Map<String, String> smallFullLinks;
+
+    @Mock
+    private Map<String, String> relatedPartyTransactionsLinks;
+
+    private static final String COMPANY_ACCOUNTS_ID_PATH_VAR = "companyAccountId";
+    private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
+    private static final String RELATED_PARTY_TRANSACTIONS_SELF_LINK = "relatedPartyTransactionsSelfLink";
+
+    @BeforeEach
+    void setUp() {
+
+        doReturn(transaction).when(request).getAttribute(AttributeName.TRANSACTION.getValue());
+
+        Map<String, String> pathVariables = new HashMap<>();
+        pathVariables.put(COMPANY_ACCOUNTS_ID_PATH_VAR, COMPANY_ACCOUNTS_ID);
+
+        doReturn(pathVariables).when(request).getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+    }
+
+    @Test
+    @DisplayName("Related party transactions interceptor - success")
+    void relatedPartyTransactionsInterceptorSuccess() throws DataException {
+
+        when(relatedPartyTransactionsService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(responseObject);
+        when(responseObject.getStatus()).thenReturn(ResponseStatus.FOUND);
+        when(responseObject.getData()).thenReturn(relatedPartyTransactions);
+
+        doReturn(smallFull).when(request).getAttribute(AttributeName.SMALLFULL.getValue());
+        when(smallFull.getLinks()).thenReturn(smallFullLinks);
+        when(smallFullLinks.get(SmallFullLinkType.RELATED_PARTY_TRANSACTIONS.getLink())).thenReturn(
+                RELATED_PARTY_TRANSACTIONS_SELF_LINK);
+
+        when(relatedPartyTransactions.getLinks()).thenReturn(relatedPartyTransactionsLinks);
+        when(relatedPartyTransactionsLinks.get(BasicLinkType.SELF.getLink())).thenReturn(
+                RELATED_PARTY_TRANSACTIONS_SELF_LINK);
+
+        boolean preHandle = interceptor.preHandle(request, response, new Object());
+
+        assertTrue(preHandle);
+
+        verify(request).setAttribute(AttributeName.RELATED_PARTY_TRANSACTIONS.getValue(), relatedPartyTransactions);
+    }
+
+    @Test
+    @DisplayName("Related party transactions interceptor - related party transactions not found")
+    void relatedPartyTransactionsInterceptorRelatedPartyTransactionNotFound() throws DataException {
+
+        when(relatedPartyTransactionsService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(responseObject);
+        when(responseObject.getStatus()).thenReturn(ResponseStatus.NOT_FOUND);
+
+        boolean preHandle = interceptor.preHandle(request, response, new Object());
+
+        assertFalse(preHandle);
+
+        verify(response).setStatus(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    @DisplayName("Related party transactions interceptor - parent link not found")
+    void relatedPartyTransactionsInterceptorParentLinkNotFound() throws DataException {
+
+        when(relatedPartyTransactionsService.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(responseObject);
+        when(responseObject.getStatus()).thenReturn(ResponseStatus.FOUND);
+        when(responseObject.getData()).thenReturn(relatedPartyTransactions);
+
+        doReturn(smallFull).when(request).getAttribute(AttributeName.SMALLFULL.getValue());
+        when(smallFull.getLinks()).thenReturn(smallFullLinks);
+        when(smallFullLinks.get(SmallFullLinkType.RELATED_PARTY_TRANSACTIONS.getLink())).thenReturn(null);
+
+        when(relatedPartyTransactions.getLinks()).thenReturn(relatedPartyTransactionsLinks);
+        when(relatedPartyTransactionsLinks.get(BasicLinkType.SELF.getLink())).thenReturn(
+                RELATED_PARTY_TRANSACTIONS_SELF_LINK);
+
+        boolean preHandle = interceptor.preHandle(request, response, new Object());
+
+        assertFalse(preHandle);
+
+        verify(response).setStatus(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("Related party transactions interceptor - data exception")
+    void relatedPartyTransactionsInterceptorDataException() throws DataException {
+
+        when(relatedPartyTransactionsService.find(COMPANY_ACCOUNTS_ID, request)).thenThrow(DataException.class);
+
+        boolean preHandle = interceptor.preHandle(request, response, new Object());
+
+        assertFalse(preHandle);
+
+        verify(response).setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+}


### PR DESCRIPTION
Adds interceptor class and unit tests for related party transactions. This interceptor sets the request attribute for related party transactions with the desired url mapping