### PR TITLE
rename dep check and use parent-pom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,6 @@ sonar:
 sonar-pr-analysis:
 	mvn sonar:sonar -P sonar-pr-analysis
 
-.PHONY: dependency-check
-dependency-check:
+.PHONY: security-check
+security-check:
 	mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=4 -DassemblyAnalyzerEnabled=false

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>uk.gov.companieshouse</groupId>
     <artifactId>companies-house-parent</artifactId>
-    <version>1.3.1</version>
+    <version>2.1.4</version>
   </parent>
 
   <properties>
@@ -32,8 +32,6 @@
     <private-api-sdk-java.version>2.0.64</private-api-sdk-java.version>
     <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
     <commons-io.version>2.7</commons-io.version>
-
-    <dependency-check-plugin.version>8.2.1</dependency-check-plugin.version>
 
     <spring-boot-dependencies.version>2.5.5</spring-boot-dependencies.version>
     <spring-boot-maven-plugin.version>2.5.5</spring-boot-maven-plugin.version>
@@ -247,18 +245,6 @@
                     <expandClasspathDependencies>true</expandClasspathDependencies>
                 </container>
             </configuration>
-      </plugin>
-      <plugin>
-          <groupId>org.owasp</groupId>
-          <artifactId>dependency-check-maven</artifactId>
-          <version>${dependency-check-plugin.version}</version>
-          <executions>
-              <execution>
-              <goals>
-                  <goal>check</goal>
-              </goals>
-              </execution>
-          </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
rename to security-check to allow pipeline to run it if needed:

Cache results of previous builds per advice (https://github.com/jeremylong/DependencyCheck?tab=readme-ov-file#the-nvd-api-key-ci-and-rate-limiting)

Use parent pom to retrieve version and key for nvd api check rather than data feed.