### PR TITLE
Add validation for RPT transactions, transaction type

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/smallfull/notes/relatedpartytransactions/RptTransaction.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/smallfull/notes/relatedpartytransactions/RptTransaction.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.companieshouse.api.accounts.model.rest.RestObject;
 import uk.gov.companieshouse.api.accounts.validation.CharSetValid;
+import uk.gov.companieshouse.api.accounts.validation.ValidRptTransactionType;
 import uk.gov.companieshouse.charset.CharSet;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -35,6 +36,7 @@ public class RptTransaction extends RestObject {
     private String descriptionOfTransaction;
 
     @NotNull
+    @ValidRptTransactionType
     @CharSetValid(CharSet.CHARACTER_SET_2)
     @JsonProperty("transaction_type")
     private String transactionType;

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/RptTransactionValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/RptTransactionValidator.java
@@ -12,8 +12,6 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 public class RptTransactionValidator extends BaseValidator {
 
     private static final String TRANSACTION_BREAKDOWN_PATH_BALANCE_AT_PERIOD_START = "$.transaction.breakdown.balance_at_period_start";
-    private static final String[] TRANSACTION_TYPE_MESSAGE = {"money given to the company by a related party", "money given to a related party by the company"};
-    private static final String TRANSACTION_TYPE = "$.transaction.transaction_type";
 
     @Autowired
     public RptTransactionValidator(CompanyService companyService) {
@@ -31,12 +29,6 @@ public class RptTransactionValidator extends BaseValidator {
             return errors;
         } else if (isMultipleYearFiler && rptTransaction.getBreakdown().getBalanceAtPeriodStart() == null) {
             addError(errors, mandatoryElementMissing, TRANSACTION_BREAKDOWN_PATH_BALANCE_AT_PERIOD_START);
-            return errors;
-        }
-
-        if (!((rptTransaction.getTransactionType().trim().equalsIgnoreCase(TRANSACTION_TYPE_MESSAGE[0]) ||
-                rptTransaction.getTransactionType().trim().equalsIgnoreCase(TRANSACTION_TYPE_MESSAGE[1])))) {
-            addError(errors, invalidValue, TRANSACTION_TYPE);
             return errors;
         }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/RptTransactionValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/RptTransactionValidator.java
@@ -12,6 +12,8 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 public class RptTransactionValidator extends BaseValidator {
 
     private static final String TRANSACTION_BREAKDOWN_PATH_BALANCE_AT_PERIOD_START = "$.transaction.breakdown.balance_at_period_start";
+    private static final String[] TRANSACTION_TYPE_MESSAGE = {"money given to the company by a related party", "money given to a related party by the company"};
+    private static final String TRANSACTION_TYPE = "$.transaction.transaction_type";
 
     @Autowired
     public RptTransactionValidator(CompanyService companyService) {
@@ -24,11 +26,17 @@ public class RptTransactionValidator extends BaseValidator {
 
         boolean isMultipleYearFiler = getIsMultipleYearFiler(transaction);
 
-        if(!isMultipleYearFiler && rptTransaction.getBreakdown().getBalanceAtPeriodStart() != null ) {
+        if (!isMultipleYearFiler && rptTransaction.getBreakdown().getBalanceAtPeriodStart() != null) {
             addError(errors, unexpectedData, TRANSACTION_BREAKDOWN_PATH_BALANCE_AT_PERIOD_START);
             return errors;
         } else if (isMultipleYearFiler && rptTransaction.getBreakdown().getBalanceAtPeriodStart() == null) {
             addError(errors, mandatoryElementMissing, TRANSACTION_BREAKDOWN_PATH_BALANCE_AT_PERIOD_START);
+            return errors;
+        }
+
+        if (!((rptTransaction.getTransactionType().trim().equalsIgnoreCase(TRANSACTION_TYPE_MESSAGE[0]) ||
+                rptTransaction.getTransactionType().trim().equalsIgnoreCase(TRANSACTION_TYPE_MESSAGE[1])))) {
+            addError(errors, invalidValue, TRANSACTION_TYPE);
             return errors;
         }
 

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/ValidRptTransactionType.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/ValidRptTransactionType.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.api.accounts.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target(FIELD)
+@Constraint(validatedBy = ValidRptTransactionTypeImpl.class)
+public @interface ValidRptTransactionType {
+
+    String message() default "{mustMatch.money.given.or.received.by.related.party}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/ValidRptTransactionTypeImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/ValidRptTransactionTypeImpl.java
@@ -1,10 +1,12 @@
 package uk.gov.companieshouse.api.accounts.validation;
 
 import org.apache.commons.lang.StringUtils;
+import org.springframework.stereotype.Component;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
+@Component
 public class ValidRptTransactionTypeImpl implements ConstraintValidator<ValidRptTransactionType, String> {
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/ValidRptTransactionTypeImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/ValidRptTransactionTypeImpl.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.api.accounts.validation;
+
+import org.apache.commons.lang.StringUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ValidRptTransactionTypeImpl implements ConstraintValidator<ValidRptTransactionType, String> {
+
+    @Override
+    public boolean isValid(String rptTransactionType, ConstraintValidatorContext context) {
+        return StringUtils.isBlank(rptTransactionType)
+                || rptTransactionType.trim().equalsIgnoreCase("money given to the company by a related party")
+                || rptTransactionType.trim().equalsIgnoreCase( "money given to a related party by the company");
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/ValidRptTransactionTypeImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/ValidRptTransactionTypeImpl.java
@@ -5,14 +5,22 @@ import org.springframework.stereotype.Component;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import java.util.HashSet;
+import java.util.Set;
 
 @Component
 public class ValidRptTransactionTypeImpl implements ConstraintValidator<ValidRptTransactionType, String> {
 
+    private static final Set<String> LEGAL_TRANSACTION_TYPES = new HashSet<>();
+
+    static {
+        LEGAL_TRANSACTION_TYPES.add("Money given to the company by a related party");
+        LEGAL_TRANSACTION_TYPES.add("Money given to a related party by the company");
+    }
+
     @Override
     public boolean isValid(String rptTransactionType, ConstraintValidatorContext context) {
         return StringUtils.isBlank(rptTransactionType)
-                || rptTransactionType.trim().equalsIgnoreCase("money given to the company by a related party")
-                || rptTransactionType.trim().equalsIgnoreCase( "money given to a related party by the company");
+                || LEGAL_TRANSACTION_TYPES.contains(rptTransactionType.trim());
     }
 }

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -25,3 +25,4 @@ date.outside.currentPeriod=date_outside_current_period
 mustMatch.directorOrSecretary=must_match_director_or_secretary
 mustMatch.director=must_match_a_director_given_in_directors_report
 mustMatch.frs101.or.frs102=must_match_frs101_or_frs102
+mustMatch.money.given.or.received.by.related.party=must_match_money_given_or_received_by_related_party

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/ValidRptTransactionTypeImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/ValidRptTransactionTypeImplTest.java
@@ -1,0 +1,62 @@
+package uk.gov.companieshouse.api.accounts.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.validation.ConstraintValidatorContext;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ValidRptTransactionTypeImplTest {
+
+    @Mock
+    private ConstraintValidatorContext context;
+
+    private static final String MONEY_GIVEN_TO_RELATED_PARTY = "Money given to a related party by the company";
+    private static final String MONEY_GIVEN_BY_RELATED_PARTY = "Money given to the company by a related party";
+    private static final String OTHER = "Money given by someone else";
+
+    private ValidRptTransactionTypeImpl validRptTransactionType;
+
+    @BeforeEach
+    private void setup() {
+
+        validRptTransactionType = new ValidRptTransactionTypeImpl();
+    }
+
+    @Test
+    @DisplayName("Test when money is given to related party by the company")
+    void testMoneyGivenToRelatedParty() {
+
+        assertTrue(validRptTransactionType.isValid(MONEY_GIVEN_TO_RELATED_PARTY, context));
+    }
+
+    @Test
+    @DisplayName("Test when money is given by related party to the company")
+    void testMoneyGivenByRelatedParty() {
+
+        assertTrue(validRptTransactionType.isValid(MONEY_GIVEN_BY_RELATED_PARTY, context));
+    }
+
+    @Test
+    @DisplayName("Test when RPT transaction type is null")
+    void testRptTransactionTypeIsNull() {
+
+        assertTrue(validRptTransactionType.isValid(null, context));
+    }
+
+    @Test
+    @DisplayName("Test when RPT transaction type is other than money give to the related party or money given by related party")
+    void testRegulatoryStandardOther() {
+
+        assertFalse(validRptTransactionType.isValid(OTHER, context));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/ValidRptTransactionTypeImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/ValidRptTransactionTypeImplTest.java
@@ -17,12 +17,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ValidRptTransactionTypeImplTest {
 
-    @Mock
-    private ConstraintValidatorContext context;
-
     private static final String MONEY_GIVEN_TO_RELATED_PARTY = "Money given to a related party by the company";
     private static final String MONEY_GIVEN_BY_RELATED_PARTY = "Money given to the company by a related party";
     private static final String OTHER = "Money given by someone else";
+
+    @Mock
+    private ConstraintValidatorContext context;
 
     private ValidRptTransactionTypeImpl validRptTransactionType;
 


### PR DESCRIPTION
This commit checks whether the value supplied for transaction type field of transactions is one of the two acceptable values.
If the value supplied does not match either of the two sentences then it throws invalid data error

Resolves: BI-6264


![image](https://user-images.githubusercontent.com/53441646/100914601-2fce8080-34cb-11eb-9050-5f613a9d0620.png)
