### PR TITLE
Role for s3 access

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -33,6 +33,10 @@ data "aws_iam_role" "ecs_cluster_iam_role" {
   name = "${local.name_prefix}-ecs-task-execution-role"
 }
 
+data "aws_iam_role" "ecs_task_role" {
+  name = "${local.name_prefix}-ecs-task-role"
+}
+
 data "aws_lb" "service_lb" {
   name = "${var.environment}-chs-apichgovuk"
 }

--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -33,10 +33,6 @@ data "aws_iam_role" "ecs_cluster_iam_role" {
   name = "${local.name_prefix}-ecs-task-execution-role"
 }
 
-data "aws_iam_role" "ecs_task_role" {
-  name = "${local.name_prefix}-ecs-task-role"
-}
-
 data "aws_lb" "service_lb" {
   name = "${var.environment}-chs-apichgovuk"
 }

--- a/terraform/groups/ecs-service/iam.tf
+++ b/terraform/groups/ecs-service/iam.tf
@@ -1,0 +1,20 @@
+data "aws_iam_policy_document" "bucket_access_policy" {
+  statement {
+    sid = "S3Read"
+
+    actions = [
+      "s3:GetObject"
+    ]
+
+    resources = [
+      "arn:aws:s3:::<bucket value from secret goes here>/*",
+      "arn:aws:s3:::<bucket value from secret goes here>"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "bucket_access_policy" {
+  name   = "bucket-access-role-policy"
+  role   = data.aws_iam_role.ecs_task_role.id
+  policy = data.aws_iam_policy_document.bucket_access_policy.json
+}

--- a/terraform/groups/ecs-service/iam.tf
+++ b/terraform/groups/ecs-service/iam.tf
@@ -1,3 +1,21 @@
+resource "aws_iam_role" "ecs_task_role" {
+  name               = "${local.name_prefix}-${local.service_name}-ecs-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_policy.json
+}
+
+data "aws_iam_policy_document" "ecs_task_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "ecs-tasks.amazonaws.com"
+      ]
+    }
+  }
+}
+
 data "aws_iam_policy_document" "bucket_access_policy" {
   statement {
     sid = "S3Read"
@@ -7,14 +25,14 @@ data "aws_iam_policy_document" "bucket_access_policy" {
     ]
 
     resources = [
-      "arn:aws:s3:::<bucket value from secret goes here>/*",
-      "arn:aws:s3:::<bucket value from secret goes here>"
+      "arn:aws:s3:::${local.service_secrets.document_render_bucket_name}/*",
+      "arn:aws:s3:::${local.service_secrets.document_render_bucket_name}"
     ]
   }
 }
 
 resource "aws_iam_role_policy" "bucket_access_policy" {
   name   = "bucket-access-role-policy"
-  role   = data.aws_iam_role.ecs_task_role.id
+  role   = aws_iam_role.ecs_task_role.id
   policy = data.aws_iam_policy_document.bucket_access_policy.json
 }

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -37,6 +37,7 @@ module "ecs-service" {
   vpc_id                  = data.aws_vpc.vpc.id
   ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
   task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
+  task_role_arn           = data.aws_iam_role.ecs_task_role.arn
 
   # Load balancer configuration
   lb_listener_arn                   = data.aws_lb_listener.service_lb_listener.arn

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -37,7 +37,7 @@ module "ecs-service" {
   vpc_id                  = data.aws_vpc.vpc.id
   ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
   task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
-  task_role_arn           = data.aws_iam_role.ecs_task_role.arn
+  task_role_arn           = aws_iam_role.ecs_task_role.arn
 
   # Load balancer configuration
   lb_listener_arn                   = data.aws_lb_listener.service_lb_listener.arn


### PR DESCRIPTION
This pr creates a new role for the service to allow it access to the document renderer bucket so that it can access the accounts image at the end of the journey ready to be sent to CHIPS.