### PR TITLE
Implement BlockOverseasCompanyInterceptor and PermissionException handling

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplication.java
@@ -7,6 +7,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import uk.gov.companieshouse.api.accounts.interceptor.AuthenticationInterceptor;
+import uk.gov.companieshouse.api.accounts.interceptor.BlockOverseasCompanyInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.CicReportInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.ClosedTransactionInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.CompanyAccountInterceptor;
@@ -44,6 +45,9 @@ public class CompanyAccountsApplication implements WebMvcConfigurer {
 
     @Autowired
     private SmallFullInterceptor smallFullInterceptor;
+
+    @Autowired
+    private BlockOverseasCompanyInterceptor blockOverseasCompanyInterceptor;
 
     @Autowired
     private CurrentPeriodInterceptor currentPeriodInterceptor;
@@ -128,6 +132,11 @@ public class CompanyAccountsApplication implements WebMvcConfigurer {
                 "/private/transactions/{transactionId}/company-accounts/{companyAccountId}/**");
 
         registry.addInterceptor(smallFullInterceptor)
+            .addPathPatterns(
+                "/transactions/{transactionId}/company-accounts/{companyAccountId}/small-full",
+                "/transactions/{transactionId}/company-accounts/{companyAccountId}/small-full/**");
+
+        registry.addInterceptor(blockOverseasCompanyInterceptor)
             .addPathPatterns(
                 "/transactions/{transactionId}/company-accounts/{companyAccountId}/small-full",
                 "/transactions/{transactionId}/company-accounts/{companyAccountId}/small-full/**");

--- a/src/main/java/uk/gov/companieshouse/api/accounts/exception/PermissionException.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/exception/PermissionException.java
@@ -1,0 +1,12 @@
+package uk.gov.companieshouse.api.accounts.exception;
+
+public class PermissionException extends RuntimeException {
+
+    public PermissionException(String message) {
+        super(message);
+    }
+    
+    public PermissionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import uk.gov.companieshouse.api.accounts.exception.PermissionException;
 import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.validation.ErrorType;
@@ -34,6 +35,8 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private static final Logger STRUCTURED_LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
+    private static final String MESSAGE_KEY = "message";
+    private static final String ERROR_KEY = "error";
 
     @Value("${invalid.value}")
     private String invalidValue;
@@ -41,10 +44,19 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<Object> handleException(Exception ex) {
         HashMap<String, Object> message = new HashMap<>();
-        message.put("message", ex.getMessage());
-        message.put("error", ex.getClass());
+        message.put(MESSAGE_KEY, ex.getMessage());
+        message.put(ERROR_KEY, ex.getClass());
         STRUCTURED_LOGGER.error(ex.getMessage(), message);
         return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(PermissionException.class)
+    protected ResponseEntity<Object> handlePermissionException(PermissionException ex) {
+        HashMap<String, Object> message = new HashMap<>();
+        message.put(MESSAGE_KEY, ex.getMessage());
+        message.put(ERROR_KEY, ex.getClass());
+        STRUCTURED_LOGGER.info(ex.getMessage(), message);
+        return new ResponseEntity<>(HttpStatus.FORBIDDEN);
     }
 
     @Override
@@ -86,8 +98,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private void logClientError(Exception ex) {
         HashMap<String, Object> message = new HashMap<>();
-        message.put("message", ex.getMessage());
-        message.put("error", ex.getClass());
+        message.put(MESSAGE_KEY, ex.getMessage());
+        message.put(ERROR_KEY, ex.getClass());
         STRUCTURED_LOGGER.info(ex.getMessage(), message);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/BlockOverseasCompanyInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/BlockOverseasCompanyInterceptor.java
@@ -1,0 +1,51 @@
+package uk.gov.companieshouse.api.accounts.interceptor;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import uk.gov.companieshouse.api.accounts.CompanyAccountsApplication;
+import uk.gov.companieshouse.api.accounts.exception.PermissionException;
+import uk.gov.companieshouse.api.util.security.AuthorisationUtil;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+import uk.gov.companieshouse.api.util.security.Permission;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Component
+public class BlockOverseasCompanyInterceptor implements HandlerInterceptor {
+    
+    private static final String COMPANY_ACCOUNTS_READ_UPDATE_PERMISSION_ERROR =
+        "Token does not have required permissions READ and UPDATE for company accounts";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        TokenPermissions tokenPermissions = getTokenPermissions(request)
+            .orElseThrow(() -> new IllegalStateException("Token permissions not found in request"));
+        
+        var hasCompanyAccountRead = tokenPermissions.hasPermission(Permission.Key.COMPANY_ACCOUNTS, Permission.Value.READ);
+        var hasCompanyAccountWrite = tokenPermissions.hasPermission(Permission.Key.COMPANY_ACCOUNTS, Permission.Value.UPDATE);
+
+        var hasPermissions = hasCompanyAccountRead && hasCompanyAccountWrite;
+
+
+        if (!hasPermissions) {
+            LOGGER.info(COMPANY_ACCOUNTS_READ_UPDATE_PERMISSION_ERROR);
+            throw new PermissionException(COMPANY_ACCOUNTS_READ_UPDATE_PERMISSION_ERROR);
+        }
+
+        LOGGER.info("Token has required permissions READ and UPDATE for company accounts");
+        return hasPermissions;
+    }
+
+
+    private Optional<TokenPermissions> getTokenPermissions(HttpServletRequest request) {
+        return AuthorisationUtil.getTokenPermissions(request);
+    }
+    
+}

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/SmallFullInterceptor.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.Map;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -35,8 +34,11 @@ public class SmallFullInterceptor implements HandlerInterceptor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CompanyAccountsApplication.APPLICATION_NAME_SPACE);
 
-    @Autowired
     private SmallFullService smallFullService;
+
+    public SmallFullInterceptor(SmallFullService smallFullService) {
+        this.smallFullService = smallFullService;
+    }
 
     /**
      * This class validates a Small-full account exists for the given CompanyAccount. Validation is

--- a/src/test/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplicationTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/CompanyAccountsApplicationTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import uk.gov.companieshouse.api.accounts.interceptor.AuthenticationInterceptor;
+import uk.gov.companieshouse.api.accounts.interceptor.BlockOverseasCompanyInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.CicReportInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.ClosedTransactionInterceptor;
 import uk.gov.companieshouse.api.accounts.interceptor.CompanyAccountInterceptor;
@@ -80,6 +81,9 @@ class CompanyAccountsApplicationTest {
     private AuthenticationInterceptor authenticationInterceptor;
 
     @Mock
+    private BlockOverseasCompanyInterceptor blockOverseasCompanyInterceptor;
+
+    @Mock
     private InterceptorRegistry interceptorRegistry;
 
     @Mock
@@ -96,6 +100,7 @@ class CompanyAccountsApplicationTest {
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(closedTransactionInterceptor);
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(companyAccountInterceptor);
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(smallFullInterceptor);
+        doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(blockOverseasCompanyInterceptor);
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(currentPeriodInterceptor);
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(previousPeriodInterceptor);
         doReturn(interceptorRegistration).when(interceptorRegistry).addInterceptor(cicReportInterceptor);

--- a/src/test/java/uk/gov/companieshouse/api/accounts/exception/PermissionExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/exception/PermissionExceptionTest.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.api.accounts.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PermissionExceptionTest {
+
+    @Test
+    @DisplayName("Constructor sets exception message")
+    void constructorSetsMessage() {
+        PermissionException permissionException = new PermissionException("permissions required");
+
+        assertEquals("permissions required", permissionException.getMessage());
+    }
+
+    @Test
+    @DisplayName("Constructor sets message and cause")
+    void constructorSetsMessageAndCause() {
+        RuntimeException cause = new RuntimeException("root cause");
+        PermissionException permissionException = new PermissionException("permissions required", cause);
+
+        assertEquals("permissions required", permissionException.getMessage());
+        assertSame(cause, permissionException.getCause());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/exception/handler/GlobalExceptionHandlerTest.java
@@ -18,6 +18,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import uk.gov.companieshouse.api.accounts.exception.PermissionException;
 import uk.gov.companieshouse.api.accounts.model.validation.Error;
 import uk.gov.companieshouse.api.accounts.model.validation.Errors;
 import uk.gov.companieshouse.api.accounts.validation.ErrorType;
@@ -65,6 +66,15 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<Object> entity = globalExceptionHandler.handleException(new Exception());
         assertNotNull(entity);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, entity.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Handle PermissionException returns Forbidden status")
+    void testHandlePermissionException() {
+        ResponseEntity<Object> entity = globalExceptionHandler
+            .handlePermissionException(new PermissionException("Missing permissions"));
+        assertNotNull(entity);
+        assertEquals(HttpStatus.FORBIDDEN, entity.getStatusCode());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/BlockOverseasCompanyInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/BlockOverseasCompanyInterceptorTest.java
@@ -1,0 +1,87 @@
+package uk.gov.companieshouse.api.accounts.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import uk.gov.companieshouse.api.accounts.exception.PermissionException;
+import uk.gov.companieshouse.api.util.security.AuthorisationUtil;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+import uk.gov.companieshouse.api.util.security.Permission;
+
+@ExtendWith(MockitoExtension.class)
+class BlockOverseasCompanyInterceptorTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    private BlockOverseasCompanyInterceptor interceptor;
+
+    @Test
+    @DisplayName("preHandle returns true when token has both READ and UPDATE permissions")
+    void preHandleReturnsTrueWhenReadAndUpdatePermissionsArePresent() {
+        TokenPermissions tokenPermissions = mock(TokenPermissions.class);
+        when(tokenPermissions.hasPermission(Permission.Key.COMPANY_ACCOUNTS, Permission.Value.READ)).thenReturn(true);
+        when(tokenPermissions.hasPermission(Permission.Key.COMPANY_ACCOUNTS, Permission.Value.UPDATE)).thenReturn(true);
+
+        try (MockedStatic<AuthorisationUtil> authorisationUtil = Mockito.mockStatic(AuthorisationUtil.class)) {
+            authorisationUtil.when(() -> AuthorisationUtil.getTokenPermissions(request))
+                .thenReturn(Optional.of(tokenPermissions));
+
+            boolean result = interceptor.preHandle(request, response, new Object());
+
+            assertTrue(result);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "false, true",
+        "true, false",
+        "false, false"
+    })
+    @DisplayName("preHandle throws PermissionException when either READ or UPDATE permission is missing")
+    void preHandleThrowsPermissionExceptionWhenReadPermissionIsMissing(boolean readPermission, boolean updatePermission) {
+        TokenPermissions tokenPermissions = mock(TokenPermissions.class);
+        when(tokenPermissions.hasPermission(Permission.Key.COMPANY_ACCOUNTS, Permission.Value.READ)).thenReturn(readPermission);
+        when(tokenPermissions.hasPermission(Permission.Key.COMPANY_ACCOUNTS, Permission.Value.UPDATE)).thenReturn(updatePermission);
+
+        try (MockedStatic<AuthorisationUtil> authorisationUtil = Mockito.mockStatic(AuthorisationUtil.class)) {
+            authorisationUtil.when(() -> AuthorisationUtil.getTokenPermissions(request))
+                .thenReturn(Optional.of(tokenPermissions));
+
+            assertThrowsExactly(PermissionException.class, () -> interceptor.preHandle(request, response, new Object()));
+        }
+    }
+
+    @Test
+    @DisplayName("preHandle throws IllegalStateException when token permissions are missing")
+    void preHandleThrowsIllegalStateExceptionWhenTokenPermissionsAreMissing() {
+        try (MockedStatic<AuthorisationUtil> authorisationUtil = Mockito.mockStatic(AuthorisationUtil.class)) {
+            authorisationUtil.when(() -> AuthorisationUtil.getTokenPermissions(request))
+                .thenReturn(Optional.empty());
+
+            assertThrowsExactly(IllegalStateException.class, () -> interceptor.preHandle(request, response, new Object()));
+        }
+    }
+}


### PR DESCRIPTION
- Added BlockOverseasCompanyInterceptor to enforce permission checks for company accounts.
- Introduced PermissionException class to handle permission-related errors.
- Updated GlobalExceptionHandler to manage PermissionException and return appropriate HTTP status.
- Modified CompanyAccountsApplication to register the new interceptor.
- Enhanced unit tests for BlockOverseasCompanyInterceptor and PermissionException to ensure correct behavior.