### PR TITLE
Add related party transactions service, model and transformers

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/Kind.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/Kind.java
@@ -32,7 +32,8 @@ public enum Kind {
     LOANS_TO_DIRECTORS_LOANS("small-full-accounts-loans-to-directors#loans"),
     LOANS_TO_DIRECTORS_ADDITIONAL_INFO("small-full-accounts-loans-to-directors#additional-information"),
     RELATED_PARTY_TRANSACTIONS("small-full-accounts-note#related-party-transactions"),
-    RPT_TRANSACTIONS("small-full-accounts-note-related-party-transactions#transactions");
+    RPT_TRANSACTIONS("small-full-accounts-note-related-party-transactions#transactions"),
+    RELATED_PARTY_TRANSACTIONS_ADDITIONAL_INFO("small-full-accounts-related-party-transactions#additional-information");
 
     private String value;
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/smallfull/notes/relatedpartytransactions/AdditionalInformationDataEntity.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/smallfull/notes/relatedpartytransactions/AdditionalInformationDataEntity.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.api.accounts.model.entity.smallfull.notes.relatedpartytransactions;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+import uk.gov.companieshouse.api.accounts.model.entity.BaseDataEntity;
+
+public class AdditionalInformationDataEntity extends BaseDataEntity {
+
+    @Field("details")
+    private String details;
+
+    public String getDetails() {
+        return details;
+    }
+
+    public void setDetails(String details) {
+        this.details = details;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/smallfull/notes/relatedpartytransactions/AdditionalInformationEntity.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/entity/smallfull/notes/relatedpartytransactions/AdditionalInformationEntity.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.api.accounts.model.entity.smallfull.notes.relatedpartytransactions;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import uk.gov.companieshouse.api.accounts.model.entity.BaseEntity;
+
+@Document(collection = "notes")
+public class AdditionalInformationEntity extends BaseEntity {
+
+    @Field
+    private AdditionalInformationDataEntity data;
+
+    public AdditionalInformationDataEntity getData() {
+        return data;
+    }
+
+    public void setData(
+            AdditionalInformationDataEntity data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/smallfull/notes/relatedpartytransactions/AdditionalInformation.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/smallfull/notes/relatedpartytransactions/AdditionalInformation.java
@@ -1,0 +1,20 @@
+package uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.relatedpartytransactions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.companieshouse.api.accounts.model.rest.RestObject;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AdditionalInformation extends RestObject {
+
+    @JsonProperty("details")
+    private String details;
+
+    public String getDetails() {
+        return details;
+    }
+
+    public void setDetails(String details) {
+        this.details = details;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/repository/smallfull/RelatedPartyTransactionsAdditionalInformationRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/repository/smallfull/RelatedPartyTransactionsAdditionalInformationRepository.java
@@ -1,0 +1,9 @@
+package uk.gov.companieshouse.api.accounts.repository.smallfull;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.companieshouse.api.accounts.model.entity.smallfull.notes.relatedpartytransactions.AdditionalInformationEntity;
+
+@Repository
+public interface RelatedPartyTransactionsAdditionalInformationRepository extends MongoRepository<AdditionalInformationEntity, String> {
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/RelatedPartyTransactionsAdditionalInformationService.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/service/impl/RelatedPartyTransactionsAdditionalInformationService.java
@@ -1,0 +1,162 @@
+package uk.gov.companieshouse.api.accounts.service.impl;
+
+import com.mongodb.MongoException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.GenerateEtagUtil;
+import uk.gov.companieshouse.api.accounts.Kind;
+import uk.gov.companieshouse.api.accounts.ResourceName;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
+import uk.gov.companieshouse.api.accounts.links.RelatedPartyTransactionsLinkType;
+import uk.gov.companieshouse.api.accounts.model.entity.smallfull.notes.relatedpartytransactions.AdditionalInformationEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.relatedpartytransactions.AdditionalInformation;
+import uk.gov.companieshouse.api.accounts.repository.smallfull.RelatedPartyTransactionsAdditionalInformationRepository;
+import uk.gov.companieshouse.api.accounts.service.ResourceService;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.accounts.transformer.RelatedPartyTransactionsAdditionalInformationTransformer;
+import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class RelatedPartyTransactionsAdditionalInformationService implements ResourceService<AdditionalInformation> {
+
+    @Autowired
+    private RelatedPartyTransactionsAdditionalInformationTransformer transformer;
+
+    @Autowired
+    private RelatedPartyTransactionsAdditionalInformationRepository repository;
+
+    @Autowired
+    private RelatedPartyTransactionsServiceImpl relatedPartyTransactionsService;
+
+    @Autowired
+    private KeyIdGenerator keyIdGenerator;
+
+    @Override
+    public ResponseObject<AdditionalInformation> create(AdditionalInformation rest,
+                                                        Transaction transaction, String companyAccountId, HttpServletRequest request)
+            throws DataException {
+
+        setMetadataOnRest(rest, transaction, companyAccountId);
+
+        AdditionalInformationEntity entity = transformer.transform(rest);
+        entity.setId(generateID(companyAccountId));
+
+        try {
+            repository.insert(entity);
+        } catch (DuplicateKeyException e) {
+
+            return new ResponseObject<>(ResponseStatus.DUPLICATE_KEY_ERROR);
+        } catch (MongoException e) {
+
+            throw new DataException(e);
+        }
+
+        relatedPartyTransactionsService.addLink(companyAccountId, RelatedPartyTransactionsLinkType.ADDITIONAL_INFO,
+                getSelfLinkFromRestEntity(rest), request);
+
+        return new ResponseObject<>(ResponseStatus.CREATED, rest);
+    }
+
+    @Override
+    public ResponseObject<AdditionalInformation> update(AdditionalInformation rest,
+                                                        Transaction transaction, String companyAccountId, HttpServletRequest request)
+            throws DataException {
+
+        setMetadataOnRest(rest, transaction, companyAccountId);
+
+        AdditionalInformationEntity entity = transformer.transform(rest);
+        entity.setId(generateID(companyAccountId));
+
+        try {
+            repository.save(entity);
+        } catch (MongoException e) {
+            throw new DataException(e);
+        }
+
+        return new ResponseObject<>(ResponseStatus.UPDATED, rest);
+    }
+
+    @Override
+    public ResponseObject<AdditionalInformation> find(String companyAccountsId,
+                                                      HttpServletRequest request) throws DataException {
+
+        AdditionalInformationEntity entity;
+
+        try {
+            entity = repository.findById(generateID(companyAccountsId)).orElse(null);
+        } catch (MongoException e) {
+            throw new DataException(e);
+        }
+
+        if (entity == null) {
+            return new ResponseObject<>(ResponseStatus.NOT_FOUND);
+        }
+        return new ResponseObject<>(ResponseStatus.FOUND, transformer.transform(entity));
+    }
+
+    @Override
+    public ResponseObject<AdditionalInformation> delete(String companyAccountsId,
+                                                        HttpServletRequest request) throws DataException {
+
+        String id = generateID(companyAccountsId);
+
+        try {
+            if (repository.existsById(id)) {
+                repository.deleteById(id);
+
+                relatedPartyTransactionsService.removeLink(companyAccountsId,
+                        RelatedPartyTransactionsLinkType.ADDITIONAL_INFO, request);
+
+                return new ResponseObject<>(ResponseStatus.UPDATED);
+            } else {
+
+                return new ResponseObject<>(ResponseStatus.NOT_FOUND);
+            }
+        } catch (MongoException e) {
+
+            throw new DataException(e);
+        }
+    }
+
+    private String generateSelfLink(Transaction transaction, String companyAccountId) {
+
+        return transaction.getLinks().getSelf() + "/"
+                + ResourceName.COMPANY_ACCOUNT.getName() + "/" + companyAccountId + "/"
+                + ResourceName.SMALL_FULL.getName() + "/notes/"
+                + ResourceName.RELATED_PARTY_TRANSACTIONS.getName() + "/"
+                + ResourceName.ADDITIONAL_INFO.getName();
+    }
+
+    private Map<String, String> createLinks(Transaction transaction, String companyAccountsId) {
+
+        Map<String, String> map = new HashMap<>();
+        map.put(BasicLinkType.SELF.getLink(), generateSelfLink(transaction, companyAccountsId));
+        return map;
+    }
+
+    private void setMetadataOnRest(AdditionalInformation rest, Transaction transaction, String companyAccountsId) {
+
+        rest.setLinks(createLinks(transaction, companyAccountsId));
+        rest.setEtag(GenerateEtagUtil.generateEtag());
+        rest.setKind(Kind.RELATED_PARTY_TRANSACTIONS_ADDITIONAL_INFO.getValue());
+    }
+
+    private String generateID(String companyAccountId) {
+
+        return keyIdGenerator.generate(companyAccountId + "-" + ResourceName.RELATED_PARTY_TRANSACTIONS.getName() +
+                "-" + ResourceName.ADDITIONAL_INFO.getName());
+    }
+
+    private String getSelfLinkFromRestEntity(AdditionalInformation rest) {
+
+        return rest.getLinks().get(BasicLinkType.SELF.getLink());
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/transformer/RelatedPartyTransactionsAdditionalInformationTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/transformer/RelatedPartyTransactionsAdditionalInformationTransformer.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.api.accounts.transformer;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.accounts.model.entity.smallfull.notes.relatedpartytransactions.AdditionalInformationDataEntity;
+import uk.gov.companieshouse.api.accounts.model.entity.smallfull.notes.relatedpartytransactions.AdditionalInformationEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.relatedpartytransactions.AdditionalInformation;
+
+@Component
+public class RelatedPartyTransactionsAdditionalInformationTransformer implements GenericTransformer<AdditionalInformation, AdditionalInformationEntity> {
+
+    @Override
+    public AdditionalInformationEntity transform(AdditionalInformation rest) {
+
+        AdditionalInformationDataEntity additionalInformationDataEntity = new AdditionalInformationDataEntity();
+        AdditionalInformationEntity additionalInformationEntity = new AdditionalInformationEntity();
+
+        BeanUtils.copyProperties(rest, additionalInformationDataEntity);
+
+        additionalInformationEntity.setData(additionalInformationDataEntity);
+
+        return additionalInformationEntity;
+    }
+
+    @Override
+    public AdditionalInformation transform(AdditionalInformationEntity entity) {
+
+        AdditionalInformation additionalInformation = new AdditionalInformation();
+        BeanUtils.copyProperties(entity.getData(), additionalInformation);
+
+        return additionalInformation;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/RelatedPartyTransactionsAdditionalInformationServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/RelatedPartyTransactionsAdditionalInformationServiceTest.java
@@ -1,0 +1,311 @@
+package uk.gov.companieshouse.api.accounts.service.impl;
+
+import com.mongodb.MongoException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.verification.VerificationMode;
+import org.springframework.dao.DuplicateKeyException;
+import uk.gov.companieshouse.api.accounts.Kind;
+import uk.gov.companieshouse.api.accounts.ResourceName;
+import uk.gov.companieshouse.api.accounts.exception.DataException;
+import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
+import uk.gov.companieshouse.api.accounts.links.RelatedPartyTransactionsLinkType;
+import uk.gov.companieshouse.api.accounts.model.entity.smallfull.notes.relatedpartytransactions.AdditionalInformationEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.relatedpartytransactions.AdditionalInformation;
+import uk.gov.companieshouse.api.accounts.repository.smallfull.RelatedPartyTransactionsAdditionalInformationRepository;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseObject;
+import uk.gov.companieshouse.api.accounts.service.response.ResponseStatus;
+import uk.gov.companieshouse.api.accounts.transformer.RelatedPartyTransactionsAdditionalInformationTransformer;
+import uk.gov.companieshouse.api.accounts.utility.impl.KeyIdGenerator;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class )
+public class RelatedPartyTransactionsAdditionalInformationServiceTest {
+
+    @Mock
+    private RelatedPartyTransactionsAdditionalInformationTransformer transformer;
+
+    @Mock
+    private RelatedPartyTransactionsAdditionalInformationRepository repository;
+
+    @Mock
+    private RelatedPartyTransactionsServiceImpl relatedPartyTransactionsService;
+
+    @Mock
+    private KeyIdGenerator keyIdGenerator;
+
+    @Mock
+    private AdditionalInformation additionalInformation;
+
+    @Mock
+    private Transaction transaction;
+
+    @Mock
+    private TransactionLinks transactionLinks;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private AdditionalInformationEntity additionalInformationEntity;
+
+    @Mock
+    private Map<String, String> links;
+
+    @InjectMocks
+    private RelatedPartyTransactionsAdditionalInformationService rptAdditionalInformationService;
+
+    private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
+    private static final String GENERATED_ID = "generatedId";
+    private static final String TRANSACTION_SELF_LINK = "transactionSelfLink";
+    private static final String ADDITIONAL_INFO_SELF_LINK = "additionalInformationSelfLink";
+
+    @BeforeEach
+    private void setup() {
+
+        when(keyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.RELATED_PARTY_TRANSACTIONS.getName() + "-" + ResourceName.ADDITIONAL_INFO.getName()))
+                .thenReturn(GENERATED_ID);
+    }
+
+    @Test
+    @DisplayName("Tests the successful creation of an additionalInformation resource")
+    void createAdditionalInformationSuccess() throws DataException {
+
+        when(transformer.transform(additionalInformation)).thenReturn(additionalInformationEntity);
+
+        when(transaction.getLinks()).thenReturn(transactionLinks);
+        when(transactionLinks.getSelf()).thenReturn(TRANSACTION_SELF_LINK);
+
+        when(additionalInformation.getLinks()).thenReturn(links);
+        when(links.get(BasicLinkType.SELF.getLink())).thenReturn(ADDITIONAL_INFO_SELF_LINK);
+
+        ResponseObject<AdditionalInformation> response =
+                rptAdditionalInformationService
+                        .create(additionalInformation, transaction, COMPANY_ACCOUNTS_ID, request);
+
+        assertMetaDataSetOnRestObject();
+        assertIdGeneratedForDatabaseEntity();
+        assertRepositoryInsertCalled();
+        assertWhetherRelatedPartyTransactionsServiceCalledToAddLink(true);
+        assertEquals(ResponseStatus.CREATED, response.getStatus());
+        assertEquals(additionalInformation, response.getData());
+    }
+
+    @Test
+    @DisplayName("Tests the creation of a additionalInformation resource where the repository throws a duplicate key exception")
+    void createAdditionalInformationDuplicateKeyException() throws DataException {
+
+        when(transformer.transform(additionalInformation)).thenReturn(additionalInformationEntity);
+
+        when(transaction.getLinks()).thenReturn(transactionLinks);
+        when(transactionLinks.getSelf()).thenReturn(TRANSACTION_SELF_LINK);
+
+        when(repository.insert(additionalInformationEntity)).thenThrow(DuplicateKeyException.class);
+
+        ResponseObject<AdditionalInformation> response =
+                rptAdditionalInformationService
+                        .create(additionalInformation, transaction, COMPANY_ACCOUNTS_ID, request);
+
+        assertMetaDataSetOnRestObject();
+        assertIdGeneratedForDatabaseEntity();
+        assertWhetherRelatedPartyTransactionsServiceCalledToAddLink(false);
+        assertEquals(ResponseStatus.DUPLICATE_KEY_ERROR, response.getStatus());
+        assertNull(response.getData());
+    }
+
+    @Test
+    @DisplayName("Tests the creation of a additionalInformation resource where the repository throws a Mongo exception")
+    void createAdditionalInformationMongoException() throws DataException {
+
+        when(transformer.transform(additionalInformation)).thenReturn(additionalInformationEntity);
+
+        when(transaction.getLinks()).thenReturn(transactionLinks);
+        when(transactionLinks.getSelf()).thenReturn(TRANSACTION_SELF_LINK);
+
+        when(repository.insert(additionalInformationEntity)).thenThrow(MongoException.class);
+
+        assertThrows(DataException.class, () ->
+                rptAdditionalInformationService
+                        .create(additionalInformation, transaction, COMPANY_ACCOUNTS_ID, request));
+
+        assertMetaDataSetOnRestObject();
+        assertIdGeneratedForDatabaseEntity();
+        assertWhetherRelatedPartyTransactionsServiceCalledToAddLink(false);
+    }
+
+    @Test
+    @DisplayName("Tests the successful update of a additionalInformation resource")
+    void updateAdditionalInformationSuccess() throws DataException {
+
+        when(transformer.transform(additionalInformation)).thenReturn(additionalInformationEntity);
+
+        when(transaction.getLinks()).thenReturn(transactionLinks);
+        when(transactionLinks.getSelf()).thenReturn(TRANSACTION_SELF_LINK);
+
+        ResponseObject<AdditionalInformation> response =
+                rptAdditionalInformationService
+                        .update(additionalInformation, transaction, COMPANY_ACCOUNTS_ID, request);
+
+        assertMetaDataSetOnRestObject();
+        assertIdGeneratedForDatabaseEntity();
+        assertRepositoryUpdateCalled();
+        assertEquals(ResponseStatus.UPDATED, response.getStatus());
+        assertEquals(additionalInformation, response.getData());
+    }
+
+    @Test
+    @DisplayName("Tests the update of a additionalInformation resource where the repository throws a Mongo exception")
+    void updateAdditionalInformationMongoException() {
+
+        when(transformer.transform(additionalInformation)).thenReturn(additionalInformationEntity);
+
+        when(transaction.getLinks()).thenReturn(transactionLinks);
+        when(transactionLinks.getSelf()).thenReturn(TRANSACTION_SELF_LINK);
+
+        when(repository.save(additionalInformationEntity)).thenThrow(MongoException.class);
+
+        assertThrows(DataException.class, () ->
+                rptAdditionalInformationService
+                        .update(additionalInformation, transaction, COMPANY_ACCOUNTS_ID, request));
+
+        assertMetaDataSetOnRestObject();
+        assertIdGeneratedForDatabaseEntity();
+    }
+
+    @Test
+    @DisplayName("Tests the successful retrieval of a additionalInformation resource")
+    void getAdditionalInformationSuccess() throws DataException {
+
+        when(repository.findById(GENERATED_ID)).thenReturn(Optional.of(additionalInformationEntity));
+        when(transformer.transform(additionalInformationEntity)).thenReturn(additionalInformation);
+
+        ResponseObject<AdditionalInformation> response =
+                rptAdditionalInformationService.find(COMPANY_ACCOUNTS_ID, request);
+
+        assertEquals(ResponseStatus.FOUND, response.getStatus());
+        assertEquals(additionalInformation, response.getData());
+    }
+
+    @Test
+    @DisplayName("Tests the retrieval of a non-existent additionalInformation resource")
+    void getAdditionalInformationNotFound() throws DataException {
+
+        when(repository.findById(GENERATED_ID)).thenReturn(Optional.empty());
+
+        ResponseObject<AdditionalInformation> response =
+                rptAdditionalInformationService.find(COMPANY_ACCOUNTS_ID, request);
+
+        assertEquals(ResponseStatus.NOT_FOUND, response.getStatus());
+        assertNull(response.getData());
+    }
+
+    @Test
+    @DisplayName("Tests the retrieval of a additionalInformation resource where the repository throws a Mongo exception")
+    void getAdditionalInformationMongoException() {
+
+        when(repository.findById(GENERATED_ID)).thenThrow(MongoException.class);
+
+        assertThrows(DataException.class, () ->
+                rptAdditionalInformationService.find(COMPANY_ACCOUNTS_ID, request));
+    }
+
+    @Test
+    @DisplayName("Tests the successful deletion of a additionalInformation resource")
+    void deleteAdditionalInformationSuccess() throws DataException {
+
+        when(repository.existsById(GENERATED_ID)).thenReturn(true);
+
+        ResponseObject<AdditionalInformation> response =
+                rptAdditionalInformationService.delete(COMPANY_ACCOUNTS_ID, request);
+
+        assertRepositoryDeleteByIdCalled();
+        assertWhetherRelatedPartyTransactionsServiceCalledToRemoveLink(true);
+        assertEquals(ResponseStatus.UPDATED, response.getStatus());
+        assertNull(response.getData());
+    }
+
+    @Test
+    @DisplayName("Tests the deletion of a additionalInformation resource where the repository throws a Mongo exception")
+    void deleteAdditionalInformationMongoException() throws DataException {
+
+        when(repository.existsById(GENERATED_ID)).thenReturn(true);
+        doThrow(MongoException.class).when(repository).deleteById(GENERATED_ID);
+
+        assertThrows(DataException.class, () ->
+                rptAdditionalInformationService.delete(COMPANY_ACCOUNTS_ID, request));
+
+        assertWhetherRelatedPartyTransactionsServiceCalledToRemoveLink(false);
+    }
+
+    @Test
+    @DisplayName("Tests the deletion of a non-existent additionalInformation resource")
+    void deleteAdditionalInformationNotFound() throws DataException {
+
+        when(repository.existsById(GENERATED_ID)).thenReturn(false);
+
+        ResponseObject<AdditionalInformation> response =
+                rptAdditionalInformationService.delete(COMPANY_ACCOUNTS_ID, request);
+
+        verify(repository, never()).deleteById(GENERATED_ID);
+        assertWhetherRelatedPartyTransactionsServiceCalledToRemoveLink(false);
+        assertEquals(ResponseStatus.NOT_FOUND, response.getStatus());
+        assertNull(response.getData());
+    }
+
+    private void assertMetaDataSetOnRestObject() {
+        verify(additionalInformation, times(1)).setKind(Kind.RELATED_PARTY_TRANSACTIONS_ADDITIONAL_INFO.getValue());
+        verify(additionalInformation, times(1)).setEtag(anyString());
+        verify(additionalInformation, times(1)).setLinks(anyMap());
+    }
+
+    private void assertIdGeneratedForDatabaseEntity() {
+        verify(additionalInformationEntity, times(1)).setId(GENERATED_ID);
+    }
+
+    private void assertRepositoryInsertCalled() {
+        verify(repository, times(1)).insert(additionalInformationEntity);
+    }
+
+    private void assertRepositoryUpdateCalled() {
+        verify(repository, times(1)).save(additionalInformationEntity);
+    }
+
+    private void assertRepositoryDeleteByIdCalled() {
+        verify(repository, times(1)).deleteById(GENERATED_ID);
+    }
+
+    private void assertWhetherRelatedPartyTransactionsServiceCalledToAddLink(boolean isServiceExpected) throws DataException {
+
+        VerificationMode timesExpected = isServiceExpected ? times(1) : never();
+        verify(relatedPartyTransactionsService, timesExpected)
+                .addLink(COMPANY_ACCOUNTS_ID, RelatedPartyTransactionsLinkType.ADDITIONAL_INFO, ADDITIONAL_INFO_SELF_LINK, request);
+    }
+
+    private void assertWhetherRelatedPartyTransactionsServiceCalledToRemoveLink(boolean isServiceExpected) throws DataException {
+
+        VerificationMode timesExpected = isServiceExpected ? times(1) : never();
+        verify(relatedPartyTransactionsService, timesExpected)
+                .removeLink(COMPANY_ACCOUNTS_ID, RelatedPartyTransactionsLinkType.ADDITIONAL_INFO, request);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/RelatedPartyTransactionsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/service/impl/RelatedPartyTransactionsServiceImplTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.verification.VerificationMode;
 import org.springframework.dao.DuplicateKeyException;
 import com.mongodb.MongoException;
+import uk.gov.companieshouse.api.accounts.AttributeName;
 import uk.gov.companieshouse.api.accounts.ResourceName;
 import uk.gov.companieshouse.api.accounts.exception.DataException;
 import uk.gov.companieshouse.api.accounts.links.BasicLinkType;
@@ -88,6 +89,12 @@ class RelatedPartyTransactionsServiceImplTest {
 
     @Mock
     private RptTransaction rptTransaction;
+
+    @Mock
+    private RptTransactionServiceImpl rptTransactionService;
+
+    @Mock
+    private RelatedPartyTransactionsAdditionalInformationService additionalInformationService;
 
     @InjectMocks
     private RelatedPartyTransactionsServiceImpl service;
@@ -206,7 +213,9 @@ class RelatedPartyTransactionsServiceImplTest {
     @Test
     @DisplayName("Tests the successful deletion of a related party transactions resource")
     void deleteRelatedPartyTransactionsSuccess() throws DataException {
-        
+
+        when(request.getAttribute(AttributeName.TRANSACTION.getValue())).thenReturn(transaction);
+
         when(keyIdGenerator.generate(COMPANY_ACCOUNTS_ID + "-" + ResourceName.RELATED_PARTY_TRANSACTIONS.getName()))
                 .thenReturn(GENERATED_ID);
 
@@ -219,6 +228,9 @@ class RelatedPartyTransactionsServiceImplTest {
         assertWhetherSmallFullServiceCalledToRemoveLink(true);
         assertEquals(ResponseStatus.UPDATED, response.getStatus());
         assertNull(response.getData());
+
+        verify(rptTransactionService).deleteAll(transaction, COMPANY_ACCOUNTS_ID, request);
+        verify(additionalInformationService).delete(COMPANY_ACCOUNTS_ID, request);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/transformer/RelatedPartyTransactionsAdditionalInformationTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/transformer/RelatedPartyTransactionsAdditionalInformationTransformerTest.java
@@ -1,0 +1,52 @@
+package uk.gov.companieshouse.api.accounts.transformer;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.accounts.model.entity.smallfull.notes.relatedpartytransactions.AdditionalInformationDataEntity;
+import uk.gov.companieshouse.api.accounts.model.entity.smallfull.notes.relatedpartytransactions.AdditionalInformationEntity;
+import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.relatedpartytransactions.AdditionalInformation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class RelatedPartyTransactionsAdditionalInformationTransformerTest {
+
+    private static final String DETAILS = "details";
+
+    private RelatedPartyTransactionsAdditionalInformationTransformer transformer =
+            new RelatedPartyTransactionsAdditionalInformationTransformer();
+
+    @Test
+    @DisplayName("Transform rest object to entity")
+    void restToEntity() {
+
+        AdditionalInformation additionalInformation = new AdditionalInformation();
+        additionalInformation.setDetails(DETAILS);
+
+        AdditionalInformationEntity additionalInformationEntity = transformer.transform(additionalInformation);
+
+        assertNotNull(additionalInformationEntity);
+        assertNotNull(additionalInformationEntity.getData());
+        assertEquals(DETAILS, additionalInformationEntity.getData().getDetails());
+    }
+
+    @Test
+    @DisplayName("Transform entity to rest object")
+    void entityToRest() {
+
+        AdditionalInformationDataEntity additionalInformationDataEntity = new AdditionalInformationDataEntity();
+        additionalInformationDataEntity.setDetails(DETAILS);
+
+        AdditionalInformationEntity additionalInformationEntity = new AdditionalInformationEntity();
+        additionalInformationEntity.setData(additionalInformationDataEntity);
+
+        AdditionalInformation additionalInformation = transformer.transform(additionalInformationEntity);
+
+        assertNotNull(additionalInformation);
+        assertEquals(DETAILS, additionalInformation.getDetails());
+    }
+}


### PR DESCRIPTION
This PR add additional information resource for related party transactions. This includes model, transformer and service layer and also modifies code that when the parent
resource which is related party transactions is deleted then the child resource also gets deleted. This also includes relevant unit tests