### PR TITLE
Make name of related party optional

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/smallfull/notes/relatedpartytransactions/RptTransaction.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/model/rest/smallfull/notes/relatedpartytransactions/RptTransaction.java
@@ -19,7 +19,7 @@ public class RptTransaction extends RestObject {
 
 
     @CharSetValid(CharSet.CHARACTER_SET_2)
-    @Size(min = MIN_FIELD_LENGTH, max = MAX_FIELD_LENGTH, message = "invalid.input.length")
+    @Size(max = MAX_FIELD_LENGTH, message = "invalid.input.length")
     @JsonProperty("name_of_related_party")
     private String nameOfRelatedParty;
 


### PR DESCRIPTION
- Remove the minimum length constraint from name of related party to make it optional

Resolves: BI-5337