### PR TITLE
Update log4j to safe version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <!-- Dependency Versions -->
     <api-helper-java.version>1.4.3</api-helper-java.version>
     <structured-logging.version>1.9.11</structured-logging.version>
+    <log4j2.version>2.16.0</log4j2.version>
     <aws-java-sdk.version>1.11.486</aws-java-sdk.version>
     <company-accounts-library.version>1.2.12</company-accounts-library.version>
     <private-api-sdk-java.version>2.0.64</private-api-sdk-java.version>
@@ -45,6 +46,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j2.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,8 @@
 
     <!-- Dependency Versions -->
     <api-helper-java.version>1.4.3</api-helper-java.version>
-    <structured-logging.version>1.4.0-rc2</structured-logging.version>
+    <structured-logging.version>1.9.11</structured-logging.version>
+    <log4j2.version>2.16.0</log4j2.version>
     <aws-java-sdk.version>1.11.486</aws-java-sdk.version>
     <company-accounts-library.version>1.2.12</company-accounts-library.version>
     <private-api-sdk-java.version>2.0.64</private-api-sdk-java.version>
@@ -46,6 +47,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j2.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot-dependencies.version}</version>
@@ -57,6 +65,11 @@
 
   <dependencies>
     <!-- Compile -->
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20211205</version>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
     <!-- Dependency Versions -->
     <api-helper-java.version>1.4.3</api-helper-java.version>
     <structured-logging.version>1.9.11</structured-logging.version>
-    <log4j2.version>2.16.0</log4j2.version>
     <aws-java-sdk.version>1.11.486</aws-java-sdk.version>
     <company-accounts-library.version>1.2.12</company-accounts-library.version>
     <private-api-sdk-java.version>2.0.64</private-api-sdk-java.version>
