### PR TITLE
Update jib plugin version to fix PKIX error in docker build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
       <plugin>
             <groupId>com.google.cloud.tools</groupId>
             <artifactId>jib-maven-plugin</artifactId>
-            <version>2.7.0</version>
+            <version>3.1.1</version>
             <configuration>
                 <container>
                     <expandClasspathDependencies>true</expandClasspathDependencies>


### PR DESCRIPTION
- Fix to avoid error in docker build job in the pipeline 

> PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target