### PR TITLE
updating template to reflect 2019 taxonomy

### DIFF
--- a/src/main/resources/filing/templates/small-full-accounts.html
+++ b/src/main/resources/filing/templates/small-full-accounts.html
@@ -1,6 +1,6 @@
 {{"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" | unescaped}}
 
-<html xmlns:ixt2="http://www.xbrl.org/inlineXBRL/transformation/2011-07-31" xmlns="http://www.w3.org/1999/xhtml" xmlns:core="http://xbrl.frc.org.uk/fr/2014-09-01/core" xmlns:xbrldi="http://xbrl.org/2006/xbrldi" xmlns:curr="http://xbrl.frc.org.uk/cd/2014-09-01/currencies" xmlns:countries="http://xbrl.frc.org.uk/cd/2014-09-01/countries" xmlns:uk-bus="http://xbrl.frc.org.uk/cd/2014-09-01/business" xmlns:ix="http://www.xbrl.org/2013/inlineXBRL" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:xbrli="http://www.xbrl.org/2003/instance" xmlns:direp="http://xbrl.frc.org.uk/reports/2014-09-01/direp" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xmlns:link="http://www.xbrl.org/2003/linkbase" xmlns:iso4217="http://www.xbrl.org/2003/iso4217">
+<html xmlns:ixt2="http://www.xbrl.org/inlineXBRL/transformation/2011-07-31" xmlns="http://www.w3.org/1999/xhtml" xmlns:core="http://xbrl.frc.org.uk/fr/2019-01-01/core" xmlns:xbrldi="http://xbrl.org/2006/xbrldi" xmlns:curr="http://xbrl.frc.org.uk/cd/2019-01-01/currencies" xmlns:countries="http://xbrl.frc.org.uk/cd/2019-01-01/countries" xmlns:uk-bus="http://xbrl.frc.org.uk/cd/2019-01-01/business" xmlns:ix="http://www.xbrl.org/2013/inlineXBRL" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:xbrli="http://www.xbrl.org/2003/instance" xmlns:direp="http://xbrl.frc.org.uk/reports/2019-01-01/direp" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xmlns:link="http://www.xbrl.org/2003/linkbase" xmlns:iso4217="http://www.xbrl.org/2003/iso4217">
 {{$company := .small_full_accounts.company}}
 {{$companyName := $company.company_name}}
 {{$companyNumber := $company.company_number}}
@@ -306,7 +306,7 @@
 
         </ix:hidden>
         <ix:references>
-          <link:schemaRef xlink:type="simple" xlink:href="https://xbrl.frc.org.uk/FRS-102/2014-09-01/FRS-102-2014-09-01.xsd" />
+          <link:schemaRef xlink:href="https://xbrl.frc.org.uk/FRS-102/2019-01-01/FRS-102-2019-01-01.xsd" xlink:type="simple" />
         </ix:references>
         <ix:resources>
           <xbrli:unit id="GBP">


### PR DESCRIPTION
Updating the Small full taxonomy template to have the correct dates for 2019 taxonomy__

__[UK-11](https://companieshouse.atlassian.net/browse/UK-11)__

### Type of change
* [ ] Updating the taxonomy references to reflect the 2019 standard
