### PR TITLE
Resolves issues with mandatory element missing on stocks note

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/transactionclosure/StocksTxnClosureValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/transactionclosure/StocksTxnClosureValidator.java
@@ -9,6 +9,7 @@ import uk.gov.companieshouse.api.accounts.model.rest.BalanceSheet;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.Note;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
+import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.stocks.Stocks;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.service.CompanyService;
 import uk.gov.companieshouse.api.accounts.service.NoteService;
@@ -59,15 +60,22 @@ public class StocksTxnClosureValidator extends BaseValidator {
                 }
             }
         } else { // if there's no stock note, then there should be no stock values on the balance sheet.
-            if (Optional.of(currentPeriodBalanceSheet)
+
+
+            long currentStock = Optional.of(currentPeriodBalanceSheet)
                     .map(BalanceSheet::getCurrentAssets)
                     .map(CurrentAssets::getStocks)
-                    .isPresent() ||
-                    (getIsMultipleYearFiler(transaction) &&
-                    Optional.of(previousPeriodBalanceSheet)
-                            .map(BalanceSheet::getCurrentAssets)
-                            .map(CurrentAssets::getStocks)
-                            .isPresent())) {
+                    .orElse(0L);
+
+            long previousStock = 0L;
+
+            if(getIsMultipleYearFiler(transaction)) {
+                 previousStock = Optional.of(previousPeriodBalanceSheet)
+                        .map(BalanceSheet::getCurrentAssets)
+                        .map(CurrentAssets::getStocks)
+                        .orElse(0L);
+            }
+            if (currentStock != 0 || previousStock != 0) {
                 addError(errors, mandatoryElementMissing, SMALL_FULL_STOCKS_LOCATION);
             }
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/validation/transactionclosure/StocksTxnClosureValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/validation/transactionclosure/StocksTxnClosureValidator.java
@@ -9,7 +9,6 @@ import uk.gov.companieshouse.api.accounts.model.rest.BalanceSheet;
 import uk.gov.companieshouse.api.accounts.model.rest.CurrentAssets;
 import uk.gov.companieshouse.api.accounts.model.rest.Note;
 import uk.gov.companieshouse.api.accounts.model.rest.SmallFull;
-import uk.gov.companieshouse.api.accounts.model.rest.smallfull.notes.stocks.Stocks;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.service.CompanyService;
 import uk.gov.companieshouse.api.accounts.service.NoteService;

--- a/src/test/java/uk/gov/companieshouse/api/accounts/validation/transactionclosure/StocksTxnClosureValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/validation/transactionclosure/StocksTxnClosureValidatorTest.java
@@ -216,6 +216,40 @@ class StocksTxnClosureValidatorTest {
         assertEquals(emptyErrors, responseErrors);
     }
 
+    @Test
+    @DisplayName("Validate stocks on txn closure - no stocks note - balance sheet data contains '0' - MF")
+    void validateStocksTnClosureNoNoteDoesNotErrorMF() throws ServiceException, DataException {
+
+        Errors emptyErrors = new Errors();
+
+        when(smallFull.getLinks()).thenReturn(createSmallFullLinks(false));
+
+        when(companyService.isMultipleYearFiler(transaction)).thenReturn(true);
+        when(previousPeriodBs.getCurrentAssets()).thenReturn(currentAssets);
+        when(currentAssets.getStocks()).thenReturn(0L);
+
+        Errors responseErrors = stocksTxnClosureValidator.validate(COMPANY_ACCOUNTS_ID, smallFull, transaction, request, emptyErrors, currentPeriodBs, previousPeriodBs);
+
+        assertFalse(responseErrors.hasErrors());
+        assertEquals(responseErrors.getErrorCount(), 0);
+    }
+
+    @Test
+    @DisplayName("Validate stocks on txn closure - no stocks note - balance sheet data contains '0' - SF")
+    void validateStocksTnClosureNoNoteDoesNotErrorSF() throws ServiceException, DataException {
+
+        Errors emptyErrors = new Errors();
+
+        when(smallFull.getLinks()).thenReturn(createSmallFullLinks(false));
+
+        when(companyService.isMultipleYearFiler(transaction)).thenReturn(false);
+
+        Errors responseErrors = stocksTxnClosureValidator.validate(COMPANY_ACCOUNTS_ID, smallFull, transaction, request, emptyErrors, currentPeriodBs, previousPeriodBs);
+
+        assertFalse(responseErrors.hasErrors());
+        assertEquals(responseErrors.getErrorCount(), 0);
+    }
+
     private Map<String, String> createSmallFullLinks(boolean includeStocksLink) {
         Map<String, String> links = new HashMap<>();
 


### PR DESCRIPTION
This commit resolves issues where users when they enter 0 in the figure for stocks on balance sheet. When users enter 0 or leave the field blank on balance sheet then it does not display the note in the journey. Transactions closure validation previously looked into this and based on the figure it validated the value. This commit in addition to transaction closure resolves the issue

Resolves: BI-6485