### PR TITLE
fix: update listener rules to catch more paths

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -10,7 +10,7 @@ locals {
   docker_repo                = "company-accounts.api.ch.gov.uk"
   kms_alias                  = "alias/${var.aws_profile}/environment-services-kms"
   lb_listener_rule_priority  = 58
-  lb_listener_paths          = ["/transactions/*/company-accounts","/private/transactions/*/company-accounts","/company-accounts/healthcheck"]
+  lb_listener_paths          = ["/transactions/*/company-accounts*","/private/transactions/*/company-accounts*","/company-accounts/healthcheck"]
   healthcheck_path           = "/company-accounts/healthcheck" #healthcheck path for company accounts api
   healthcheck_matcher        = "200"
   s3_config_bucket           = data.vault_generic_secret.shared_s3.data["config_bucket_name"]


### PR DESCRIPTION
Updating the listener rules to catch more paths,
As per the routes.yaml, updating the paths to include wildcards at the end.
` /transactions/*/company-accounts*
  /private/transactions/*/company-accounts*`
  
This was done to ensure company-accounts traffic wasn't being directed to transactions api. 