### PR TITLE
Remove account as available_payment_method in the payments service

### DIFF
--- a/src/main/resources/costs/costs.yaml
+++ b/src/main/resources/costs/costs.yaml
@@ -1,7 +1,7 @@
 costs:
   cic-report:
     amount: 15
-    available_payment_methods: [credit-card, account]
+    available_payment_methods: [credit-card]
     class_of_payment: [data-maintenance]
     description: CIC report and accounts
     description_identifier: cic-report


### PR DESCRIPTION
As `account` payment-method isn't provided by the payments service adding it in as a payment option for the payments service causes a bug showing an `unrecognised_payment_method` 