### PR TITLE
Added a call to delete sub transactions if parent rpt is deleted

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/RelatedPartyTransactionsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/RelatedPartyTransactionsServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import com.mongodb.MongoException;
 import uk.gov.companieshouse.GenerateEtagUtil;
+import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.Kind;
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
@@ -39,6 +40,9 @@ public class RelatedPartyTransactionsServiceImpl implements ParentService<Relate
 
     @Autowired
     private SmallFullService smallFullService;
+
+    @Autowired
+    RptTransactionServiceImpl rptTransactionService;
 
     @Override
     public ResponseObject<RelatedPartyTransactions> create(RelatedPartyTransactions rest, Transaction transaction,
@@ -88,6 +92,11 @@ public class RelatedPartyTransactionsServiceImpl implements ParentService<Relate
             HttpServletRequest request) throws DataException {
 
         String id = generateID(companyAccountsId);
+
+        Transaction transaction = (Transaction) request
+                .getAttribute(AttributeName.TRANSACTION.getValue());
+
+        rptTransactionService.deleteAll(transaction, companyAccountsId, request);
 
         try {
             if (repository.existsById(id)) {

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/RelatedPartyTransactionsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/RelatedPartyTransactionsServiceImplTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.verification.VerificationMode;
 import org.springframework.dao.DuplicateKeyException;
 import com.mongodb.MongoException;
+import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
@@ -88,6 +89,9 @@ class RelatedPartyTransactionsServiceImplTest {
 
     @Mock
     private RptTransaction rptTransaction;
+
+    @Mock
+    private RptTransactionServiceImpl rptTransactionService;
 
     @InjectMocks
     private RelatedPartyTransactionsServiceImpl service;
@@ -206,7 +210,9 @@ class RelatedPartyTransactionsServiceImplTest {
     @Test
     @DisplayName("Tests the successful deletion of a related party transactions resource")
     void deleteRelatedPartyTransactionsSuccess() throws DataException {
-        
+
+        when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
+
         when(keyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.RELATED_PARTY_TRANSACTIONS.getName()))
                 .thenReturn(GENERATED_ID);
 
@@ -219,6 +225,8 @@ class RelatedPartyTransactionsServiceImplTest {
         assertWhetherSmallFullServiceCalledToRemoveLink(true);
         assertEquals(ResponseStatus.UPDATED, response.getStatus());
         assertNull(response.getData());
+
+        verify(rptTransactionService).deleteAll(transaction, COMPANY_ACCOUNTS_ID, request);
     }
 
     @Test


### PR DESCRIPTION
This call was needed as leaving it out meant the child resources were still existing even if the user decided to remove the parent resource.

Updated unit test to cover new line of code.