@@ -46,13 +45,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-bom</artifactId>
-                <version>${log4j2.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/src/main/java/uk/gov/companieshouse/api/accounts/controller/FilingController.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/controller/FilingController.java
@@ -63,7 +63,6 @@ public class FilingController {
 
         final Map<String, Object> debugMap = new HashMap<>();
         debugMap.put("request_method", request.getMethod());
-        debugMap.put("message", FILING_CONTROLLER_ERROR + errorMessage);
-        LOGGER.errorRequest(request, null, debugMap);
+        LOGGER.errorRequest(request, FILING_CONTROLLER_ERROR + errorMessage, debugMap);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/ClosedTransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/ClosedTransactionInterceptor.java
@@ -34,10 +34,7 @@ public class ClosedTransactionInterceptor extends HandlerInterceptorAdapter {
             .equalsIgnoreCase(transaction.getStatus().getStatus())) {
             final Map<String, Object> debugMap = new HashMap<>();
             debugMap.put("request_method", request.getMethod());
-            debugMap.put("message",
-                "ClosedTransactionInterceptor error: no closed transaction available");
-
-            LOGGER.errorRequest(request, null, debugMap);
+            LOGGER.errorRequest(request, "ClosedTransactionInterceptor error: no closed transaction available", debugMap);
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return false;
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/CompanyAccountInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/CompanyAccountInterceptor.java
@@ -67,9 +67,7 @@ public class CompanyAccountInterceptor extends HandlerInterceptorAdapter {
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
         if (transaction == null) {
-            debugMap.put("message",
-                "CompanyAccountInterceptor error: no transaction in request session");
-            LOGGER.errorRequest(request, null, debugMap);
+            LOGGER.errorRequest(request, "CompanyAccountInterceptor error: no transaction in request session", debugMap);
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return false;
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/CurrentPeriodInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/CurrentPeriodInterceptor.java
@@ -53,9 +53,7 @@ public class CurrentPeriodInterceptor extends HandlerInterceptorAdapter {
         Transaction transaction = (Transaction) request
                 .getAttribute(AttributeName.TRANSACTION.getValue());
         if (transaction == null) {
-            debugMap.put("message",
-                    "CurrentPeriodInterceptor error: No transaction in request session");
-            LOGGER.errorRequest(request, null, debugMap);
+             LOGGER.errorRequest(request, "CurrentPeriodInterceptor error: No transaction in request session", debugMap);
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return false;
         }
@@ -72,9 +70,7 @@ public class CurrentPeriodInterceptor extends HandlerInterceptorAdapter {
                 .getAttribute(AttributeName.SMALLFULL.getValue());
 
         if (smallFull == null) {
-            debugMap.put("message",
-                    "CurrentPeriodInterceptor error: No company account in request session");
-            LOGGER.errorRequest(request, null, debugMap);
+              LOGGER.errorRequest(request, "CurrentPeriodInterceptor error: No company account in request session", debugMap);
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return false;
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/OpenTransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/OpenTransactionInterceptor.java
@@ -36,9 +36,8 @@ public class OpenTransactionInterceptor extends HandlerInterceptorAdapter {
                 .equalsIgnoreCase(transaction.getStatus().getStatus()))) {
             final Map<String, Object> debugMap = new HashMap<>();
             debugMap.put("request_method", request.getMethod());
-            debugMap.put("message", "OpenTransactionInterceptor error: no open transaction available");
 
-            LOGGER.errorRequest(request, null, debugMap);
+            LOGGER.errorRequest(request, "OpenTransactionInterceptor error: no open transaction available", debugMap);
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             return false;
         }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/PreviousPeriodInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/PreviousPeriodInterceptor.java
@@ -53,9 +53,7 @@ public class PreviousPeriodInterceptor extends HandlerInterceptorAdapter {
             Transaction transaction = (Transaction) request
                     .getAttribute(AttributeName.TRANSACTION.getValue());
             if (transaction == null) {
-                debugMap.put("message",
-                        "PreviousPeriodInterceptor error: No transaction in request session");
-                LOGGER.errorRequest(request, null, debugMap);
+                LOGGER.errorRequest(request, "PreviousPeriodInterceptor error: No transaction in request session", debugMap);
                 response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 return false;
             }
@@ -72,9 +70,7 @@ public class PreviousPeriodInterceptor extends HandlerInterceptorAdapter {
                     .getAttribute(AttributeName.SMALLFULL.getValue());
 
             if (smallFull == null) {
-                debugMap.put("message",
-                        "PreviousPeriodInterceptor error: No company account in request session");
-                LOGGER.errorRequest(request, null, debugMap);
+                LOGGER.errorRequest(request, "PreviousPeriodInterceptor error: No company account in request session", debugMap);
                 response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 return false;
             }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptor.java
@@ -71,9 +71,7 @@ public class SmallFullInterceptor extends HandlerInterceptorAdapter {
         Transaction transaction = (Transaction) request
             .getAttribute(AttributeName.TRANSACTION.getValue());
         if (transaction == null) {
-            debugMap.put("message",
-                "SmallFullInterceptor error: No transaction in request session");
-            LOGGER.errorRequest(request, null, debugMap);
+             LOGGER.errorRequest(request, "SmallFullInterceptor error: No transaction in request session", debugMap);
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return false;
         }
@@ -90,9 +88,8 @@ public class SmallFullInterceptor extends HandlerInterceptorAdapter {
             .getAttribute(AttributeName.COMPANY_ACCOUNT.getValue());
 
         if (companyAccount == null) {
-            debugMap.put("message",
-                "SmallFullInterceptor error: No company account in request session");
-            LOGGER.errorRequest(request, null, debugMap);
+
+            LOGGER.errorRequest(request, "SmallFullInterceptor error: No company account in request session", debugMap);
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return false;
         }


### PR DESCRIPTION
Updates log4j to version 2.16.0 and structured-logging to version 1.9.11.

This dependency has been directly added to the pom.xml file due to springboot dependency management bringing in old version of log4j regardless of what is being  used in structured-logging. This will should be removed when springboot has been upgraded to the required patch 2.5.8 or  
2.6.2.
More information can be found here: https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot
Structured-logging version updated to 1.9.10.

Resolved issue of overloaded methods in structured logging library.

Resolves DEBT-1436.