### PR TITLE
Fix sonar code smell issues

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/Costs.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/Costs.java
@@ -6,14 +6,14 @@ import java.util.Map;
 public class Costs {
 
     @JsonProperty("costs")
-    private Map<String, Cost> costsList;
+    private Map<String, Cost> costsMap;
 
     public Map<String, Cost> getCostsList() {
-        return costsList;
+        return costsMap;
     }
 
     public void setCostsList(
             Map<String, Cost> costs) {
-        this.costsList = costs;
+        this.costsMap = costs;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/Costs.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/Costs.java
@@ -6,14 +6,14 @@ import java.util.Map;
 public class Costs {
 
     @JsonProperty("costs")
-    private Map<String, Cost> costs;
+    private Map<String, Cost> costsList;
 
-    public Map<String, Cost> getCosts() {
-        return costs;
+    public Map<String, Cost> getCostsList() {
+        return costsList;
     }
 
-    public void setCosts(
+    public void setCostsList(
             Map<String, Cost> costs) {
-        this.costs = costs;
+        this.costsList = costs;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/Costs.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/Costs.java
@@ -8,11 +8,11 @@ public class Costs {
     @JsonProperty("costs")
     private Map<String, Cost> costsMap;
 
-    public Map<String, Cost> getCostsList() {
+    public Map<String, Cost> getCostsMap() {
         return costsMap;
     }
 
-    public void setCostsList(
+    public void setCostsMap(
             Map<String, Cost> costs) {
         this.costsMap = costs;
     }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Error.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Error.java
@@ -17,7 +17,7 @@ public class Error {
 
     @JsonProperty("error")
     @Field("error")
-    private String error;
+    private String errorMessage;
 
     @JsonProperty("error_values")
     @Field("error_values")
@@ -48,7 +48,7 @@ public class Error {
             throw new IllegalArgumentException("Type cannot be null or empty");
         }
 
-        this.error = error;
+        this.errorMessage = error;
         this.location = location;
         this.locationType = locationType;
         this.type = type;
@@ -63,7 +63,7 @@ public class Error {
             return false;
         }
         Error error1 = (Error) o;
-        return Objects.equals(getError(), error1.getError()) &&
+        return Objects.equals(getErrorMessage(), error1.getErrorMessage()) &&
             Objects.equals(getErrorValues(), error1.getErrorValues()) &&
             Objects.equals(getLocation(), error1.getLocation()) &&
             Objects.equals(getLocationType(), error1.getLocationType()) &&
@@ -73,7 +73,7 @@ public class Error {
     @Override
     public int hashCode() {
         return Objects
-            .hash(getError(), getErrorValues(), getLocation(), getLocationType(), getType());
+            .hash(getErrorMessage(), getErrorValues(), getLocation(), getLocationType(), getType());
     }
 
     /**
@@ -94,8 +94,8 @@ public class Error {
         errorValues.put(argument, value);
     }
 
-    public String getError() {
-        return error;
+    public String getErrorMessage() {
+        return errorMessage;
     }
 
     public Map<String, String> getErrorValues() {

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Errors.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Errors.java
@@ -13,7 +13,7 @@ public class Errors {
 
     @JsonProperty("errors")
     @Field("errors")
-    private Set<Error> errorsList = new HashSet<>();
+    private Set<Error> errorsSet = new HashSet<>();
 
     /**
      * Add the given {@link Error}
@@ -26,7 +26,7 @@ public class Errors {
             throw new IllegalArgumentException("Error cannot be null");
         }
 
-        return errorsList.add(error);
+        return errorsSet.add(error);
     }
 
     /**
@@ -35,7 +35,7 @@ public class Errors {
      * @return True or false
      */
     public boolean hasErrors() {
-        return !errorsList.isEmpty();
+        return !errorsSet.isEmpty();
     }
 
     /**
@@ -44,7 +44,7 @@ public class Errors {
      * @return Set of errors
      */
     public Set<Error> getErrors() {
-        return this.errorsList;
+        return this.errorsSet;
     }
 
     /**
@@ -57,7 +57,7 @@ public class Errors {
             throw new IllegalArgumentException("Error cannot be null");
         }
 
-        return errorsList.contains(error);
+        return errorsSet.contains(error);
     }
 
     /**
@@ -67,7 +67,7 @@ public class Errors {
      */
     @JsonIgnore
     public int getErrorCount() {
-        return errorsList.size();
+        return errorsSet.size();
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Errors.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/validation/Errors.java
@@ -13,7 +13,7 @@ public class Errors {
 
     @JsonProperty("errors")
     @Field("errors")
-    private Set<Error> errors = new HashSet<>();
+    private Set<Error> errorsList = new HashSet<>();
 
     /**
      * Add the given {@link Error}
@@ -26,7 +26,7 @@ public class Errors {
             throw new IllegalArgumentException("Error cannot be null");
         }
 
-        return errors.add(error);
+        return errorsList.add(error);
     }
 
     /**
@@ -35,7 +35,7 @@ public class Errors {
      * @return True or false
      */
     public boolean hasErrors() {
-        return !errors.isEmpty();
+        return !errorsList.isEmpty();
     }
 
     /**
@@ -44,7 +44,7 @@ public class Errors {
      * @return Set of errors
      */
     public Set<Error> getErrors() {
-        return this.errors;
+        return this.errorsList;
     }
 
     /**
@@ -57,7 +57,7 @@ public class Errors {
             throw new IllegalArgumentException("Error cannot be null");
         }
 
-        return errors.contains(error);
+        return errorsList.contains(error);
     }
 
     /**
@@ -67,7 +67,7 @@ public class Errors {
      */
     @JsonIgnore
     public int getErrorCount() {
-        return errors.size();
+        return errorsList.size();
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/request/AccountsNoteConverter.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/request/AccountsNoteConverter.java
@@ -20,7 +20,7 @@ public class AccountsNoteConverter {
 
             if(ACCOUNTS_NOTE_MAP.get(accountsNote.getAccountType()) == null) {
 
-                ACCOUNTS_NOTE_MAP.put(accountsNote.getAccountType(), new EnumMap<NoteType, AccountingNoteType>(NoteType.class));
+                ACCOUNTS_NOTE_MAP.put(accountsNote.getAccountType(), new EnumMap<>(NoteType.class));
             }
 
             ACCOUNTS_NOTE_MAP.get(accountsNote.getAccountType()).put(accountsNote.getNoteType(), accountsNote);

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CostServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CostServiceImpl.java
@@ -45,7 +45,7 @@ public class CostServiceImpl implements CostService {
 
             for (int i = 0; i < payableResources.size(); i++) {
 
-                costArray[i] = costs.getCostsList().get(payableResources.get(i).getResource());
+                costArray[i] = costs.getCostsMap().get(payableResources.get(i).getResource());
             }
 
             return costArray;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CostServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/CostServiceImpl.java
@@ -45,7 +45,7 @@ public class CostServiceImpl implements CostService {
 
             for (int i = 0; i < payableResources.size(); i++) {
 
-                costArray[i] = costs.getCosts().get(payableResources.get(i).getResource());
+                costArray[i] = costs.getCostsList().get(payableResources.get(i).getResource());
             }
 
             return costArray;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/FilingServiceImpl.java
@@ -159,7 +159,7 @@ public class FilingServiceImpl implements FilingService {
     private boolean isValidIxbrl(String fileLocation) {
 
         boolean isIxbrlValid = false;
-        if (!environmentReader.getOptionalBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR)) {
+        if (!environmentReader.getOptionalBoolean(DISABLE_IXBRL_VALIDATION_ENV_VAR).booleanValue()) {
             String ixbrlData = downloadIxbrlFromLocation(fileLocation);
 
             if (ixbrlData != null) {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/ApplicationConfigurationTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/ApplicationConfigurationTest.java
@@ -9,25 +9,25 @@ import org.springframework.web.client.RestTemplate;
 
 import uk.gov.companieshouse.environment.EnvironmentReader;
 
-public class ApplicationConfigurationTest {
+class ApplicationConfigurationTest {
 
 	private ApplicationConfiguration applicationConfiguration;
 	
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 		applicationConfiguration = new ApplicationConfiguration();
 	}
 	
 	@Test
 	@DisplayName("Get the bean for sending REST requests")
-	public void getBeanForRestRequests() {
+	void getBeanForRestRequests() {
 		RestTemplate bean = applicationConfiguration.getRestTemplate();
 		assertNotNull(bean);
 	}
 	
 	@Test
 	@DisplayName("Get the bean for reading environment variables")
-	public void getBeanForReadingEnvironmentVariables() {
+	void getBeanForReadingEnvironmentVariables() {
 		EnvironmentReader bean = applicationConfiguration.getEnvironmentReader();
 		assertNotNull(bean);
 	}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplicationTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplicationTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CompanyAccountsApplicationTest {
+class CompanyAccountsApplicationTest {
 
     @InjectMocks
     private CompanyAccountsApplication companyAccountsApplication;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/configuration/AmazonS3ConfigurationTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/configuration/AmazonS3ConfigurationTest.java
@@ -18,7 +18,7 @@ import com.amazonaws.services.s3.AmazonS3;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class AmazonS3ConfigurationTest {
+class AmazonS3ConfigurationTest {
 
     @InjectMocks
     private AmazonS3Configuration amazonS3Configuration;
@@ -27,13 +27,13 @@ public class AmazonS3ConfigurationTest {
     private EnvironmentReader environmentReader;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         when(environmentReader.getMandatoryString("REGION_NAME_FOR_AMAZON_S3")).thenReturn("eu-west-2");
     }
 
     @Test
     @DisplayName("Test get Amazon S3 without Providing Proxy")
-    public void testGetAmazonS3WithoutProxy() {
+    void testGetAmazonS3WithoutProxy() {
         AmazonS3 result = amazonS3Configuration.getAmazonS3();
         assertNotNull(result);
         verifyProxyCheck();
@@ -42,7 +42,7 @@ public class AmazonS3ConfigurationTest {
 
     @Test
     @DisplayName("Test get Amazon S3 by Providing Proxy")
-    public void testGetAmazonS3WithProxy() {
+    void testGetAmazonS3WithProxy() {
         when(environmentReader.getOptionalInteger("HTTP_URL_CONNECTION_PROXY_PORT")).thenReturn(8080);
         when(environmentReader.getOptionalString("IMAGE_CLOUD_PROXY_HOST")).thenReturn("PROXY_HOST");
         AmazonS3 result = amazonS3Configuration.getAmazonS3();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/ApprovalControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/ApprovalControllerTest.java
@@ -82,7 +82,7 @@ class ApprovalControllerTest {
         when(bindingResult.hasErrors()).thenReturn(false);
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject<Approval> responseObject = new ResponseObject<>(ResponseStatus.CREATED, approval);
+        ResponseObject responseObject = new ResponseObject<>(ResponseStatus.CREATED, approval);
         when(approvalService.create(approval, transaction, COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(responseObject);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/ApprovalControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/ApprovalControllerTest.java
@@ -37,7 +37,7 @@ import uk.gov.companieshouse.api.accounts.utility.ApiResponseMapper;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class ApprovalControllerTest {
+class ApprovalControllerTest {
 
     @Mock
     private HttpServletRequest request;
@@ -82,7 +82,7 @@ public class ApprovalControllerTest {
         when(bindingResult.hasErrors()).thenReturn(false);
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED, approval);
+        ResponseObject<Approval> responseObject = new ResponseObject<>(ResponseStatus.CREATED, approval);
         when(approvalService.create(approval, transaction, COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(responseObject);
 
@@ -142,7 +142,7 @@ public class ApprovalControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND, approval);
+        ResponseObject<Approval> responseObject = new ResponseObject<>(ResponseStatus.FOUND, approval);
         when(approvalService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(responseObject);
 
@@ -186,7 +186,7 @@ public class ApprovalControllerTest {
 
         when(bindingResult.hasErrors()).thenReturn(false);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED, approval);
+        ResponseObject<Approval> responseObject = new ResponseObject<>(ResponseStatus.UPDATED, approval);
         when(approvalService.update(approval, transaction, COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(responseObject);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CicApprovalControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CicApprovalControllerTest.java
@@ -40,7 +40,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CicApprovalControllerTest {
+class CicApprovalControllerTest {
 
     @Mock
     private HttpServletRequest request;
@@ -80,7 +80,7 @@ public class CicApprovalControllerTest {
 
     @Test
     @DisplayName("Tests the successful creation of a CicApproval resource")
-    public void canCreateCicReportApproval() throws DataException {
+    void canCreateCicReportApproval() throws DataException {
         when(request.getAttribute("transaction")).thenReturn(transaction);
         ResponseObject successCreateResponse = new ResponseObject(ResponseStatus.CREATED,
                 cicApproval);
@@ -121,7 +121,7 @@ public class CicApprovalControllerTest {
 
     @Test
     @DisplayName("Test the retreval of a CicApproval resource")
-    public void canRetrieveCicReportApproval() throws DataException {
+    void canRetrieveCicReportApproval() throws DataException {
         when(request.getAttribute("transaction")).thenReturn(transaction);
         ResponseObject successFindResponse = new ResponseObject(ResponseStatus.FOUND,
                 cicApproval);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CicReportControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CicReportControllerTest.java
@@ -27,7 +27,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CicReportControllerTest {
+class CicReportControllerTest {
 
     @Mock
     private CicReportService service;
@@ -55,7 +55,7 @@ public class CicReportControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED, cicReport);
+        ResponseObject<CicReport> responseObject = new ResponseObject<>(ResponseStatus.CREATED, cicReport);
         when(service.create(cicReport, transaction, COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(responseObject);
 
@@ -96,7 +96,7 @@ public class CicReportControllerTest {
     @DisplayName("Get cic report - success")
     void getCicReportSuccess() throws DataException {
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND, cicReport);
+        ResponseObject<CicReport> responseObject = new ResponseObject<>(ResponseStatus.FOUND, cicReport);
         when(service.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(responseObject);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.FOUND)

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CicStatementsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CicStatementsControllerTest.java
@@ -34,7 +34,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CicStatementsControllerTest {
+class CicStatementsControllerTest {
 
     @Mock
     private HttpServletRequest request;
@@ -79,7 +79,7 @@ public class CicStatementsControllerTest {
         when(bindingResult.hasErrors()).thenReturn(false);
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED, cicStatements);
+        ResponseObject<CicStatements> responseObject = new ResponseObject<>(ResponseStatus.CREATED, cicStatements);
         when(service.create(cicStatements, transaction, COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(responseObject);
 
@@ -138,7 +138,7 @@ public class CicStatementsControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND, cicStatements);
+        ResponseObject<CicStatements> responseObject = new ResponseObject<>(ResponseStatus.FOUND, cicStatements);
         when(service.find(COMPANY_ACCOUNTS_ID, request)).thenReturn(responseObject);
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.FOUND)
@@ -181,7 +181,7 @@ public class CicStatementsControllerTest {
                 .thenReturn(CIC_STATEMENTS_LINK);
         when(bindingResult.hasErrors()).thenReturn(false);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED, cicStatements);
+        ResponseObject<CicStatements> responseObject = new ResponseObject<>(ResponseStatus.UPDATED, cicStatements);
         when(service.update(cicStatements, transaction, COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(responseObject);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CompanyAccountControllerTest.java
@@ -2,15 +2,12 @@ package uk.gov.companieshouse.api.accounts.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import java.security.NoSuchAlgorithmException;
 import javax.servlet.http.HttpServletRequest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -30,14 +27,14 @@ import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.service.CompanyAccountService;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
 import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
-import uk.gov.companieshouse.api.accounts.validation.CompanyAccountValidator;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.accounts.transformer.CompanyAccountTransformer;
 import uk.gov.companieshouse.api.accounts.utility.ApiResponseMapper;
+import uk.gov.companieshouse.api.accounts.validation.CompanyAccountValidator;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CompanyAccountControllerTest {
+class CompanyAccountControllerTest {
 
     @Mock
     private Transaction transactionMock;
@@ -66,11 +63,6 @@ public class CompanyAccountControllerTest {
     @InjectMocks
     private CompanyAccountController companyAccountController;
 
-    @BeforeEach
-    public void setUp() {
-
-    }
-
     @Test
     @DisplayName("Tests the successful creation of an company account resource and patching transaction resource")
     void canCreateAccountSuccessfully() throws DataException, PatchException {
@@ -79,7 +71,7 @@ public class CompanyAccountControllerTest {
         when(validator.validateCompanyAccount(transactionMock)).thenReturn(errors);
 
         when(httpServletRequestMock.getAttribute("transaction")).thenReturn(transactionMock);
-        ResponseObject responseObject = new ResponseObject<>(ResponseStatus.CREATED,
+        ResponseObject<CompanyAccount> responseObject = new ResponseObject<>(ResponseStatus.CREATED,
             companyAccount);
         when(companyAccountServiceMock
                 .create(companyAccount, transactionMock, httpServletRequestMock))
@@ -108,7 +100,7 @@ public class CompanyAccountControllerTest {
         when(validator.validateCompanyAccount(transactionMock)).thenReturn(errors);
 
         when(httpServletRequestMock.getAttribute("transaction")).thenReturn(transactionMock);
-        ResponseObject responseObject = new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR,
+        ResponseObject<CompanyAccount> responseObject = new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR,
             companyAccount);
         when(companyAccountServiceMock
                 .create(companyAccount, transactionMock, httpServletRequestMock))
@@ -149,7 +141,7 @@ public class CompanyAccountControllerTest {
 
     @Test
     @DisplayName("Tests the successful get of a company account resource")
-    public void canGetCompanyAccount() throws NoSuchAlgorithmException {
+    void canGetCompanyAccount() throws NoSuchAlgorithmException {
         doReturn(companyAccount).when(httpServletRequestMock)
                 .getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
         ResponseEntity response = companyAccountController
@@ -162,7 +154,7 @@ public class CompanyAccountControllerTest {
 
     @Test
     @DisplayName("Tests the unsuccessful get of a company account resource")
-    public void getCompanyAccountFail() throws NoSuchAlgorithmException {
+    void getCompanyAccountFail() throws NoSuchAlgorithmException {
         doReturn(null).when(httpServletRequestMock)
                 .getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
         ResponseEntity response = companyAccountController

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CostControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CostControllerTest.java
@@ -23,7 +23,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CostControllerTest {
+class CostControllerTest {
 
     @Mock
     private CostService costService;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/CurrentPeriodControllerTest.java
@@ -33,7 +33,7 @@ import uk.gov.companieshouse.api.accounts.utility.ApiResponseMapper;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CurrentPeriodControllerTest {
+class CurrentPeriodControllerTest {
 
     @Mock
     private HttpServletRequest request;
@@ -61,9 +61,9 @@ public class CurrentPeriodControllerTest {
 
     @Test
     @DisplayName("Tests the successful creation of a currentPeriod resource")
-    public void canCreateCurrentPeriod() throws DataException {
+    void canCreateCurrentPeriod() throws DataException {
         when(request.getAttribute("transaction")).thenReturn(transaction);
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED,
+        ResponseObject<CurrentPeriod> responseObject = new ResponseObject<>(ResponseStatus.CREATED,
             currentPeriod);
 
         doReturn(responseObject).when(currentPeriodService)
@@ -85,10 +85,10 @@ public class CurrentPeriodControllerTest {
 
     @Test
     @DisplayName("Test the retreval of a current period resource")
-    public void canRetrieveCurrentPeriod() throws DataException {
+    void canRetrieveCurrentPeriod() throws DataException {
         when(request.getAttribute("transaction")).thenReturn(transaction);
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.OK).body(currentPeriod);
-        doReturn(new ResponseObject(ResponseStatus.FOUND,
+        doReturn(new ResponseObject<CurrentPeriod>(ResponseStatus.FOUND,
             currentPeriod)).when(currentPeriodService).find("123456", request);
         when(apiResponseMapper.mapGetResponse(currentPeriod,
             request)).thenReturn(responseEntity);
@@ -102,13 +102,13 @@ public class CurrentPeriodControllerTest {
 
     @Test
     @DisplayName("Tests the successful update of a currentPeriod resource")
-    public void canUpdateCurrentPeriod() throws DataException {
+    void canUpdateCurrentPeriod() throws DataException {
         doReturn(smallFull).when(request)
             .getAttribute(AttributeName.SMALLFULL.getValue());
         HashMap<String, String> links = new HashMap<>();
         links.put(SmallFullLinkType.CURRENT_PERIOD.getLink(), "link");
         when(smallFull.getLinks()).thenReturn(links);
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED,
+        ResponseObject<CurrentPeriod> responseObject = new ResponseObject<>(ResponseStatus.UPDATED,
             currentPeriod);
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.NO_CONTENT).build();
         when(apiResponseMapper.map(responseObject.getStatus(),
@@ -128,7 +128,7 @@ public class CurrentPeriodControllerTest {
 
     @Test
     @DisplayName("Tests the unsuccessful update of a currentPeriod resource")
-    public void canUpdateCurrentPeriodFail() throws DataException {
+    void canUpdateCurrentPeriodFail() throws DataException {
         doReturn(smallFull).when(request)
             .getAttribute(AttributeName.SMALLFULL.getValue());
         HashMap<String, String> links = new HashMap<>();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/DirectorStatementsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/DirectorStatementsControllerTest.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.when;
 class DirectorStatementsControllerTest {
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
-    private static final String STATEMENTS_ID = "statementsId";
     private static final String STATEMENTS_LINK = "statementsLink";
 
     @Mock
@@ -81,7 +80,7 @@ class DirectorStatementsControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED,
+        ResponseObject<Statements> responseObject = new ResponseObject<>(ResponseStatus.CREATED,
                 statements);
         when(statementsService.create(statements, transaction,
                 COMPANY_ACCOUNTS_ID, request)).thenReturn(responseObject);
@@ -185,7 +184,7 @@ class DirectorStatementsControllerTest {
 
         when(bindingResult.hasErrors()).thenReturn(false);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED,
+        ResponseObject<Statements> responseObject = new ResponseObject<>(ResponseStatus.UPDATED,
                 statements);
         when(statementsService.update(statements, transaction,
                 COMPANY_ACCOUNTS_ID, request)).thenReturn(responseObject);
@@ -234,7 +233,7 @@ class DirectorStatementsControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND,
+        ResponseObject<Statements> responseObject = new ResponseObject<>(ResponseStatus.FOUND,
                 statements);
         when(statementsService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(responseObject);
@@ -279,7 +278,7 @@ class DirectorStatementsControllerTest {
 
         when(request.getAttribute(anyString())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED,
+        ResponseObject<Statements> responseObject = new ResponseObject<>(ResponseStatus.UPDATED,
                 statements);
 
         when(statementsService.delete(COMPANY_ACCOUNTS_ID, request))

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/DirectorsApprovalControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/DirectorsApprovalControllerTest.java
@@ -79,10 +79,10 @@ class DirectorsApprovalControllerTest {
 
     @Test
     @DisplayName("Tests the successful creation of a directors approval resource")
-    public void canCreateDirectorsApproval() throws DataException {
+    void canCreateDirectorsApproval() throws DataException {
 
         when(request.getAttribute("transaction")).thenReturn(transaction);
-        ResponseObject successCreateResponse = new ResponseObject(ResponseStatus.CREATED,
+        ResponseObject<DirectorsApproval> successCreateResponse = new ResponseObject<>(ResponseStatus.CREATED,
                 directorsApproval);
         doReturn(successCreateResponse).when(directorsApprovalService)
                 .create(any(DirectorsApproval.class), any(Transaction.class), anyString(),

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/DirectorsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/DirectorsControllerTest.java
@@ -41,7 +41,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class DirectorsControllerTest {
+class DirectorsControllerTest {
 
     @Mock
     private DirectorService directorService;
@@ -87,7 +87,7 @@ public class DirectorsControllerTest {
         when(bindingResult.hasErrors()).thenReturn(false);
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED, directorRest);
+        ResponseObject<Director> responseObject = new ResponseObject<>(ResponseStatus.CREATED, directorRest);
         when(directorService.create(directorRest, transaction, DIRECTORS_ID, request))
                 .thenReturn(responseObject);
 
@@ -163,7 +163,7 @@ public class DirectorsControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND, directorRest);
+        ResponseObject<Director> responseObject = new ResponseObject<>(ResponseStatus.FOUND, directorRest);
         when(directorService.find(DIRECTORS_ID, request))
                 .thenReturn(responseObject);
 
@@ -259,7 +259,7 @@ public class DirectorsControllerTest {
 
         when(bindingResult.hasErrors()).thenReturn(false);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED, directorRest);
+        ResponseObject<Director> responseObject = new ResponseObject<>(ResponseStatus.UPDATED, directorRest);
         when(directorService.update(directorRest, transaction, COMPANY_ACCOUNT_ID, request))
                 .thenReturn(responseObject);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/DirectorsReportControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/DirectorsReportControllerTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class DirectorsReportControllerTest {
+class DirectorsReportControllerTest {
 
     private static final String COMPANY_ACCOUNT_ID = "companyAccountId";
 
@@ -67,7 +67,7 @@ public class DirectorsReportControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED,
+        ResponseObject<DirectorsReport> responseObject = new ResponseObject<>(ResponseStatus.CREATED,
                 directorsReport);
         when(directorsReportService.create(directorsReport, transaction,
                 COMPANY_ACCOUNT_ID, request)).thenReturn(responseObject);
@@ -132,7 +132,7 @@ public class DirectorsReportControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND,
+        ResponseObject<DirectorsReport> responseObject = new ResponseObject<>(ResponseStatus.FOUND,
                 directorsReport);
         when(directorsReportService.find(COMPANY_ACCOUNT_ID, request))
                 .thenReturn(responseObject);
@@ -177,7 +177,7 @@ public class DirectorsReportControllerTest {
 
         when(request.getAttribute(anyString())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED,
+        ResponseObject<DirectorsReport> responseObject = new ResponseObject<>(ResponseStatus.UPDATED,
                 directorsReport);
 
         when(directorsReportService.delete(COMPANY_ACCOUNT_ID, request))

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/LoansControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/LoansControllerTest.java
@@ -41,7 +41,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class LoansControllerTest {
+class LoansControllerTest {
 
     @Mock
     private LoanServiceImpl loanService;
@@ -87,7 +87,7 @@ public class LoansControllerTest {
         when(bindingResult.hasErrors()).thenReturn(false);
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED, loanRest);
+        ResponseObject<Loan> responseObject = new ResponseObject<>(ResponseStatus.CREATED, loanRest);
         when(loanService.create(loanRest, transaction, LOANS_ID, request))
                 .thenReturn(responseObject);
 
@@ -156,7 +156,7 @@ public class LoansControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND, loanRest);
+        ResponseObject<Loan> responseObject = new ResponseObject<>(ResponseStatus.FOUND, loanRest);
         when(loanService.find(LOANS_ID, request))
                 .thenReturn(responseObject);
 
@@ -250,8 +250,7 @@ public class LoansControllerTest {
         when(loansToDirectors.getLoans()).thenReturn(loans);
         when(loans.get(LOANS_ID)).thenReturn(LOANS_LINK);
 
-
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED, loanRest);
+        ResponseObject<Loan> responseObject = new ResponseObject<>(ResponseStatus.UPDATED, loanRest);
         when(loanService.update(loanRest, transaction, COMPANY_ACCOUNT_ID, request))
                 .thenReturn(responseObject);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/NoteControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/NoteControllerTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class NoteControllerTest {
+class NoteControllerTest {
 
     @Mock
     private BindingResult bindingResult;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/PreviousPeriodControllerTest.java
@@ -37,7 +37,7 @@ import uk.gov.companieshouse.api.accounts.utility.ErrorMapper;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class PreviousPeriodControllerTest {
+class PreviousPeriodControllerTest {
 
     public static final String COMPANY_ACCOUNT_ID = "12345";
 
@@ -75,7 +75,7 @@ public class PreviousPeriodControllerTest {
     @DisplayName("Tests the successful creation of a previous period resource")
     void canCreatePreviousPeriod() throws DataException {
         doReturn(transaction).when(request).getAttribute(AttributeName.TRANSACTION.getValue());
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED, previousPeriod);
+        ResponseObject<PreviousPeriod> responseObject = new ResponseObject<>(ResponseStatus.CREATED, previousPeriod);
         doReturn(responseObject).when(previousPeriodService)
             .create(any(PreviousPeriod.class), any(Transaction.class), anyString(),
                 any(HttpServletRequest.class));
@@ -117,7 +117,7 @@ public class PreviousPeriodControllerTest {
 
     @Test
     @DisplayName("Test correct response when binding result has an error")
-    public void badRequestWhenBindingResultHasErrors() {
+    void badRequestWhenBindingResultHasErrors() {
 
         when(bindingResult.hasErrors()).thenReturn(true);
         when(errorMapper.mapBindingResultErrorsToErrorModel(bindingResult)).thenReturn(errors);
@@ -130,7 +130,7 @@ public class PreviousPeriodControllerTest {
 
     @Test
     @DisplayName("Test the successful retrieval of a previous period resource")
-    public void canRetrievePreviousPeriod() throws DataException {
+    void canRetrievePreviousPeriod() throws DataException {
         doReturn(transaction).when(request).getAttribute(AttributeName.TRANSACTION.getValue());
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.OK).body(previousPeriod);
@@ -147,10 +147,10 @@ public class PreviousPeriodControllerTest {
 
     @Test
     @DisplayName("PUT - Tests the successful update of a previous period resource")
-    public void canUpdatePreviousPeriod() throws DataException {
+    void canUpdatePreviousPeriod() throws DataException {
         mockSmallFull();
         mockPreviousPeriodLinkOnSmallFullResource();
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED, previousPeriod);
+        ResponseObject<PreviousPeriod> responseObject = new ResponseObject<>(ResponseStatus.UPDATED, previousPeriod);
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.NO_CONTENT).build();
         when(apiResponseMapper.map(responseObject.getStatus(),null, responseObject.getErrors()))
                 .thenReturn(responseEntity);
@@ -164,7 +164,7 @@ public class PreviousPeriodControllerTest {
 
     @Test
     @DisplayName("PUT - Tests the unsuccessful update of a previous period resource due to no link to small full resource")
-    public void canUpdatePreviousPeriodFail() {
+    void canUpdatePreviousPeriodFail() {
         mockSmallFull();
         when(smallFull.getLinks()).thenReturn(new HashMap<>());
         ResponseEntity response = previousPeriodController.update(previousPeriod, bindingResult, "123456", request);
@@ -174,7 +174,7 @@ public class PreviousPeriodControllerTest {
 
     @Test
     @DisplayName("PUT - Tests the unsuccessful update of a previous period resource due to binding result errors")
-    public void canUpdatePreviousPeriodFailBindingResultErrors() {
+    void canUpdatePreviousPeriodFailBindingResultErrors() {
         mockSmallFull();
         mockPreviousPeriodLinkOnSmallFullResource();
         when(bindingResult.hasErrors()).thenReturn(true);
@@ -187,7 +187,7 @@ public class PreviousPeriodControllerTest {
 
     @Test
     @DisplayName("Test the unsuccessful retrieval of a previous period resource")
-    public void canRetrievePreviousPeriodFailed() throws DataException {
+    void canRetrievePreviousPeriodFailed() throws DataException {
         doReturn(transaction).when(request).getAttribute(AttributeName.TRANSACTION.getValue());
 
         ResponseEntity responseEntity = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/ProfitAndLossControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/ProfitAndLossControllerTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ProfitAndLossControllerTest {
+class ProfitAndLossControllerTest {
 
     @Mock
     private ProfitAndLossService profitAndLossService;
@@ -91,7 +91,7 @@ public class ProfitAndLossControllerTest {
         when(bindingResult.hasErrors()).thenReturn(false);
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED, profitAndLoss);
+        ResponseObject<ProfitAndLoss> responseObject = new ResponseObject<>(ResponseStatus.CREATED, profitAndLoss);
         when(profitAndLossService.create(profitAndLoss, transaction, COMPANY_ACCOUNTS_ID, request, period))
         .thenReturn(responseObject);
 
@@ -160,7 +160,7 @@ public class ProfitAndLossControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND, profitAndLoss);
+        ResponseObject<ProfitAndLoss> responseObject = new ResponseObject<>(ResponseStatus.FOUND, profitAndLoss);
         when(profitAndLossService.find(COMPANY_ACCOUNTS_ID, period))
                 .thenReturn(responseObject);
 
@@ -210,7 +210,7 @@ public class ProfitAndLossControllerTest {
 
         when(bindingResult.hasErrors()).thenReturn(false);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED, profitAndLoss);
+        ResponseObject<ProfitAndLoss> responseObject = new ResponseObject<>(ResponseStatus.UPDATED, profitAndLoss);
         when(profitAndLossService.update(profitAndLoss, transaction, COMPANY_ACCOUNTS_ID, request, period))
                 .thenReturn(responseObject);
 
@@ -242,7 +242,7 @@ public class ProfitAndLossControllerTest {
 
         when(bindingResult.hasErrors()).thenReturn(false);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED, profitAndLoss);
+        ResponseObject<ProfitAndLoss> responseObject = new ResponseObject<>(ResponseStatus.UPDATED, profitAndLoss);
         when(profitAndLossService.update(profitAndLoss, transaction, COMPANY_ACCOUNTS_ID, request, accountingPeriod))
                 .thenReturn(responseObject);
 
@@ -425,6 +425,4 @@ public class ProfitAndLossControllerTest {
         assertNotNull(binder);
         assertEquals(accountingPeriod.toString(), converter.getAsText());
     }
-
-
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/RptTransactionsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/RptTransactionsControllerTest.java
@@ -248,8 +248,7 @@ class RptTransactionsControllerTest {
         when(relatedPartyTransactions.getTransactions()).thenReturn(rptTransactions);
         when(rptTransactions.get(RPT_TRANSACTIONS_ID)).thenReturn(RPT_TRANSACTIONS_LINK);
 
-
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED, rptTransaction);
+        ResponseObject<RptTransaction> responseObject = new ResponseObject<>(ResponseStatus.UPDATED, rptTransaction);
         when(rptTransactionService.update(rptTransaction, transaction, COMPANY_ACCOUNT_ID, request))
                 .thenReturn(responseObject);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/RptTransactionsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/RptTransactionsControllerTest.java
@@ -1,5 +1,17 @@
 package uk.gov.companieshouse.api.accounts.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -21,24 +33,15 @@ import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
 import uk.gov.companieshouse.api.accounts.utility.ApiResponseMapper;
 import uk.gov.companieshouse.api.accounts.utility.ErrorMapper;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import uk.gov.companieshouse.charset.validation.CharSetValidation;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RptTransactionsControllerTest {
+
+    private static final String RPT_TRANSACTIONS_ID = "rptTransactionsId";
+    private static final String COMPANY_ACCOUNT_ID = "companyAccountId";
+    private static final String RPT_TRANSACTIONS_LINK = "rptTransactionsLink";
 
     @Mock
     private RptTransactionServiceImpl rptTransactionService;
@@ -70,12 +73,11 @@ class RptTransactionsControllerTest {
     @Mock
     private Map<String, String> rptTransactions;
 
+    @Mock
+    private CharSetValidation charSetValidator;
+    
     @InjectMocks
     private RptTransactionsController controller;
-
-    private static final String RPT_TRANSACTIONS_ID = "rptTransactionsId";
-    private static final String COMPANY_ACCOUNT_ID = "companyAccountId";
-    private static final String RPT_TRANSACTIONS_LINK = "rptTransactionsLink";
 
     @Test
     @DisplayName("Tests the successful creation of a RptTransaction")
@@ -84,7 +86,7 @@ class RptTransactionsControllerTest {
         when(bindingResult.hasErrors()).thenReturn(false);
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED, rptTransaction);
+        ResponseObject<RptTransaction> responseObject = new ResponseObject<RptTransaction>(ResponseStatus.CREATED, rptTransaction);
         when(rptTransactionService.create(rptTransaction, transaction, RPT_TRANSACTIONS_ID, request))
                 .thenReturn(responseObject);
 
@@ -152,7 +154,7 @@ class RptTransactionsControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND, rptTransaction);
+        ResponseObject<RptTransaction> responseObject = new ResponseObject<>(ResponseStatus.FOUND, rptTransaction);
         when(rptTransactionService.find(RPT_TRANSACTIONS_ID, request))
                 .thenReturn(responseObject);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/SecretaryControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/SecretaryControllerTest.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.when;
 class SecretaryControllerTest {
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
-    private static final String SECRETARY_ID = "secretaryId";
     private static final String SECRETARY_LINK = "secretaryLink";
 
     @Mock
@@ -81,7 +80,7 @@ class SecretaryControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.CREATED,
+        ResponseObject<Secretary> responseObject = new ResponseObject<>(ResponseStatus.CREATED,
                 secretary);
         when(secretaryService.create(secretary, transaction,
                 COMPANY_ACCOUNTS_ID, request)).thenReturn(responseObject);
@@ -185,7 +184,7 @@ class SecretaryControllerTest {
 
         when(bindingResult.hasErrors()).thenReturn(false);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED,
+        ResponseObject<Secretary> responseObject = new ResponseObject<>(ResponseStatus.UPDATED,
                 secretary);
         when(secretaryService.update(secretary, transaction,
                 COMPANY_ACCOUNTS_ID, request)).thenReturn(responseObject);
@@ -234,7 +233,7 @@ class SecretaryControllerTest {
 
         when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.FOUND,
+        ResponseObject<Secretary> responseObject = new ResponseObject<>(ResponseStatus.FOUND,
                 secretary);
         when(secretaryService.find(COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(responseObject);
@@ -279,7 +278,7 @@ class SecretaryControllerTest {
 
         when(request.getAttribute(anyString())).thenReturn(transaction);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.UPDATED,
+        ResponseObject<Secretary> responseObject = new ResponseObject<>(ResponseStatus.UPDATED,
                 secretary);
 
         when(secretaryService.delete(COMPANY_ACCOUNTS_ID, request))

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/SmallFullControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/SmallFullControllerTest.java
@@ -40,7 +40,7 @@ import uk.gov.companieshouse.api.accounts.utility.ApiResponseMapper;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class SmallFullControllerTest {
+class SmallFullControllerTest {
 
     @Mock
     private HttpServletRequest request;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/StatementsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/StatementsControllerTest.java
@@ -30,7 +30,7 @@ import uk.gov.companieshouse.api.accounts.utility.ApiResponseMapper;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class StatementsControllerTest {
+class StatementsControllerTest {
 
     private static final String COMPANY_ACCOUNTS_ID = "123123";
 
@@ -248,7 +248,6 @@ public class StatementsControllerTest {
                 any(HttpServletRequest.class));
     }
 
-
     /**
      * Verify statementService.update is called 1 time.
      *
@@ -290,6 +289,6 @@ public class StatementsControllerTest {
     }
 
     private ResponseObject<Statement> createResponseObject(ResponseStatus responseStatus) {
-        return new ResponseObject(responseStatus, statementMock);
+        return new ResponseObject<Statement>(responseStatus, statementMock);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/controller/ValidationStatusControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/controller/ValidationStatusControllerTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ValidationStatusControllerTest {
+class ValidationStatusControllerTest {
 
     @Mock
     ValidationStatusService service;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandlerTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class GlobalExceptionHandlerTest {
+class GlobalExceptionHandlerTest {
 
     @InjectMocks
     private GlobalExceptionHandler globalExceptionHandler;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/filter/AccountsNoteFilterTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/filter/AccountsNoteFilterTest.java
@@ -21,7 +21,7 @@ import uk.gov.companieshouse.api.accounts.utility.PackageResolver;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class AccountsNoteFilterTest {
+class AccountsNoteFilterTest {
 
     @Mock
     private ServletResponse servletResponse;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/CicReportInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/CicReportInterceptorTest.java
@@ -34,7 +34,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CicReportInterceptorTest {
+class CicReportInterceptorTest {
 
     @Mock
     private CicReportService cicReportService;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/ClosedTransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/ClosedTransactionInterceptorTest.java
@@ -20,7 +20,7 @@ import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class ClosedTransactionInterceptorTest {
+class ClosedTransactionInterceptorTest {
 
     @InjectMocks
     private ClosedTransactionInterceptor transactionInterceptor;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/CompanyAccountInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/CompanyAccountInterceptorTest.java
@@ -34,7 +34,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CompanyAccountInterceptorTest {
+class CompanyAccountInterceptorTest {
 
     @Mock
     private CompanyAccountEntity companyAccountEntity;
@@ -68,7 +68,7 @@ public class CompanyAccountInterceptorTest {
 
     @Test
     @DisplayName("Tests the interceptor returns correctly when all is valid")
-    public void testReturnsCorrectlyOnValidConditions() throws DataException {
+    void testReturnsCorrectlyOnValidConditions() throws DataException {
         setUpPathVariables();
         setUpReourceList("linkToCompanyAccount");
         setUpCompanyAccount();
@@ -85,7 +85,7 @@ public class CompanyAccountInterceptorTest {
 
     @Test
     @DisplayName("Tests the interceptor returns false on a failed CompanyAccountEntity lookup")
-    public void testReturnsFalseForATransactionIsNull() {
+    void testReturnsFalseForATransactionIsNull() {
         setUpPathVariables();
         when(httpServletRequest.getAttribute(AttributeName.TRANSACTION.getValue()))
                 .thenReturn(null);
@@ -95,7 +95,7 @@ public class CompanyAccountInterceptorTest {
 
     @Test
     @DisplayName("Tests the interceptor returns false on a failed CompanyAccountEntity lookup")
-    public void testReturnsFalseForAFailedLookup() throws DataException {
+    void testReturnsFalseForAFailedLookup() throws DataException {
         setUpPathVariables();
         when(companyAccountService.findById("123456", httpServletRequest)).thenReturn(responseObject);
         when(responseObject.getStatus()).thenReturn(ResponseStatus.NOT_FOUND);
@@ -106,7 +106,7 @@ public class CompanyAccountInterceptorTest {
 
     @Test
     @DisplayName("Tests the interceptor returns false when the two links do not match")
-    public void testReturnsFalseForLinksThatDoNotMatch() throws DataException {
+    void testReturnsFalseForLinksThatDoNotMatch() throws DataException {
         setUpPathVariables();
         setUpReourceList("badLink");
         setUpCompanyAccount();
@@ -140,5 +140,4 @@ public class CompanyAccountInterceptorTest {
         when(httpServletRequest.getAttribute(anyString())).thenReturn(transaction)
             .thenReturn(pathVariables);
     }
-
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/CurrentPeriodInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/CurrentPeriodInterceptorTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CurrentPeriodInterceptorTest {
+class CurrentPeriodInterceptorTest {
 
     @Mock
     private CurrentPeriod currentPeriod;
@@ -94,7 +94,7 @@ public class CurrentPeriodInterceptorTest {
 
     @Test
     @DisplayName("Tests the interceptor returns correctly when all is valid")
-    public void testReturnsCorrectlyOnValidConditions() throws NoSuchAlgorithmException, DataException {
+    void testReturnsCorrectlyOnValidConditions() throws NoSuchAlgorithmException, DataException {
         setUp();
         when(currentPeriodService.find(anyString(), any(HttpServletRequest.class))).thenReturn(responseObject);
         when(responseObject.getStatus()).thenReturn(ResponseStatus.FOUND);
@@ -112,7 +112,7 @@ public class CurrentPeriodInterceptorTest {
 
     @Test
     @DisplayName("Tests the interceptor returns false on a failed CurrentPeriodEntity lookup")
-    public void testReturnsFalseForAFailedLookup() throws NoSuchAlgorithmException, DataException {
+    void testReturnsFalseForAFailedLookup() throws NoSuchAlgorithmException, DataException {
         setUp();
         doThrow(mock(DataException.class)).when(currentPeriodService).find(anyString(), any(HttpServletRequest.class));
         assertFalse(currentPeriodInterceptor.preHandle(httpServletRequest, httpServletResponse,

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/DirectorsReportInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/DirectorsReportInterceptorTest.java
@@ -34,7 +34,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class DirectorsReportInterceptorTest {
+class DirectorsReportInterceptorTest {
 
     @Mock
     private DirectorsReportServiceImpl directorsReportService;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/LoansToDirectorsInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/LoansToDirectorsInterceptorTest.java
@@ -37,7 +37,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class LoansToDirectorsInterceptorTest {
+class LoansToDirectorsInterceptorTest {
 
     @Mock
     private LoansToDirectorsServiceImpl loansToDirectorsService;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/LoggingInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/LoggingInterceptorTest.java
@@ -1,6 +1,13 @@
 package uk.gov.companieshouse.api.accounts.interceptor;
 
-import org.junit.jupiter.api.BeforeEach;
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -8,24 +15,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.ModelAndView;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import static junit.framework.TestCase.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class LoggingInterceptorTest {
+class LoggingInterceptorTest {
 
     @InjectMocks
     private LoggingInterceptor loggingInterceptor;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/OpenTransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/OpenTransactionInterceptorTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class OpenTransactionInterceptorTest {
+class OpenTransactionInterceptorTest {
 
     @InjectMocks
     private OpenTransactionInterceptor transactionInterceptor;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/PreviousPeriodInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/PreviousPeriodInterceptorTest.java
@@ -37,7 +37,7 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-  class PreviousPeriodInterceptorTest {
+class PreviousPeriodInterceptorTest {
 
 
     @Mock

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptorTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class SmallFullInterceptorTest {
+class SmallFullInterceptorTest {
 
     @Mock
     private SmallFull smallFull;
@@ -95,7 +95,7 @@ public class SmallFullInterceptorTest {
 
     @Test
     @DisplayName("Tests the interceptor returns correctly when all is valid")
-    public void testReturnsCorrectlyOnValidConditions() throws NoSuchAlgorithmException, DataException {
+    void testReturnsCorrectlyOnValidConditions() throws NoSuchAlgorithmException, DataException {
 
         setUp();
         when(smallFullService.find(anyString(), any(HttpServletRequest.class))).thenReturn(responseObject);
@@ -114,7 +114,7 @@ public class SmallFullInterceptorTest {
 
     @Test
     @DisplayName("Tests the interceptor returns false on a failed SmallFullEntity lookup")
-    public void testReturnsFalseForAFailedLookup() throws NoSuchAlgorithmException, DataException {
+    void testReturnsFalseForAFailedLookup() throws NoSuchAlgorithmException, DataException {
 
         setUp();
         doThrow(mock(DataException.class)).when(smallFullService).find(anyString(), any(HttpServletRequest.class));

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/TransactionInterceptorTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class TransactionInterceptorTest {
+class TransactionInterceptorTest {
 
     @InjectMocks
     private TransactionInterceptor transactionInterceptor;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/parent/ParentResourceFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/parent/ParentResourceFactoryTest.java
@@ -19,7 +19,7 @@ import uk.gov.companieshouse.api.accounts.links.LinkType;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ParentResourceFactoryTest {
+class ParentResourceFactoryTest {
 
     @Mock
     private ParentResource<LinkType> parentResource;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/parent/SmallFullParentResourceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/parent/SmallFullParentResourceTest.java
@@ -24,7 +24,7 @@ import uk.gov.companieshouse.api.accounts.service.impl.SmallFullService;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class SmallFullParentResourceTest {
+class SmallFullParentResourceTest {
 
     @Mock
     private SmallFullService smallFullService;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/repository/AccountsNoteRepositoryFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/repository/AccountsNoteRepositoryFactoryTest.java
@@ -38,7 +38,7 @@ class AccountsNoteRepositoryFactoryTest {
 
         List<AccountsNoteRepository<NoteEntity>> noteRepositories = new ArrayList<>();
         noteRepositories.add(accountsNoteRepository);
-        repositoryFactory = new AccountsNoteRepositoryFactory(noteRepositories);
+        repositoryFactory = new AccountsNoteRepositoryFactory<>(noteRepositories);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/request/AccountsNoteConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/request/AccountsNoteConverterTest.java
@@ -1,5 +1,8 @@
 package uk.gov.companieshouse.api.accounts.request;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import java.util.EnumMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,27 +13,20 @@ import uk.gov.companieshouse.api.accounts.enumeration.AccountType;
 import uk.gov.companieshouse.api.accounts.enumeration.AccountingNoteType;
 import uk.gov.companieshouse.api.accounts.enumeration.NoteType;
 
-import java.util.EnumMap;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AccountsNoteConverterTest {
 
-    private AccountingNoteType accountingNoteType = AccountingNoteType.SMALL_FULL_OFF_BALANCE_SHEET_ARRANGEMENTS;
-
     private EnumMap<AccountType, EnumMap<NoteType, AccountingNoteType>> ACCOUNTS_NOTE_MAP = new EnumMap<>(AccountType.class);
     private EnumMap<NoteType, AccountingNoteType> ACCOUNTS_NOTE_TYPE = new EnumMap<>(NoteType.class);
-    private NoteType noteType = NoteType.OFF_BALANCE_SHEET_ARRANGEMENTS;
 
     private AccountsNoteConverter converter;
 
     @BeforeEach
     private void setup() {
 
-        ACCOUNTS_NOTE_TYPE.put(noteType, accountingNoteType);
-        ACCOUNTS_NOTE_MAP.put(accountingNoteType.getAccountType(), ACCOUNTS_NOTE_TYPE);
+        ACCOUNTS_NOTE_TYPE.put(NoteType.OFF_BALANCE_SHEET_ARRANGEMENTS, AccountingNoteType.SMALL_FULL_OFF_BALANCE_SHEET_ARRANGEMENTS);
+        ACCOUNTS_NOTE_MAP.put(AccountingNoteType.SMALL_FULL_OFF_BALANCE_SHEET_ARRANGEMENTS.getAccountType(), ACCOUNTS_NOTE_TYPE);
 
         converter = new AccountsNoteConverter();
     }
@@ -39,7 +35,17 @@ class AccountsNoteConverterTest {
     @DisplayName("Get account type for the converter with the value from the map")
     void getAccountTypeForTheConverterSuccess() {
 
-        assertEquals(accountingNoteType,
-                ACCOUNTS_NOTE_TYPE.get(noteType));
+        AccountingNoteType accountingNoteType = converter.getAccountsNote(AccountType.SMALL_FULL, NoteType.OFF_BALANCE_SHEET_ARRANGEMENTS);
+        assertEquals(AccountingNoteType.SMALL_FULL_OFF_BALANCE_SHEET_ARRANGEMENTS,
+                accountingNoteType);
+    }
+
+    @Test
+    @DisplayName("Get incorrect account type for the converter with the value from the map")
+    void getIncorrectAccountTypeForTheConverterSuccess() {
+
+        AccountingNoteType accountingNoteType = converter.getAccountsNote(AccountType.SMALL_FULL, NoteType.STOCKS);
+        assertNotEquals(AccountingNoteType.SMALL_FULL_OFF_BALANCE_SHEET_ARRANGEMENTS,
+                accountingNoteType);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CicApprovalServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CicApprovalServiceTest.java
@@ -41,7 +41,7 @@ import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CicApprovalServiceTest {
+class CicApprovalServiceTest {
 
     @Mock
     private HttpServletRequest request;
@@ -169,7 +169,7 @@ public class CicApprovalServiceTest {
 
     @Test
     @DisplayName("Tests the successful update of an CicApproval resource")
-    public void canUpdateAnCicReportApproval() throws DataException {
+    void canUpdateAnCicReportApproval() throws DataException {
         when(cicApprovalTransformer.transform(cicApproval)).thenReturn(
                 cicReportApprovalEntity);
         doReturn(new Errors()).when(cicApprovalValidator)
@@ -219,7 +219,7 @@ public class CicApprovalServiceTest {
 
     @Test
     @DisplayName("Tests the successful find of an CicApproval resource")
-    public void findCicReportApproval() throws DataException {
+    void findCicReportApproval() throws DataException {
         when(cicReportApprovalRepository.findById(RESOURCE_ID))
             .thenReturn(Optional.ofNullable(cicReportApprovalEntity));
         when(cicApprovalTransformer.transform(cicReportApprovalEntity))
@@ -232,7 +232,7 @@ public class CicApprovalServiceTest {
 
     @Test
     @DisplayName("Tests the unsuccessful find of an CicApproval resource")
-    public void findCicReportApprovalUnsuccessful() throws DataException {
+    void findCicReportApprovalUnsuccessful() throws DataException {
         when(cicReportApprovalRepository.findById(RESOURCE_ID))
                 .thenReturn(Optional.ofNullable(null));
         ResponseObject<CicApproval> result = cicApprovalService
@@ -243,7 +243,7 @@ public class CicApprovalServiceTest {
 
     @Test
     @DisplayName("Tests mongo exception thrown on find of an CicApproval resource")
-    public void findCicReportApprovalMongoException() {
+    void findCicReportApprovalMongoException() {
         when(cicReportApprovalRepository.findById(RESOURCE_ID)).thenThrow(mongoException);
         assertThrows(DataException.class, () -> cicApprovalService
             .find(COMPANY_ACCOUNTS_ID, request));
@@ -251,7 +251,7 @@ public class CicApprovalServiceTest {
 
     @Test
     @DisplayName("Tests the successful delete of an CicApproval resource")
-    public void deleteCicReportApproval() throws DataException {
+    void deleteCicReportApproval() throws DataException {
         when(cicReportApprovalRepository.existsById(RESOURCE_ID)).thenReturn(true);
         ResponseObject<CicApproval> result = cicApprovalService.delete(COMPANY_ACCOUNTS_ID, request);
         assertNotNull(result);
@@ -260,7 +260,7 @@ public class CicApprovalServiceTest {
 
     @Test
     @DisplayName("Tests mongo exception thrown on delete of an CicApproval resource")
-    public void deleteCicReportApprovalMongoException() {
+    void deleteCicReportApprovalMongoException() {
         when(cicReportApprovalRepository.existsById(RESOURCE_ID)).thenThrow(mongoException);
         assertThrows(DataException.class, () -> cicApprovalService
                 .delete(COMPANY_ACCOUNTS_ID, request));
@@ -268,7 +268,7 @@ public class CicApprovalServiceTest {
 
     @Test
     @DisplayName("Tests the unsuccessful on delete of an CicApproval resource")
-    public void deleteCicReportApprovalUnsuccessful() throws DataException {
+    void deleteCicReportApprovalUnsuccessful() throws DataException {
         when(cicReportApprovalRepository.existsById(RESOURCE_ID)).thenReturn(false);
         ResponseObject<CicApproval> result = cicApprovalService
                 .delete(COMPANY_ACCOUNTS_ID, request);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CicReportServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CicReportServiceTest.java
@@ -46,7 +46,7 @@ import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CicReportServiceTest {
+class CicReportServiceTest {
 
     @Mock
     private CicReportRepository repository;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CicStatementsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CicStatementsServiceTest.java
@@ -44,7 +44,7 @@ import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CicStatementsServiceTest {
+class CicStatementsServiceTest {
 
     @Mock
     private CicStatementsRepository repository;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CompanyServiceImplTests.java
@@ -31,7 +31,7 @@ import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CompanyServiceImplTests {
+class CompanyServiceImplTests {
 
     @Mock
     private ApiClientService mockApiClientService;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CostServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CostServiceImplTest.java
@@ -64,7 +64,7 @@ class CostServiceImplTest {
         when(transactionService.getPayableResources(transaction))
                 .thenReturn(Arrays.asList(PayableResource.CIC));
 
-        when(costs.getCostsList()).thenReturn(costMap);
+        when(costs.getCostsMap()).thenReturn(costMap);
 
         when(costMap.get(PayableResource.CIC.getResource())).thenReturn(cost);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CostServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CostServiceImplTest.java
@@ -26,7 +26,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CostServiceImplTest {
+class CostServiceImplTest {
 
     @Mock
     private TransactionService transactionService;
@@ -64,7 +64,7 @@ public class CostServiceImplTest {
         when(transactionService.getPayableResources(transaction))
                 .thenReturn(Arrays.asList(PayableResource.CIC));
 
-        when(costs.getCosts()).thenReturn(costMap);
+        when(costs.getCostsList()).thenReturn(costMap);
 
         when(costMap.get(PayableResource.CIC.getResource())).thenReturn(cost);
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/CurrentPeriodServiceTest.java
@@ -47,7 +47,7 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CurrentPeriodServiceTest {
+class CurrentPeriodServiceTest {
 
     @Mock
     private HttpServletRequest request;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DirectorsApprovalServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DirectorsApprovalServiceTest.java
@@ -97,7 +97,7 @@ class DirectorsApprovalServiceTest {
 
     @Test
     @DisplayName("Tests the successful creation of an directors approval resource")
-    public void canCreateADirectorsApproval() throws DataException {
+    void canCreateADirectorsApproval() throws DataException {
 
         when(validator.validateApproval(directorsApproval, transaction, COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(errors);
@@ -115,7 +115,7 @@ class DirectorsApprovalServiceTest {
 
     @Test
     @DisplayName("Tests the duplicate key when creating a directors approval resource")
-    public void createDirectorsApprovalDuplicateKey() throws DataException {
+    void createDirectorsApprovalDuplicateKey() throws DataException {
 
         when(validator.validateApproval(directorsApproval, transaction, COMPANY_ACCOUNTS_ID, request))
                 .thenReturn(errors);
@@ -167,7 +167,7 @@ class DirectorsApprovalServiceTest {
 
     @Test
     @DisplayName("Tests the successful find of an directors approval resource")
-    public void findDirectorsApproval() throws DataException {
+    void findDirectorsApproval() throws DataException {
 
         when(keyIdGenerator
                 .generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.APPROVAL.getName()))
@@ -184,7 +184,7 @@ class DirectorsApprovalServiceTest {
 
     @Test
     @DisplayName("Tests mongo exception thrown on find of an director approval resource")
-    public void findDirectorsApprovalMongoException() {
+    void findDirectorsApprovalMongoException() {
 
         when(keyIdGenerator
                 .generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.APPROVAL.getName()))
@@ -196,7 +196,7 @@ class DirectorsApprovalServiceTest {
 
     @Test
     @DisplayName("Tests mongo exception thrown on find of an director approval resource")
-    public void findDirectorsApprovalNotFound() throws DataException {
+    void findDirectorsApprovalNotFound() throws DataException {
 
         when(keyIdGenerator
                 .generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.APPROVAL.getName()))

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DirectorsReportServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/DirectorsReportServiceImplTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class DirectorsReportServiceImplTest {
+class DirectorsReportServiceImplTest {
 
     @Mock
     private DirectorsReportTransformer transformer;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/LoansToDirectorsAdditionalInformationServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/LoansToDirectorsAdditionalInformationServiceTest.java
@@ -40,7 +40,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 
 @ExtendWith(MockitoExtension.class )
-public class LoansToDirectorsAdditionalInformationServiceTest {
+class LoansToDirectorsAdditionalInformationServiceTest {
 
     @Mock
     private LoansToDirectorsAdditionalInformationTransformer transformer;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/LoansToDirectorsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/LoansToDirectorsServiceImplTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class LoansToDirectorsServiceImplTest {
+class LoansToDirectorsServiceImplTest {
 
     @Mock
     private LoansToDirectorsTransformer transformer;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/NoteServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/NoteServiceImplTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class NoteServiceImplTest {
+class NoteServiceImplTest {
 
     @Mock
     private KeyIdGenerator keyIdGenerator;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/PreviousPeriodServiceTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class PreviousPeriodServiceTest {
+class PreviousPeriodServiceTest {
 
     @Mock
     private HttpServletRequest request;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/ProfitAndLossServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/ProfitAndLossServiceTest.java
@@ -49,7 +49,7 @@ import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ProfitAndLossServiceTest {
+class ProfitAndLossServiceTest {
 
     @Mock
     private ProfitAndLossTransformer transformer;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/SecretaryServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/SecretaryServiceTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class )
-public class SecretaryServiceTest {
+class SecretaryServiceTest {
 
     @Mock
     private SecretaryTransformer transformer;
@@ -76,14 +76,9 @@ public class SecretaryServiceTest {
     private SecretaryService secretaryService;
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
-    private static final String SECRETARY_ID = "secretaryId";
     private static final String GENERATED_ID = "generatedId";
     private static final String TRANSACTION_SELF_LINK = "transactionSelfLink";
     private static final String SECRETARY_SELF_LINK = "secretarySelfLink";
-
-    private static final String URI = "/transactions/transactionId/company-accounts/" +
-            COMPANY_ACCOUNTS_ID + "/small-full/directors-report" +
-            "/secretaries/" + SECRETARY_ID;
 
     @Test
     @DisplayName("Tests the successful creation of a secretary resource")

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/SmallFullServiceTest.java
@@ -61,7 +61,7 @@ import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class SmallFullServiceTest {
+class SmallFullServiceTest {
 
     @Mock
     private HttpServletRequest request;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StatementServiceTest.java
@@ -58,7 +58,7 @@ import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 @PropertySource("classpath:LegalStatements.properties")
-public class StatementServiceTest {
+class StatementServiceTest {
 
 
     private static final String ETAG = "etag";

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StatementsServicePropertiesTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StatementsServicePropertiesTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class StatementsServicePropertiesTest {
+class StatementsServicePropertiesTest {
 
     @InjectMocks
     private StatementsServiceProperties statementsServiceProperties;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StatementsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/StatementsServiceTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class )
-public class StatementsServiceTest {
+class StatementsServiceTest {
 
     @Mock
     private StatementsTransformer transformer;
@@ -79,7 +79,6 @@ public class StatementsServiceTest {
     private static final String GENERATED_ID = "generatedId";
     private static final String TRANSACTION_SELF_LINK = "transactionSelfLink";
     private static final String STATEMENTS_SELF_LINK = "statementsSelfLink";
-
 
     @Test
     @DisplayName("Tests the successful creation of a statements resource")

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/TnepValidationServiceImplTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-
 import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
-import uk.gov.companieshouse.api.accounts.utility.filetransfer.FileTransferTool;
 import uk.gov.companieshouse.api.accounts.validation.Results;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/TransactionServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/TransactionServiceImplTest.java
@@ -19,7 +19,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TransactionServiceImplTest {
+class TransactionServiceImplTest {
 
     @Mock
     private CompanyService companyService;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/AccountingPoliciesTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/AccountingPoliciesTransformerTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class AccountingPoliciesTransformerTest {
+class AccountingPoliciesTransformerTest {
 
     private static final String ETAG = "etag";
     private static final String KIND = "kind";
@@ -28,7 +28,7 @@ public class AccountingPoliciesTransformerTest {
 
     @Test
     @DisplayName("Tests accountingPolicies  transformer with empty object which should result in null values")
-    public void testTransformerWithEmptyObject() {
+    void testTransformerWithEmptyObject() {
         AccountingPoliciesEntity accountingPoliciesEntity = accountingPoliciesTransformer
                 .transform(new AccountingPolicies());
 
@@ -39,7 +39,7 @@ public class AccountingPoliciesTransformerTest {
 
     @Test
     @DisplayName("Tests accountingPolicies transformer with populated Rest object and validates values returned")
-    public void testRestToEntityTransformerWithPopulatedObject() {
+    void testRestToEntityTransformerWithPopulatedObject() {
 
         AccountingPolicies accountingPolicies = new AccountingPolicies();
 
@@ -73,7 +73,7 @@ public class AccountingPoliciesTransformerTest {
 
     @Test
     @DisplayName("Tests accountingPolicies transformer with populated Entity object and validates values returned")
-    public void testEntityToRestTransformerWithPopulatedObject() {
+    void testEntityToRestTransformerWithPopulatedObject() {
 
         AccountingPoliciesEntity accountingPoliciesEntity = new AccountingPoliciesEntity();
         AccountingPoliciesDataEntity accountingPoliciesDataEntity = new AccountingPoliciesDataEntity();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/ApprovalTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/ApprovalTransformerTest.java
@@ -11,7 +11,7 @@ import uk.gov.companieshouse.api.accounts.model.entity.ApprovalDataEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.ApprovalEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.Approval;
 
-public class ApprovalTransformerTest {
+class ApprovalTransformerTest {
 
     public static final String ETAG = "etag";
     public static final String KIND = "kind";
@@ -21,7 +21,7 @@ public class ApprovalTransformerTest {
 
     @Test
     @DisplayName("Tests approval  transformer with empty object which should result in null values")
-    public void testTransformerWithEmptyObject() {
+    void testTransformerWithEmptyObject() {
         ApprovalEntity approvalEntity = approvalTransformer
             .transform(new Approval());
 
@@ -32,7 +32,7 @@ public class ApprovalTransformerTest {
 
     @Test
     @DisplayName("Tests approval transformer with populated Rest object and validates values returned")
-    public void testRestToEntityTransformerWithPopulatedObject() {
+    void testRestToEntityTransformerWithPopulatedObject() {
 
         Approval approval = new Approval();
         approval.setEtag(ETAG);
@@ -54,7 +54,7 @@ public class ApprovalTransformerTest {
 
     @Test
     @DisplayName("Tests approval transformer with populated Entity object and validates values returned")
-    public void testEntityToRestTransformerWithPopulatedObject() {
+    void testEntityToRestTransformerWithPopulatedObject() {
 
         ApprovalEntity approvalEntity = new ApprovalEntity();
         ApprovalDataEntity approvalDataEntity = new ApprovalDataEntity();
@@ -64,9 +64,7 @@ public class ApprovalTransformerTest {
         approvalDataEntity.setLinks(new HashMap<>());
         approvalEntity.setData(approvalDataEntity);
 
-
         Approval approval = approvalTransformer.transform(approvalEntity);
-
 
         assertNotNull(approval);
         assertEquals(ETAG, approval.getEtag());
@@ -74,6 +72,4 @@ public class ApprovalTransformerTest {
         assertEquals(NAME, approval.getName());
         assertEquals(new HashMap<>(), approval.getLinks());
     }
-
-
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CicApprovalTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CicApprovalTransformerTest.java
@@ -11,8 +11,7 @@ import uk.gov.companieshouse.api.accounts.model.entity.CicReportApprovalDataEnti
 import uk.gov.companieshouse.api.accounts.model.entity.CicReportApprovalEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CicApproval;
 
-
-public class CicApprovalTransformerTest {
+ class CicApprovalTransformerTest {
 
     public static final String ETAG = "etag";
     public static final String KIND = "kind";
@@ -22,7 +21,7 @@ public class CicApprovalTransformerTest {
 
     @Test
     @DisplayName("Tests CicApprovalTransformer with empty object which should result in null values")
-    public void testTransformerWithEmptyObject() {
+    void testTransformerWithEmptyObject() {
         CicReportApprovalEntity cicReportApprovalEntity = cicApprovalTransformer
             .transform(new CicApproval());
 
@@ -33,7 +32,7 @@ public class CicApprovalTransformerTest {
 
     @Test
     @DisplayName("Tests CicApprovalTransformer with populated Rest object and validates values returned")
-    public void testRestToEntityTransformerWithPopulatedObject() {
+    void testRestToEntityTransformerWithPopulatedObject() {
 
         CicApproval cicApproval = new CicApproval();
         cicApproval.setEtag(ETAG);
@@ -55,7 +54,7 @@ public class CicApprovalTransformerTest {
 
     @Test
     @DisplayName("Tests CicApprovalTransformer with populated Entity object and validates values returned")
-    public void testEntityToRestTransformerWithPopulatedObject() {
+    void testEntityToRestTransformerWithPopulatedObject() {
 
         CicReportApprovalEntity cicReportApprovalEntity = new CicReportApprovalEntity();
         CicReportApprovalDataEntity cicReportApprovalDataEntity = new CicReportApprovalDataEntity();
@@ -74,6 +73,4 @@ public class CicApprovalTransformerTest {
         assertEquals(NAME, cicApproval.getName());
         assertEquals(new HashMap<>(), cicApproval.getLinks());
     }
-
-
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CicReportTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CicReportTransformerTest.java
@@ -11,7 +11,7 @@ import uk.gov.companieshouse.api.accounts.model.entity.CicReportDataEntity;
 import uk.gov.companieshouse.api.accounts.model.entity.CicReportEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CicReport;
 
-public class CicReportTransformerTest {
+class CicReportTransformerTest {
 
     private static final String ETAG = "etag";
     private static final String KIND = "kind";

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CicStatementsTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CicStatementsTransformerTest.java
@@ -14,7 +14,7 @@ import uk.gov.companieshouse.api.accounts.model.entity.CicStatementsEntity;
 import uk.gov.companieshouse.api.accounts.model.rest.CicStatements;
 import uk.gov.companieshouse.api.accounts.model.rest.ReportStatements;
 
-public class CicStatementsTransformerTest {
+class CicStatementsTransformerTest {
 
     private static final Map<String, String> LINKS = new HashMap<>();
     private static final Boolean HAS_COMPLETED_REPORT_STATEMENTS = true;
@@ -29,7 +29,7 @@ public class CicStatementsTransformerTest {
 
     @Test
     @DisplayName("REST to entity transform - fully populated object")
-    public void testRestToEntityTransformerWithFullyPopulatedObject() {
+    void testRestToEntityTransformerWithFullyPopulatedObject() {
 
         CicStatements cicStatements = new CicStatements();
         cicStatements.setHasCompletedReportStatements(HAS_COMPLETED_REPORT_STATEMENTS);
@@ -64,7 +64,7 @@ public class CicStatementsTransformerTest {
 
     @Test
     @DisplayName("REST to entity transform - no report statements")
-    public void testRestToEntityTransformerWithoutNestedReportStatements() {
+    void testRestToEntityTransformerWithoutNestedReportStatements() {
 
         CicStatements cicStatements = new CicStatements();
         cicStatements.setHasCompletedReportStatements(HAS_COMPLETED_REPORT_STATEMENTS);
@@ -87,7 +87,7 @@ public class CicStatementsTransformerTest {
 
     @Test
     @DisplayName("Entity to REST transform - fully populated object")
-    public void testEntityToRestTransformerWithFullyPopulatedObject() {
+    void testEntityToRestTransformerWithFullyPopulatedObject() {
 
         CicStatementsDataEntity cicStatementsDataEntity = new CicStatementsDataEntity();
         cicStatementsDataEntity.setEtag(ETAG);
@@ -123,7 +123,7 @@ public class CicStatementsTransformerTest {
 
     @Test
     @DisplayName("Entity to REST transform - no report statements")
-    public void testEntityToRestTransformerWithoutNestedReportStatements() {
+    void testEntityToRestTransformerWithoutNestedReportStatements() {
 
         CicStatementsDataEntity cicStatementsDataEntity = new CicStatementsDataEntity();
         cicStatementsDataEntity.setEtag(ETAG);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CompanyAccountTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CompanyAccountTransformerTest.java
@@ -19,7 +19,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CompanyAccountTransformerTest {
+class CompanyAccountTransformerTest {
 
     private CompanyAccountTransformer companyAccountTransformer = new CompanyAccountTransformer();
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CreditorsAfterMoreThanOneYearTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CreditorsAfterMoreThanOneYearTransformerTest.java
@@ -22,7 +22,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.creditorsaf
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CreditorsAfterMoreThanOneYearTransformerTest {
+class CreditorsAfterMoreThanOneYearTransformerTest {
 
     private static final Long BANK_LOANS_AND_OVERDRAFTS = 2L;
     private static final Long OTHER_CREDITORS = 3L;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CreditorsWithinOneYearTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CreditorsWithinOneYearTransformerTest.java
@@ -23,7 +23,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.creditorswi
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CreditorsWithinOneYearTransformerTest {
+class CreditorsWithinOneYearTransformerTest {
 
     private static final Long ACCRUALS_AND_DEFERRED_INCOME = 1L;
     private static final Long BANK_LOANS_AND_OVERDRAFTS = 2L;
@@ -40,7 +40,7 @@ public class CreditorsWithinOneYearTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty rest object returns null values ")
-    public void testTransformerWithEmptyRestObject() {
+    void testTransformerWithEmptyRestObject() {
 
         CreditorsWithinOneYearEntity creditorsWithinOneYearEntity = creditorsWithinOneYearTransformer
             .transform(new CreditorsWithinOneYear());
@@ -60,7 +60,7 @@ public class CreditorsWithinOneYearTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty previous period Rest Object")
-    public void testRestToEntityTransformerWithEmptyPreviousPeriodRestObject() {
+    void testRestToEntityTransformerWithEmptyPreviousPeriodRestObject() {
 
         CreditorsWithinOneYear creditorsWithinOneYear = new CreditorsWithinOneYear();
 
@@ -83,7 +83,7 @@ public class CreditorsWithinOneYearTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with fully populated Rest object and validates values returned")
-    public void testRestToEntityTransformerWithFullyPopulatedObject() {
+    void testRestToEntityTransformerWithFullyPopulatedObject() {
 
         CreditorsWithinOneYear creditorsWithinOneYear = new CreditorsWithinOneYear();
 
@@ -102,7 +102,7 @@ public class CreditorsWithinOneYearTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty entity object returns null values ")
-    public void testTransformerWithEmptyEntityObject() {
+    void testTransformerWithEmptyEntityObject() {
 
         CreditorsWithinOneYear creditorsWithinOneYear = creditorsWithinOneYearTransformer
             .transform(new CreditorsWithinOneYearEntity());
@@ -114,7 +114,7 @@ public class CreditorsWithinOneYearTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty previous period Entity Object")
-    public void testEntityToRestTransformerWithEmptyPreviousPeriodEntityObject() {
+    void testEntityToRestTransformerWithEmptyPreviousPeriodEntityObject() {
 
         CreditorsWithinOneYearEntity creditorsWithinOneYearEntity = new CreditorsWithinOneYearEntity();
         CreditorsWithinOneYearDataEntity creditorsWithinOneYearDataEntity = new CreditorsWithinOneYearDataEntity();
@@ -138,7 +138,7 @@ public class CreditorsWithinOneYearTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with fully populated Entity object and validates values returned")
-    public void testEntityToRestTransformerWithFullyPopulatedEntityObject() {
+    void testEntityToRestTransformerWithFullyPopulatedEntityObject() {
 
         CreditorsWithinOneYearEntity creditorsWithinOneYearEntity = new CreditorsWithinOneYearEntity();
         CreditorsWithinOneYearDataEntity creditorsWithinOneYearDataEntity = new CreditorsWithinOneYearDataEntity();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CurrentAssetsInvestmentTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CurrentAssetsInvestmentTransformerTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CurrentAssetsInvestmentTransformerTest {
+class CurrentAssetsInvestmentTransformerTest {
 
     private static final String DETAILS = "details";
     private static final String ETAG = "etag";
@@ -28,7 +28,7 @@ public class CurrentAssetsInvestmentTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty rest object returns null values ")
-    public void testTransformerWithEmptyRestObject() {
+    void testTransformerWithEmptyRestObject() {
 
         CurrentAssetsInvestmentsEntity currentAssetsInvestmentsEntity = currentAssetsInvestmentsTransformer
             .transform(new CurrentAssetsInvestments());
@@ -40,7 +40,7 @@ public class CurrentAssetsInvestmentTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with fully populated Rest object and validates values returned")
-    public void testRestToEntityTransformerWithFullyPopulatedObject() {
+    void testRestToEntityTransformerWithFullyPopulatedObject() {
 
         CurrentAssetsInvestments currentAssetsInvestments = new CurrentAssetsInvestments();
 
@@ -61,7 +61,7 @@ public class CurrentAssetsInvestmentTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty entity object returns null values ")
-    public void testTransformerWithEmptyEntityObject() {
+    void testTransformerWithEmptyEntityObject() {
 
         CurrentAssetsInvestments currentAssetsInvestments = currentAssetsInvestmentsTransformer
             .transform(new CurrentAssetsInvestmentsEntity());
@@ -73,7 +73,7 @@ public class CurrentAssetsInvestmentTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with fully populated Entity object and validates values returned")
-    public void testEntityToRestTransformerWithFullyPopulatedEntityObject() {
+    void testEntityToRestTransformerWithFullyPopulatedEntityObject() {
 
         CurrentAssetsInvestmentsEntity currentAssetsInvestmentsEntity = new CurrentAssetsInvestmentsEntity();
         CurrentAssetsInvestmentsDataEntity currentAssetsInvestmentsDataEntity = new CurrentAssetsInvestmentsDataEntity();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CurrentPeriodTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/CurrentPeriodTransformerTest.java
@@ -31,7 +31,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class CurrentPeriodTransformerTest {
+class CurrentPeriodTransformerTest {
 
     private static final String ETAG = "etag";
     private static final String KIND = "kind";

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/DebtorsTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/DebtorsTransformerTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class DebtorsTransformerTest {
+class DebtorsTransformerTest {
 
     private static final String ETAG = "etag";
     private static final String KIND = "kind";

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/DirectorTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/DirectorTransformerTest.java
@@ -15,7 +15,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.directorsreport.Director;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class DirectorTransformerTest {
+class DirectorTransformerTest {
 
     private static final String NAME = "name";
     private static final LocalDate APPOINTMENT_DATE = LocalDate.of(2018, 1, 1);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/DirectorsReportTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/DirectorsReportTransformerTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class DirectorsReportTransformerTest {
+class DirectorsReportTransformerTest {
 
     private static final Map<String, String> DIRECTORS = new HashMap<>();
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/EmployeesTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/EmployeesTransformerTest.java
@@ -23,7 +23,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.employees.P
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class EmployeesTransformerTest {
+class EmployeesTransformerTest {
 
     private static final Long AVERAGE_NUMBER_OF_EMPLOYEES_CURRENT = 11L;
     private static final Long AVERAGE_NUMBER_OF_EMPLOYEES_PREVIOUS = 19L;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/FinancialCommitmentsTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/FinancialCommitmentsTransformerTest.java
@@ -27,7 +27,7 @@ class FinancialCommitmentsTransformerTest {
     private FinancialCommitmentsTransformer financialCommitmentsTransformer = new FinancialCommitmentsTransformer();
     @Test
     @DisplayName("Tests transformer with empty rest object returns null values ")
-     void testTransformerWithEmptyRestObject() {
+    void testTransformerWithEmptyRestObject() {
 
         FinancialCommitmentsEntity financialCommitmentsEntity = financialCommitmentsTransformer
                 .transform(new FinancialCommitments());
@@ -40,7 +40,7 @@ class FinancialCommitmentsTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with fully populated Rest object and validates values returned")
-     void testRestToEntityTransformerWithFullyPopulatedObject() {
+    void testRestToEntityTransformerWithFullyPopulatedObject() {
 
         FinancialCommitments financialCommitments = new FinancialCommitments();
 
@@ -61,7 +61,7 @@ class FinancialCommitmentsTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty entity object returns null values ")
-     void testTransformerWithEmptyEntityObject() {
+    void testTransformerWithEmptyEntityObject() {
 
         FinancialCommitments financialCommitments = financialCommitmentsTransformer
                 .transform(new FinancialCommitmentsEntity());
@@ -73,7 +73,7 @@ class FinancialCommitmentsTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with fully populated Entity object and validates values returned")
-     void testEntityToRestTransformerWithFullyPopulatedEntityObject() {
+    void testEntityToRestTransformerWithFullyPopulatedEntityObject() {
 
         FinancialCommitmentsEntity financialCommitmentsEntity = new FinancialCommitmentsEntity();
         FinancialCommitmentsDataEntity financialCommitmentsDataEntity = new FinancialCommitmentsDataEntity();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/FixedAssetsInvestmentsTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/FixedAssetsInvestmentsTransformerTest.java
@@ -19,7 +19,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.fixedassets
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class FixedAssetsInvestmentsTransformerTest {
+class FixedAssetsInvestmentsTransformerTest {
 
     private static final String DETAILS = "details";
     private static final String ETAG = "etag";
@@ -29,7 +29,7 @@ public class FixedAssetsInvestmentsTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty rest object returns null values ")
-    public void testTransformerWithEmptyRestObject() {
+    void testTransformerWithEmptyRestObject() {
 
         FixedAssetsInvestmentsEntity fixedAssetsInvestmentsEntity = fixedAssetsInvestmentsTransformer
             .transform(new FixedAssetsInvestments());
@@ -41,7 +41,7 @@ public class FixedAssetsInvestmentsTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with fully populated Rest object and validates values returned")
-    public void testRestToEntityTransformerWithFullyPopulatedObject() {
+    void testRestToEntityTransformerWithFullyPopulatedObject() {
 
         FixedAssetsInvestments fixedAssetsInvestments = new FixedAssetsInvestments();
 
@@ -62,7 +62,7 @@ public class FixedAssetsInvestmentsTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty entity object returns null values ")
-    public void testTransformerWithEmptyEntityObject() {
+    void testTransformerWithEmptyEntityObject() {
 
         FixedAssetsInvestments fixedAssetsInvestments = fixedAssetsInvestmentsTransformer
             .transform(new FixedAssetsInvestmentsEntity());
@@ -74,7 +74,7 @@ public class FixedAssetsInvestmentsTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with fully populated Entity object and validates values returned")
-    public void testEntityToRestTransformerWithFullyPopulatedEntityObject() {
+    void testEntityToRestTransformerWithFullyPopulatedEntityObject() {
 
         FixedAssetsInvestmentsEntity fixedAssetsInvestmentsEntity = new FixedAssetsInvestmentsEntity();
         FixedAssetsInvestmentsDataEntity fixedAssetsInvestmentsDataEntity = new FixedAssetsInvestmentsDataEntity();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/IntangibleAssetsTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/IntangibleAssetsTransformerTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class IntangibleAssetsTransformerTest {
+class IntangibleAssetsTransformerTest {
 
     private static final Long NET_BOOK_VALUE_AT_END_OF_CURRENT_PERIOD = 1L;
     private static final Long NET_BOOK_VALUE_AT_END_OF_PREVIOUS_PERIOD = 2L;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/LoanTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/LoanTransformerTest.java
@@ -23,9 +23,6 @@ class LoanTransformerTest {
     private static final String DIRECTOR_NAME = "name";
     private static final String DESCRIPTION = "description";
 
-    private static final String LOAN_ID = "loanId";
-    private static final String LOAN_LINK = "loanLink";
-
     private LoanTransformer transformer = new LoanTransformer();
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/LoansToDirectorsAdditionalInformationTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/LoansToDirectorsAdditionalInformationTransformerTest.java
@@ -14,7 +14,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.loanstodire
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class LoansToDirectorsAdditionalInformationTransformerTest {
+class LoansToDirectorsAdditionalInformationTransformerTest {
 
     private static final String DETAILS = "details";
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/LoansToDirectorsTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/LoansToDirectorsTransformerTest.java
@@ -17,7 +17,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.loanstodire
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class LoansToDirectorsTransformerTest {
+class LoansToDirectorsTransformerTest {
 
     private static final Map<String, String> LOANS = new HashMap<>();
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/NoteTransformerFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/NoteTransformerFactoryTest.java
@@ -20,7 +20,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.Note;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class NoteTransformerFactoryTest {
+class NoteTransformerFactoryTest {
 
     @Mock
     private NoteTransformer<Note, NoteEntity> noteTransformer;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/PreviousPeriodTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/PreviousPeriodTransformerTest.java
@@ -31,7 +31,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.OtherLiabilitiesOrAssets;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class PreviousPeriodTransformerTest {
+class PreviousPeriodTransformerTest {
 
     private static final String ETAG = "etag";
     private static final String KIND = "kind";

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/ProfitAndLossTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/ProfitAndLossTransformerTest.java
@@ -18,7 +18,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.profitloss.ProfitAndLoss;
 import uk.gov.companieshouse.api.accounts.model.rest.profitloss.ProfitOrLossBeforeTax;
 import uk.gov.companieshouse.api.accounts.model.rest.profitloss.ProfitOrLossForFinancialYear;
 
-public class ProfitAndLossTransformerTest {
+class ProfitAndLossTransformerTest {
 
     private static final Long TURNOVER = 1L;
     private static final Long COST_OF_SALES = 2L;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/SecretaryTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/SecretaryTransformerTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class SecretaryTransformerTest {
+class SecretaryTransformerTest {
 
     private static final String NAME = "name";
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/SmallFullTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/SmallFullTransformerTest.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class SmallFullTransformerTest {
+class SmallFullTransformerTest {
     
     private SmallFullTransformer smallFullTransformer = new SmallFullTransformer();
     
@@ -146,4 +146,3 @@ public class SmallFullTransformerTest {
         Assertions.assertEquals(LAST_ACCOUNTS_PERIOD_END_ON, smallFull.getLastAccounts().getPeriodEndOn());
     }
 }
-

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StatementTransformerTest.java
@@ -22,7 +22,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.Statement;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class StatementTransformerTest {
+class StatementTransformerTest {
 
     private static final String ETAG = "etag";
     private static final String KIND = "kind";
@@ -36,7 +36,7 @@ public class StatementTransformerTest {
 
     @Test
     @DisplayName("Tests statement transformer with empty object which should result in null values")
-    public void testTransformerWithEmptyObject() {
+    void testTransformerWithEmptyObject() {
         StatementEntity statementEntity = statementTransformer.transform(new Statement());
 
         assertNotNull(statementEntity);
@@ -47,7 +47,7 @@ public class StatementTransformerTest {
 
     @Test
     @DisplayName("Tests statement transformer with populated object and validates values returned")
-    public void testRestToEntityTransformerWithPopulatedObject() {
+    void testRestToEntityTransformerWithPopulatedObject() {
         Statement statement = new Statement();
         statement.setEtag(ETAG);
         statement.setKind(KIND);
@@ -71,7 +71,7 @@ public class StatementTransformerTest {
 
     @Test
     @DisplayName("Tests statement transformer with populated object and validates values returned")
-    public void testEntityToRestTransformerWithPopulatedObject() {
+    void testEntityToRestTransformerWithPopulatedObject() {
         StatementEntity statementEntity = new StatementEntity();
         StatementDataEntity statementDataEntity = new StatementDataEntity();
         statementDataEntity.setEtag(ETAG);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StatementsTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StatementsTransformerTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class StatementsTransformerTest {
+class StatementsTransformerTest {
 
     private static final String ADDITIONAL_INFORMATION = "additionalInfo";
     private static final String COMPANY_POLICY_ON_DISABLED_EMPLOYEES = "companyPolicy";
@@ -69,5 +69,4 @@ public class StatementsTransformerTest {
         assertEquals(POLITICAL_AND_CHARITABLE_DONATIONS, statements.getPoliticalAndCharitableDonations());
         assertEquals(PRINCIPAL_ACTIVITIES, statements.getPrincipalActivities());
     }
-
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StocksTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/StocksTransformerTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class StocksTransformerTest {
+class StocksTransformerTest {
 
     private static final Long PAYMENTS_ON_ACCOUNT_CURRENT_PERIOD = 1L;
     private static final Long STOCKS_CURRENT_PERIOD = 2L;
@@ -39,7 +39,7 @@ public class StocksTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty rest object returns null values ")
-    public void testTransformerWithEmptyRestObject() {
+    void testTransformerWithEmptyRestObject() {
 
         StocksEntity stocksEntity = stocksTransformer
                 .transform(new Stocks());
@@ -51,7 +51,7 @@ public class StocksTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty previous period Rest Object")
-    public void testRestToEntityTransformerWithEmptyPreviousPeriodRestObject() {
+    void testRestToEntityTransformerWithEmptyPreviousPeriodRestObject() {
 
         Stocks stocks = new Stocks();
 
@@ -71,7 +71,7 @@ public class StocksTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with fully populated Rest object and validates values returned")
-    public void testRestToEntityTransformerWithFullyPopulatedObject() {
+    void testRestToEntityTransformerWithFullyPopulatedObject() {
 
         Stocks stocks = new Stocks();
 
@@ -89,7 +89,7 @@ public class StocksTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty entity object returns null values ")
-    public void testTransformerWithEmptyEntityObject() {
+    void testTransformerWithEmptyEntityObject() {
 
         Stocks stocks = stocksTransformer.transform(new StocksEntity());
 
@@ -100,7 +100,7 @@ public class StocksTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with empty previous period Entity Object")
-    public void testEntityToRestTransformerWithEmptyPreviousPeriodEntityObject() {
+    void testEntityToRestTransformerWithEmptyPreviousPeriodEntityObject() {
 
         StocksEntity stocksEntity = new StocksEntity();
         StocksDataEntity stocksDataEntity = new StocksDataEntity();
@@ -123,7 +123,7 @@ public class StocksTransformerTest {
 
     @Test
     @DisplayName("Tests transformer with fully populated Entity object and validates values returned")
-    public void testEntityToRestTransformerWithFullyPopulatedEntityObject() {
+    void testEntityToRestTransformerWithFullyPopulatedEntityObject() {
 
         StocksEntity stocksEntity = new StocksEntity();
         StocksDataEntity stocksDataEntity = new StocksDataEntity();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/TangibleAssetsTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/TangibleAssetsTransformerTest.java
@@ -25,7 +25,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.tangibleass
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class TangibleAssetsTransformerTest {
+class TangibleAssetsTransformerTest {
 
     private static final Long NET_BOOK_VALUE_AT_END_OF_CURRENT_PERIOD = 1L;
     private static final Long NET_BOOK_VALUE_AT_END_OF_PREVIOUS_PERIOD = 2L;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/AccountTypeFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/AccountTypeFactoryTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.api.accounts.enumeration.AccountType;
 import uk.gov.companieshouse.api.accounts.links.CompanyAccountLinkType;
 
-public class AccountTypeFactoryTest {
+class AccountTypeFactoryTest {
 
     private AccountTypeFactory accountTypeFactory = new AccountTypeFactory();
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/AccountsNotesPathsYamlReaderTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/AccountsNotesPathsYamlReaderTest.java
@@ -19,7 +19,7 @@ import uk.gov.companieshouse.api.accounts.model.AccountsNotes;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class AccountsNotesPathsYamlReaderTest {
+class AccountsNotesPathsYamlReaderTest {
 
     @Mock
     private YamlResourceMapper yamlResourceMapper;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/ApiResponseMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/ApiResponseMapperTest.java
@@ -21,7 +21,7 @@ import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class ApiResponseMapperTest {
+class ApiResponseMapperTest {
 
     @Mock
     private RestObject restObject;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/ErrorMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/ErrorMapperTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ErrorMapperTest {
+class ErrorMapperTest {
 
     @InjectMocks
     private ErrorMapper errorMapper;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/PackageResolverTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/PackageResolverTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class PackageResolverTest {
+class PackageResolverTest {
 
     private PackageResolver packageResolver = new PackageResolver();
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/utility/impl/KeyIdGeneratorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/utility/impl/KeyIdGeneratorTest.java
@@ -1,5 +1,10 @@
 package uk.gov.companieshouse.api.accounts.utility.impl;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import java.security.MessageDigest;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,17 +14,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.security.MessageDigest;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class KeyIdGeneratorTest {
+class KeyIdGeneratorTest {
 
     @InjectMocks
     private KeyIdGenerator keyIdGenerator;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/ApprovalValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/ApprovalValidatorTest.java
@@ -35,7 +35,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ApprovalValidatorTest {
+class ApprovalValidatorTest {
 
     private static final String NAME = "directorName";
     private static final String COMPANY_ACCOUNTS = "companyAccountsId";

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/BalanceSheetValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/BalanceSheetValidatorTest.java
@@ -28,7 +28,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class BalanceSheetValidatorTest {
+class BalanceSheetValidatorTest {
 
     @Mock
     private CompanyService companyService;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/BaseValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/BaseValidatorTest.java
@@ -17,7 +17,7 @@ import uk.gov.companieshouse.api.accounts.service.CompanyService;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class BaseValidatorTest {
+class BaseValidatorTest {
 
     @Mock
     private CompanyService mockCompanyService;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CicApprovalValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CicApprovalValidatorTest.java
@@ -40,7 +40,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CicApprovalValidatorTest {
+class CicApprovalValidatorTest {
 
     private static final String COMPANY_NUMBER = "12345678";
     
@@ -187,4 +187,3 @@ public class CicApprovalValidatorTest {
         return companyAccountsLinks;
     }
 }
-

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CicReportValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CicReportValidatorTest.java
@@ -24,7 +24,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CicReportValidatorTest {
+class CicReportValidatorTest {
 
     @Mock
     private Transaction transaction;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CicStatementsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CicStatementsValidatorTest.java
@@ -21,7 +21,7 @@ import uk.gov.companieshouse.api.accounts.service.CompanyService;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CicStatementsValidatorTest {
+class CicStatementsValidatorTest {
 
     @Mock
     private CicStatements cicStatements;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CompanyAccountValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CompanyAccountValidatorTest.java
@@ -1,5 +1,10 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -7,40 +12,19 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.exception.ServiceException;
-import uk.gov.companieshouse.api.accounts.model.rest.Approval;
-import uk.gov.companieshouse.api.accounts.model.rest.CompanyAccount;
-import uk.gov.companieshouse.api.accounts.model.rest.NextAccounts;
-import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
-import uk.gov.companieshouse.api.accounts.model.rest.directorsreport.Director;
 import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.service.CompanyService;
-import uk.gov.companieshouse.api.accounts.service.impl.DirectorService;
-import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
-import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
 import uk.gov.companieshouse.api.model.company.account.NextAccountsApi;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 
-import javax.servlet.http.HttpServletRequest;
-import java.time.LocalDate;
-import java.time.Month;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CompanyAccountValidatorTest {
+class CompanyAccountValidatorTest {
 
     private static final String ERROR_PATH = "$.company_account";
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterMoreThanOneYearValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsAfterMoreThanOneYearValidatorTest.java
@@ -37,7 +37,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CreditorsAfterMoreThanOneYearValidatorTest {
+class CreditorsAfterMoreThanOneYearValidatorTest {
 
     private static final String CREDITORS_AFTER_PATH = "$.creditors_after_more_than_one_year";
     private static final String CREDITORS_AFTER_CURRENT_PERIOD_PATH = CREDITORS_AFTER_PATH +
@@ -322,8 +322,6 @@ public class CreditorsAfterMoreThanOneYearValidatorTest {
     @Test
     @DisplayName("Data exception thrown when company service API call fails")
     void testDataExceptionThrown() throws ServiceException {
-
-        Errors errors = new Errors();
 
         createValidNoteCurrentPeriod();
         createValidNotePreviousPeriod();

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidatorTests.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CreditorsWithinOneYearValidatorTests.java
@@ -37,7 +37,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CreditorsWithinOneYearValidatorTests {
+class CreditorsWithinOneYearValidatorTests {
 
     private static final String CREDITORS_WITHIN_PATH = "$.creditors_within_one_year";
     private static final String CREDITORS_WITHIN_CURRENT_PERIOD_PATH = CREDITORS_WITHIN_PATH +

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentInvestmentsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentInvestmentsValidatorTest.java
@@ -34,7 +34,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CurrentInvestmentsValidatorTest {
+class CurrentInvestmentsValidatorTest {
 
     private static final String UNEXPECTED_DATA_NAME = "unexpectedData";
     private static final String UNEXPECTED_DATA_VALUE = "unexpected.data";

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/CurrentPeriodValidatorTest.java
@@ -22,7 +22,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CurrentPeriodValidatorTest {
+class CurrentPeriodValidatorTest {
 
     @Mock
     private BalanceSheetValidator balanceSheetValidator;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DataTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DataTest.java
@@ -15,7 +15,7 @@ import javax.xml.bind.annotation.XmlElement;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class DataTest {
+class DataTest {
 
     @InjectMocks
     private Data data;
@@ -47,8 +47,8 @@ public class DataTest {
 
     @Test
     @DisplayName("Test If Get Methods have the appropriate annotation")
-    public void testHasMethodsWithAnnotation() {
-        Class dataClass = Data.class;
+    void testHasMethodsWithAnnotation() {
+        Class<Data> dataClass = Data.class;
         Method[] methods = dataClass.getDeclaredMethods();
         for (Method m : methods) {
             if(m.getName().startsWith("get")) {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DebtorsValidatorTest.java
@@ -35,7 +35,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class DebtorsValidatorTest {
+class DebtorsValidatorTest {
 
     private static final String DEBTORS_PATH = "$.debtors";
     private static final String DEBTORS_PATH_CURRENT = DEBTORS_PATH + ".current_period";

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/DirectorValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/DirectorValidatorTest.java
@@ -28,7 +28,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class DirectorValidatorTest {
+class DirectorValidatorTest {
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountId";
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/EmployeesValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/EmployeesValidatorTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class EmployeesValidatorTest {
+class EmployeesValidatorTest {
 
     private static final String EMPLOYEES_PATH = "$.employees";
     private static final String EMPLOYEES_PREVIOUS_PERIOD_PATH = EMPLOYEES_PATH +

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/FixedAssetsInvestmentsValidatorTest.java
@@ -32,7 +32,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class FixedAssetsInvestmentsValidatorTest {
+class FixedAssetsInvestmentsValidatorTest {
 
     private static final String UNEXPECTED_DATA_NAME = "unexpectedData";
     private static final String UNEXPECTED_DATA_VALUE = "unexpected.data";

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/NoteValidatorFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/NoteValidatorFactoryTest.java
@@ -19,7 +19,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.Note;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class NoteValidatorFactoryTest {
+class NoteValidatorFactoryTest {
 
     @Mock
     private NoteValidator<Note> noteValidator;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/PreviousPeriodValidatorTest.java
@@ -28,7 +28,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class PreviousPeriodValidatorTest {
+class PreviousPeriodValidatorTest {
 
     @Mock
     private CompanyService companyService;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/ProfitAndLossValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/ProfitAndLossValidatorTest.java
@@ -24,7 +24,7 @@ import uk.gov.companieshouse.api.accounts.service.CompanyService;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ProfitAndLossValidatorTest {
+class ProfitAndLossValidatorTest {
 
     private ProfitAndLoss profitAndLoss;
 

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/StocksValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/StocksValidatorTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class StocksValidatorTest {
+class StocksValidatorTest {
 
     private static final String STOCKS_PATH = "$.stocks";
     private static final String STOCKS_CURRENT_PERIOD_PATH = STOCKS_PATH +

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/TangibleAssetsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/TangibleAssetsValidatorTest.java
@@ -39,7 +39,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TangibleAssetsValidatorTest {
+class TangibleAssetsValidatorTest {
 
     private static final String UNEXPECTED_DATA_KEY = "unexpectedData";
     private static final String UNEXPECTED_DATA = "unexpected.data";

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/WithinCurrentPeriodImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/WithinCurrentPeriodImplTest.java
@@ -29,7 +29,7 @@ import uk.gov.companieshouse.api.accounts.parent.ParentResourceFactory;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class WithinCurrentPeriodImplTest {
+class WithinCurrentPeriodImplTest {
 
     @Mock
     private HttpServletRequest request;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/WithinSetDaysOfPeriodEndImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/WithinSetDaysOfPeriodEndImplTest.java
@@ -26,7 +26,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class WithinSetDaysOfPeriodEndImplTest {
+class WithinSetDaysOfPeriodEndImplTest {
 
     @Mock
     private HttpServletRequest request;
@@ -235,7 +235,9 @@ public class WithinSetDaysOfPeriodEndImplTest {
 
         when(companyService.getCompanyProfile(COMPANY_NUMBER)).thenThrow(ServiceException.class);
 
+        LocalDate periodEndOnMinusFourDays = PERIOD_END_ON.minusDays(4);
+
         assertThrows(UncheckedDataException.class,
-                () -> withinSetDaysOfPeriodEndImpl.isValid(PERIOD_END_ON.minusDays(4), context)); // 4 days before period end
+                () -> withinSetDaysOfPeriodEndImpl.isValid(periodEndOnMinusFourDays, context));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/ixbrl/DocumentGeneratorResponseValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/ixbrl/DocumentGeneratorResponseValidatorTest.java
@@ -18,7 +18,7 @@ import uk.gov.companieshouse.api.accounts.model.ixbrl.documentgenerator.Links;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class DocumentGeneratorResponseValidatorTest {
+class DocumentGeneratorResponseValidatorTest {
 
     private static final String IXBRL_LOCATION = "http://test/ixbrl_bucket_location";
     private static final String PERIOD_END_ON_KEY = "period_end_on";


### PR DESCRIPTION
- Rename class members that have the same name as their classes Costs, Error and Errors. Update getters and setters and classes that call these.
- Reduce verbosity of generics in AccountsNoteConverter
- Use primitive boolean in FilingServiceImpl
- The majority of changes are the removal of the public modifier from unit tests and methods within.
- Removed any unused imports or variables which were not used.
- Added, where possible, parameterised generics
